### PR TITLE
ci: update dependabot.yml to include Go and Python dependencies and fix some cve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,35 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # GitHub Actions dependency update configuration
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    # Only create PRs when security vulnerabilities exist
+    allow:
+      - dependency-type: "all"
+    security-updates-only: true
+
+  # Go dependency update configuration
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Only create PRs when security vulnerabilities exist
+    allow:
+      - dependency-type: "all"
+    security-updates-only: true
+
+  # Python dependency update configuration
+  - package-ecosystem: "pip"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Only create PRs when security vulnerabilities exist
+    allow:
+      - dependency-type: "all"
+    security-updates-only: true

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest-cov==2.8.1
-requests==2.26.0
-scikit-learn==1.1.3
+requests==2.32.0
+scikit-learn==1.5.0
 timeout_decorator==0.5.0
 ujson==5.5.0
 pytest==7.2.0


### PR DESCRIPTION


- Add Go (gomod) dependency update configuration
- Add Python (pip) dependency update configuration
- Configure dependabot to only create PRs for security vulnerabilities
- Set weekly update schedule for all dependency ecosystems
- Set open-pull-requests-limit to 10 for each ecosystem