### PR TITLE
storage: use original context for semaphore acquisition

### DIFF
--- a/core/backup/collection.go
+++ b/core/backup/collection.go
@@ -793,7 +793,7 @@ func (ct *CollectionTask) backupSegment(ctx context.Context, seg *backuppb.Segme
 	}
 	cpTask := storage.NewCopyObjectsTask(opt)
 	if err := cpTask.Execute(ctx); err != nil {
-		return fmt.Errorf("backup: copy insert logs %w", err)
+		return fmt.Errorf("backup: copy bin logs %w", err)
 	}
 
 	// TODO: now l0 segment not under partition, update l0 segment backuped to true will cause nil pointer error

--- a/core/storage/copy_task.go
+++ b/core/storage/copy_task.go
@@ -73,7 +73,7 @@ func (c *CopyPrefixTask) Execute(ctx context.Context) error {
 			continue
 		}
 
-		if err := c.opt.Sem.Acquire(subCtx, 1); err != nil {
+		if err := c.opt.Sem.Acquire(ctx, 1); err != nil {
 			return fmt.Errorf("storage: copy prefix acquire semaphore %w", err)
 		}
 		g.Go(func() error {
@@ -129,7 +129,7 @@ func (c *CopyObjectsTask) Execute(ctx context.Context) error {
 
 	g, subCtx := errgroup.WithContext(ctx)
 	for _, attr := range c.opt.Attrs {
-		if err := c.opt.Sem.Acquire(subCtx, 1); err != nil {
+		if err := c.opt.Sem.Acquire(ctx, 1); err != nil {
 			return fmt.Errorf("storage: copy objects acquire semaphore %w", err)
 		}
 		g.Go(func() error {


### PR DESCRIPTION
Prevent semaphore errors from masking actual copy failures by using the original context instead of errgroup's cancelable context for acquisition. Maintains proper cancellation for operations while ensuring semaphore waits aren't interrupted by sibling failures.