### PR TITLE
Fix enabling both drop_exist_collection and skip_create_collection 

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -89,7 +89,7 @@ var restoreBackupCmd = &cobra.Command{
 			MetaOnly:             restoreMetaOnly,
 			RestoreIndex:         restoreRestoreIndex,
 			UseAutoIndex:         restoreUseAutoIndex,
-			DropExistCollection:  restoreDropExistIndex,
+			DropExistCollection:  restoreDropExistCollection,
 			DropExistIndex:       restoreDropExistIndex,
 			SkipCreateCollection: restoreSkipCreateCollection,
 		})


### PR DESCRIPTION
If skip_create_collection is not enabled, the collection will be validated before restoration. Therefore, when using drop_exist_collection, skip_create_collection must be enabled first. However, enabling both skip_create_collection and drop_exist_collection will result in the collection being deleted without being correctly recreated afterwards.