### PR TITLE
docs: Add docs to show env overrides

### DIFF
--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -1,3 +1,6 @@
+# Note: This is a sample configuration file for Milvus Backup. It can be overridden by environment variables as well.
+# Example to override `milvus.address`, set the environment variable `MILVUS_ADDRESS`.
+
 # Configures the system log output.
 log:
   level: info # Only supports debug, info, warn, error, panic, or fatal. Default 'info'.


### PR DESCRIPTION
Solves:
[[DOCS]: Missing section about backup.yaml override with ENVs](https://github.com/zilliztech/milvus-backup/issues/791)