### PR TITLE
 Command-line parameters for backup MinIO cross-storage

### DIFF
--- a/core/backup_context.go
+++ b/core/backup_context.go
@@ -694,8 +694,8 @@ func (b *BackupContext) Check(ctx context.Context) string {
 		return "Failed to connect to storage backup path " + info + err.Error()
 	}
 
-	checkSrcPath := path.Join(b.milvusRootPath, "milvus_backup_check_src_"+string(time.Now().Unix()))
-	checkDstPath := path.Join(b.backupRootPath, "milvus_backup_check_dst_"+string(time.Now().Unix()))
+	checkSrcPath := path.Join(b.milvusRootPath, "milvus_backup_check_src_"+fmt.Sprint(time.Now().Unix()))
+	checkDstPath := path.Join(b.backupRootPath, "milvus_backup_check_dst_"+fmt.Sprint(time.Now().Unix()))
 
 	err = b.getMilvusStorageClient().Write(ctx, b.milvusBucketName, checkSrcPath, []byte{1})
 	if err != nil {

--- a/core/backup_server.go
+++ b/core/backup_server.go
@@ -157,7 +157,7 @@ func (h *Handlers) handleCreateBackup(c *gin.Context) (interface{}, error) {
 // @Tags Backup
 // @Produce application/json
 // @Param request_id header string false "request_id"
-// @Param collection_name query string true "collection_name"
+// @Param collection_name query string false "collection_name"
 // @Success 200 {object} backuppb.ListBackupsResponse
 // @Router /list [get]
 func (h *Handlers) handleListBackups(c *gin.Context) (interface{}, error) {

--- a/core/paramtable/base_table.go
+++ b/core/paramtable/base_table.go
@@ -462,6 +462,41 @@ func (gp *BaseTable) loadMinioConfig() {
 	if minioBackupRootPath != "" {
 		_ = gp.Save("minio.backupRootPath", minioBackupRootPath)
 	}
+
+	minioBackupAddress := os.Getenv("MINIO_BACKUP_ADDRESS")
+	if minioBackupAddress != "" {
+		_ = gp.Save("minio.backupAddress", minioBackupAddress)
+	}
+
+	minioBackupPort := os.Getenv("MINIO_BACKUP_PORT")
+	if minioBackupPort != "" {
+		_ = gp.Save("minio.backupPort", minioBackupPort)
+	}
+
+	minioBackupAccessKey := os.Getenv("MINIO_BACKUP_ACCESS_KEY")
+	if minioBackupAccessKey != "" {
+		_ = gp.Save("minio.backupAccessKeyID", minioBackupAccessKey)
+	}
+
+	minioBackupSecretKey := os.Getenv("MINIO_BACKUP_SECRET_KEY")
+	if minioBackupSecretKey != "" {
+		_ = gp.Save("minio.backupSecretAccessKey", minioBackupSecretKey)
+	}
+
+	minioBackupUseSSL := os.Getenv("MINIO_BACKUP_USE_SSL")
+	if minioBackupUseSSL != "" {
+		_ = gp.Save("minio.backupUseSSL", minioBackupUseSSL)
+	}
+
+	minioBackupUseIAM := os.Getenv("MINIO_BACKUP_USE_IAM")
+	if minioBackupUseIAM != "" {
+		_ = gp.Save("minio.backupUseIAM", minioBackupUseIAM)
+	}
+
+	minioBackupIAMEndpoint := os.Getenv("MINIO_BACKUP_IAM_ENDPOINT")
+	if minioBackupIAMEndpoint != "" {
+		_ = gp.Save("minio.backupIamEndpoint", minioBackupIAMEndpoint)
+	}
 }
 
 func (gp *BaseTable) loadMilvusConfig() {

--- a/core/paramtable/params.go
+++ b/core/paramtable/params.go
@@ -375,8 +375,8 @@ func (p *MinioConfig) initBackupAccessKeyID() {
 }
 
 func (p *MinioConfig) initBackupSecretAccessKey() {
-	key := p.Base.LoadWithDefault("minio.secretAccessKey",
-		p.Base.LoadWithDefault("minio.backupSecretAccessKey", DefaultMinioSecretAccessKey))
+	key := p.Base.LoadWithDefault("minio.backupSecretAccessKey",
+		p.Base.LoadWithDefault("minio.secretAccessKey", DefaultMinioSecretAccessKey))
 	p.BackupSecretAccessKey = key
 }
 


### PR DESCRIPTION
- Added command-line parameters for backup MinIO cross-storage.
- 'initBackupSecretAccessKey': Retrieve the configuration of 'minio.backupSecretAccessKey' first.
- Changed "string" to "fmt.Sprint" to fix the "go test -v -test.run TestCreateBackup" failure.
- Swagger: Modified the collection_name parameter in ListBackup to be optional.