### PR TITLE
Parallelize bulk inserts in milvus restore v1

### DIFF
--- a/core/restore/collection.go
+++ b/core/restore/collection.go
@@ -673,19 +673,18 @@ func (ct *CollectionTask) restoreNotL0SegV1(ctx context.Context, part *backuppb.
 	wp.Start()
 
 	for _, b := range notL0SegBatches {
-		job := func(ctx context.Context) error {
-			bat, err := ct.copyAndRewriteDir(ctx, b)
-			if err != nil {
-				return fmt.Errorf("restore_collection: restore data v1 copy files: %w", err)
-			}
-
-			if err := ct.bulkInsertViaGrpc(ctx, part.GetPartitionName(), bat); err != nil {
-				return fmt.Errorf("restore_collection: restore data v1 bulk insert via grpc: %w", err)
-			}
-
-			return nil
+		bat, err := ct.copyAndRewriteDir(ctx, b)
+		if err != nil {
+			return fmt.Errorf("restore_collection: restore data v1 copy files: %w", err)
 		}
-		wp.Submit(job)
+
+		// Submit each directory as an individual task
+		for _, dir := range bat.partitionDirs {
+			wp.Submit(func(ctx context.Context) error {
+				var paths = getPaths(dir)
+				return ct.submitGRPCBulkInsertTask(ctx, part.GetPartitionName(), paths, bat.timestamp, bat.isL0, dir.size)
+			})
+		}
 	}
 
 	wp.Done()
@@ -694,6 +693,36 @@ func (ct *CollectionTask) restoreNotL0SegV1(ctx context.Context, part *backuppb.
 	}
 
 	return nil
+
+}
+
+func (ct *CollectionTask) submitGRPCBulkInsertTask(ctx context.Context, partitionName string, paths []string, timestamp uint64, isL0 bool, dirSize int64) error {
+	ct.logger.Info("start bulk insert via grpc",
+		zap.Strings("paths", paths),
+		zap.String("partition", partitionName))
+	in := client.GrpcBulkInsertInput{
+		DB:             ct.task.GetTargetDbName(),
+		CollectionName: ct.task.GetTargetCollectionName(),
+		PartitionName:  partitionName,
+		Paths:          paths,
+		BackupTS:       timestamp,
+		IsL0:           isL0,
+	}
+
+	jobID, err := ct.grpcCli.BulkInsert(ctx, in)
+	if err != nil {
+		return fmt.Errorf("restore_collection: failed to bulk insert via grpc: %w", err)
+	}
+	ct.taskTracker.UpdateRestoreTask(ct.parentTaskID, taskmgr.AddRestoreImportJob(ct.targetNS, strconv.FormatInt(jobID, 10), dirSize))
+	ct.logger.Info("create bulk insert via grpc success", zap.Int64("job_id", jobID))
+	return ct.checkBulkInsertViaGrpc(ctx, jobID)
+}
+
+func getPaths(dir partitionDir) []string {
+	if len(dir.insertLogDir) == 0 {
+		return []string{dir.deltaLogDir}
+	}
+	return []string{dir.insertLogDir, dir.deltaLogDir}
 }
 
 func (ct *CollectionTask) restoreNotL0SegV2(ctx context.Context, part *backuppb.PartitionBackupInfo) error {
@@ -972,30 +1001,8 @@ func (ct *CollectionTask) checkBulkInsertViaGrpc(ctx context.Context, jobID int6
 
 func (ct *CollectionTask) bulkInsertViaGrpc(ctx context.Context, partitionName string, b batch) error {
 	for _, dir := range b.partitionDirs {
-		var paths []string
-		if len(dir.insertLogDir) == 0 {
-			paths = []string{dir.deltaLogDir}
-		} else {
-			paths = []string{dir.insertLogDir, dir.deltaLogDir}
-		}
-
-		ct.logger.Info("start bulk insert via grpc", zap.Strings("paths", paths), zap.String("partition", partitionName))
-		in := client.GrpcBulkInsertInput{
-			DB:             ct.task.GetTargetDbName(),
-			CollectionName: ct.task.GetTargetCollectionName(),
-			PartitionName:  partitionName,
-			Paths:          paths,
-			BackupTS:       b.timestamp,
-			IsL0:           b.isL0,
-		}
-		jobID, err := ct.grpcCli.BulkInsert(ctx, in)
-		if err != nil {
-			return fmt.Errorf("restore_collection: failed to bulk insert via grpc: %w", err)
-		}
-		ct.logger.Info("create bulk insert via grpc success", zap.Int64("job_id", jobID))
-		ct.taskTracker.UpdateRestoreTask(ct.parentTaskID, taskmgr.AddRestoreImportJob(ct.targetNS, strconv.FormatInt(jobID, 10), dir.size))
-
-		if err := ct.checkBulkInsertViaGrpc(ctx, jobID); err != nil {
+		var paths = getPaths(dir)
+		if err := ct.submitGRPCBulkInsertTask(ctx, partitionName, paths, b.timestamp, b.isL0, dir.size); err != nil {
 			return fmt.Errorf("restore_collection: check bulk insert via grpc: %w", err)
 		}
 	}


### PR DESCRIPTION
The restoreNotL0SegV1 function calls bulkInsert serially for all the directories in each of the segment batches that is slowing down the import process for huge restores 

Resolving issue here - https://github.com/zilliztech/milvus-backup/issues/629#issuecomment-2920544492

issue: #629 