### PR TITLE
[FIX]: Empty b.params.MinioCfg.RootPath handler (S3/Ceph) 

### DIFF
--- a/core/backup_impl_create_backup.go
+++ b/core/backup_impl_create_backup.go
@@ -761,7 +761,7 @@ func (b *BackupContext) readSegmentInfo(ctx context.Context, collecitonID int64,
 		})
 	}
 
-	deltaLogPath := fmt.Sprintf("%s/%s/%v/%v/%v/", b.params.MinioCfg.RootPath, "delta_log", collecitonID, partitionID, segmentID)
+	deltaLogPath := fmt.Sprintf("%s%s/%v/%v/%v/", rootPath, "delta_log", collecitonID, partitionID, segmentID)
 	deltaFieldsLogDir, _, _ := b.getStorageClient().ListWithPrefix(ctx, b.milvusBucketName, deltaLogPath, false)
 	deltaLogs := make([]*backuppb.FieldBinlog, 0)
 	for _, deltaFieldLogDir := range deltaFieldsLogDir {

--- a/core/backup_impl_create_backup.go
+++ b/core/backup_impl_create_backup.go
@@ -726,8 +726,15 @@ func (b *BackupContext) readSegmentInfo(ctx context.Context, collecitonID int64,
 		NumOfRows:    numOfRows,
 	}
 	var size int64 = 0
+	var rootPath string
 
-	insertPath := fmt.Sprintf("%s/%s/%v/%v/%v/", b.params.MinioCfg.RootPath, "insert_log", collecitonID, partitionID, segmentID)
+        if b.params.MinioCfg.RootPath != "" {
+                rootPath = fmt.Sprintf("%s/", b.params.MinioCfg.RootPath)
+        } else {
+                rootPath = ""
+        }
+
+	insertPath := fmt.Sprintf("%s%s/%v/%v/%v/", rootPath, "insert_log", collecitonID, partitionID, segmentID)
 	log.Debug("insertPath", zap.String("insertPath", insertPath))
 	fieldsLogDir, _, err := b.getStorageClient().ListWithPrefix(ctx, b.milvusBucketName, insertPath, false)
 	if err != nil {


### PR DESCRIPTION
Intended to fix https://github.com/zilliztech/milvus-backup/issues/176

I tested it on my side, that seems to help. Just adding a simple handler for the cases where `b.params.MinioCfg.RootPath` is empty. Thanks!