### PR TITLE
storage: use multipart copy when object size too big

### DIFF
--- a/internal/storage/aliyun.go
+++ b/internal/storage/aliyun.go
@@ -27,12 +27,7 @@ func newAliyunClient(cfg Config) (*MinioClient, error) {
 		return nil, fmt.Errorf("storage: aliyun unsupported credential type: %s", cfg.Credential.Type.String())
 	}
 
-	cli, err := minio.New(cfg.Endpoint, &opts)
-	if err != nil {
-		return nil, fmt.Errorf("storage: create aliyun client: %w", err)
-	}
-
-	return &MinioClient{cfg: cfg, cli: cli}, nil
+	return newInternalMinio(cfg, &opts)
 }
 
 // CredentialProvider implements "github.com/minio/minio-go/v7/pkg/credentials".Provider

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -169,7 +169,7 @@ func (a *AzureClient) CopyObject(ctx context.Context, i CopyObjectInput) error {
 	return retry.Do(ctx, func() error {
 		// Remove standard HTTPS port :443 from endpoint if present
 		endpoint := strings.TrimSuffix(srcCli.cfg.Endpoint, ":443")
-		srcURL := fmt.Sprintf("https://%s.blob.%s/%s/%s", srcCli.cfg.Credential.AzureAccountName, endpoint, srcCli.cfg.Bucket, i.SrcKey)
+		srcURL := fmt.Sprintf("https://%s.blob.%s/%s/%s", srcCli.cfg.Credential.AzureAccountName, endpoint, srcCli.cfg.Bucket, i.SrcAttr.Key)
 		// Azure CopyFromURL always requires authentication for the source URL, even for same account
 		// Generate SAS token for source URL
 		srcSAS, err := a.getSAS(ctx, srcCli)

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -8,8 +8,10 @@ import (
 )
 
 type CopyObjectInput struct {
-	SrcCli  Client
-	SrcKey  string
+	SrcCli Client
+
+	SrcAttr ObjectAttr
+
 	DestKey string
 }
 

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -59,7 +59,7 @@ type remoteCopier struct {
 
 func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	rp.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
-	i := CopyObjectInput{SrcCli: rp.src, SrcKey: copyAttr.Src.Key, DestKey: copyAttr.DestKey}
+	i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
 	start := time.Now()
 	if err := rp.dest.CopyObject(ctx, i); err != nil {

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -42,7 +42,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	src := NewMockClient(t)
 	rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
 
-	in := CopyObjectInput{SrcCli: src, SrcKey: "a/b", DestKey: "c/d"}
+	in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b"}, DestKey: "c/d"}
 	dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
 
 	attr := CopyAttr{Src: ObjectAttr{Key: "a/b"}, DestKey: "c/d"}

--- a/internal/storage/gcp.go
+++ b/internal/storage/gcp.go
@@ -75,12 +75,11 @@ func (t *gcpHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 // newGCPClient returns a minio.Client which is compatible for GCS
 func newGCPClient(cfg Config) (*MinioClient, error) {
-	adderss := cfg.Endpoint
-	if adderss == "" {
-		adderss = _gcpEndpoint
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = _gcpEndpoint
 	}
-	opts := minio.Options{Secure: cfg.UseSSL}
 
+	opts := minio.Options{Secure: cfg.UseSSL}
 	switch cfg.Credential.Type {
 	case IAM:
 		trans, err := newWrapHTTPTransport(opts.Secure)
@@ -106,10 +105,5 @@ func newGCPClient(cfg Config) (*MinioClient, error) {
 		return nil, fmt.Errorf("storage: gcp unsupported credential type %v", cfg.Credential.Type)
 	}
 
-	cli, err := minio.New(adderss, &opts)
-	if err != nil {
-		return nil, fmt.Errorf("storage: create gcp client %w", err)
-	}
-
-	return &MinioClient{cfg: cfg, cli: cli}, nil
+	return newInternalMinio(cfg, &opts)
 }

--- a/internal/storage/gcp_native.go
+++ b/internal/storage/gcp_native.go
@@ -48,11 +48,11 @@ func (gcm *GCPNativeClient) CopyObject(ctx context.Context, i CopyObjectInput) e
 		return fmt.Errorf("storage: gcp native copy object only support gcp native client")
 	}
 
-	srcObj := gcm.client.Bucket(srcCli.cfg.Bucket).Object(i.SrcKey)
+	srcObj := gcm.client.Bucket(srcCli.cfg.Bucket).Object(i.SrcAttr.Key)
 	dstObj := gcm.client.Bucket(gcm.cfg.Bucket).Object(i.DestKey)
 
 	if _, err := dstObj.CopierFrom(srcObj).Run(ctx); err != nil {
-		return fmt.Errorf("storage: gcp native copy object from %s to %s: %w", i.SrcKey, i.DestKey, err)
+		return fmt.Errorf("storage: gcp native copy object from %s to %s: %w", i.SrcAttr.Key, i.DestKey, err)
 	}
 
 	return nil

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -28,7 +28,7 @@ func (l *LocalClient) CopyObject(_ context.Context, i CopyObjectInput) error {
 		return fmt.Errorf("storage: local copy object only support local client")
 	}
 
-	srcDir := filepath.Dir(i.SrcKey)
+	srcDir := filepath.Dir(i.SrcAttr.Key)
 	srcDirInfo, err := os.Stat(srcDir)
 	if err != nil {
 		return fmt.Errorf("storage: local copy object get src parent dir info %w", err)
@@ -39,7 +39,7 @@ func (l *LocalClient) CopyObject(_ context.Context, i CopyObjectInput) error {
 		return fmt.Errorf("storage: local copy object create dest parent dir %w", err)
 	}
 
-	src, err := os.Open(i.SrcKey)
+	src, err := os.Open(i.SrcAttr.Key)
 	if err != nil {
 		return fmt.Errorf("storage: local copy object open src file %w", err)
 	}
@@ -54,7 +54,7 @@ func (l *LocalClient) CopyObject(_ context.Context, i CopyObjectInput) error {
 		return fmt.Errorf("storage: local copy object copy file %w", err)
 	}
 
-	srcStat, err := os.Stat(i.SrcKey)
+	srcStat, err := os.Stat(i.SrcAttr.Key)
 	if err != nil {
 		return fmt.Errorf("storage: local copy object get src file stat %w", err)
 	}

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -101,7 +101,7 @@ func TestLocalClient_CopyObject(t *testing.T) {
 	destKey := path.Join(t.TempDir(), "backup", "test.txt")
 	cli := &LocalClient{}
 	assert.NoFileExists(t, destKey)
-	err = cli.CopyObject(context.Background(), CopyObjectInput{SrcCli: cli, SrcKey: srcKey, DestKey: destKey})
+	err = cli.CopyObject(context.Background(), CopyObjectInput{SrcCli: cli, SrcAttr: ObjectAttr{Key: srcKey, Length: 1}, DestKey: destKey})
 	assert.NoError(t, err)
 	assert.FileExists(t, destKey)
 }

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -4,11 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"sync"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
+	"github.com/zilliztech/milvus-backup/core/paramtable"
+	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/retry"
+)
+
+const (
+	_MiB = 1 << 20
+	_GiB = 1 << 30
+	_TiB = 1 << 40
+)
+
+const (
+	// s3 doc say min part size is 5MB, but we use 100MB to avoid too many parts
+	_minPartSize      int64 = 100 * _MiB
+	_maxMultiCopySize int64 = 5 * _TiB
+	_maxParts         int64 = 10000
+
+	_maxCopyPartParallelism = 10
 )
 
 var _ Client = (*MinioClient)(nil)
@@ -26,18 +47,32 @@ func newMinioClient(cfg Config) (*MinioClient, error) {
 		return nil, fmt.Errorf("storage: minio unsupported credential type %s", cfg.Credential.Type.String())
 	}
 
-	cli, err := minio.New(cfg.Endpoint, &opts)
+	return newInternalMinio(cfg, &opts)
+}
+
+func newInternalMinio(cfg Config, opts *minio.Options) (*MinioClient, error) {
+	cli, err := minio.New(cfg.Endpoint, opts)
 	if err != nil {
-		return nil, fmt.Errorf("storage: create minio client %w", err)
+		return nil, fmt.Errorf("storage: create %s client: %w", cfg.Provider, err)
 	}
 
-	return &MinioClient{cfg: cfg, cli: cli}, nil
+	core, err := minio.NewCore(cfg.Endpoint, opts)
+	if err != nil {
+		return nil, fmt.Errorf("storage: create %s client: %w", cfg.Provider, err)
+	}
+
+	logger := log.L().With(zap.String("provider", cfg.Provider), zap.String("endpoint", cfg.Endpoint))
+
+	return &MinioClient{cfg: cfg, cli: cli, core: core, logger: logger}, nil
 }
 
 type MinioClient struct {
 	cfg Config
 
-	cli *minio.Client
+	logger *zap.Logger
+
+	cli  *minio.Client
+	core *minio.Core // only for multipart copy
 }
 
 func (m *MinioClient) Config() Config {
@@ -50,14 +85,132 @@ func (m *MinioClient) CopyObject(ctx context.Context, i CopyObjectInput) error {
 		return fmt.Errorf("storage: minio copy object only support minio client")
 	}
 
+	// gcp does not support multipart copy
+	if i.SrcAttr.Length >= 500*_MiB && srcCli.cfg.Provider != paramtable.CloudProviderGCP {
+		m.logger.Debug("copy object by multipart", zap.String("src_key", i.SrcAttr.Key), zap.String("dest_key", i.DestKey))
+		return m.multiPartCopy(ctx, srcCli, i)
+	}
+
+	m.logger.Debug("copy object by single part", zap.String("src_key", i.SrcAttr.Key), zap.String("dest_key", i.DestKey))
+	return m.copyObject(ctx, srcCli, i)
+}
+
+func (m *MinioClient) copyObject(ctx context.Context, srcCli *MinioClient, i CopyObjectInput) error {
 	dst := minio.CopyDestOptions{Bucket: m.cfg.Bucket, Object: i.DestKey}
-	src := minio.CopySrcOptions{Bucket: srcCli.cfg.Bucket, Object: i.SrcKey}
+	src := minio.CopySrcOptions{Bucket: srcCli.cfg.Bucket, Object: i.SrcAttr.Key}
 	return retry.Do(ctx, func() error {
 		if _, err := m.cli.CopyObject(ctx, dst, src); err != nil {
-			return fmt.Errorf("storage: %s copy from %s / %s  to %s / %s %w", m.cfg.Provider, srcCli.cfg.Bucket, i.SrcKey, m.cfg.Bucket, i.DestKey, err)
+			return fmt.Errorf("storage: %s copy from %s / %s  to %s / %s %w", m.cfg.Provider, srcCli.cfg.Bucket, i.SrcAttr.Key, m.cfg.Bucket, i.DestKey, err)
 		}
 		return nil
 	})
+}
+
+type copyPartInput struct {
+	SrcBucket string
+	SrcKey    string
+
+	DestKey  string
+	UploadID string
+
+	Part part
+}
+
+func newCopyPartInput(srcCli *MinioClient, srcKey, destKey, uploadID string, part part) copyPartInput {
+	return copyPartInput{
+		SrcBucket: srcCli.cfg.Bucket,
+		SrcKey:    srcKey,
+
+		DestKey:  destKey,
+		UploadID: uploadID,
+
+		Part: part,
+	}
+}
+
+func (m *MinioClient) copyPart(ctx context.Context, i copyPartInput) (minio.CompletePart, error) {
+	var output minio.CompletePart
+
+	m.logger.Debug("copy part", zap.Any("input", i))
+	err := retry.Do(ctx, func() error {
+		var err error
+		output, err = m.core.CopyObjectPart(ctx,
+			i.SrcBucket,
+			i.SrcKey,
+			m.cfg.Bucket,
+			i.DestKey,
+			i.UploadID,
+			i.Part.Index,
+			i.Part.Offset,
+			i.Part.Size,
+			nil)
+		if err != nil {
+			return fmt.Errorf("storage: %s copy part %w", m.cfg.Provider, err)
+		}
+
+		return nil
+	})
+
+	return output, err
+}
+
+type sortableCompletedParts []minio.CompletePart
+
+func (a sortableCompletedParts) Len() int           { return len(a) }
+func (a sortableCompletedParts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortableCompletedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].PartNumber }
+
+func (m *MinioClient) multiPartCopy(ctx context.Context, srcCli *MinioClient, i CopyObjectInput) error {
+	parts, err := splitIntoParts(i.SrcAttr.Length)
+	if err != nil {
+		return fmt.Errorf("storage: %s split into parts %w", m.cfg.Provider, err)
+	}
+
+	uploadID, err := m.core.NewMultipartUpload(ctx, m.cfg.Bucket, i.DestKey, minio.PutObjectOptions{})
+	if err != nil {
+		return fmt.Errorf("storage: %s new multipart upload %w", m.cfg.Provider, err)
+	}
+
+	defer func() {
+		if err != nil {
+			m.logger.Error("multi part copy failed, abort multipart upload", zap.Error(err), zap.String("upload_id", uploadID))
+
+			if err := m.core.AbortMultipartUpload(ctx, m.cfg.Bucket, i.DestKey, uploadID); err != nil {
+				m.logger.Error("abort multipart upload failed", zap.Error(err))
+			}
+		}
+
+	}()
+
+	completedParts := make([]minio.CompletePart, 0, len(parts))
+	var mu sync.Mutex
+	g, subCtx := errgroup.WithContext(ctx)
+	g.SetLimit(_maxCopyPartParallelism)
+	for _, p := range parts {
+		g.Go(func() error {
+			input := newCopyPartInput(srcCli, i.SrcAttr.Key, i.DestKey, uploadID, p)
+			completePart, err := m.copyPart(subCtx, input)
+			if err != nil {
+				return fmt.Errorf("storage: %s copy part %w", m.cfg.Provider, err)
+			}
+			mu.Lock()
+			completedParts = append(completedParts, completePart)
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("storage: %s wait for copy part %w", m.cfg.Provider, err)
+	}
+
+	sort.Sort(sortableCompletedParts(completedParts))
+	if _, err := m.core.CompleteMultipartUpload(ctx, m.cfg.Bucket, i.DestKey, uploadID, completedParts, minio.PutObjectOptions{}); err != nil {
+		return fmt.Errorf("storage: %s complete multipart upload %w", m.cfg.Provider, err)
+	}
+
+	return nil
 }
 
 func (m *MinioClient) HeadObject(ctx context.Context, key string) (ObjectAttr, error) {
@@ -166,4 +319,39 @@ func (m *MinioClient) CreateBucket(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+type part struct {
+	Index  int
+	Offset int64
+	Size   int64
+}
+
+func splitIntoParts(totalSize int64) ([]part, error) {
+	if totalSize <= _minPartSize {
+		return nil, fmt.Errorf("storage: total size %d is less than min part size %d", totalSize, _minPartSize)
+	}
+
+	if totalSize > _maxMultiCopySize {
+		return nil, fmt.Errorf("storage: total size %d is greater than max part size %d", totalSize, _maxMultiCopySize)
+	}
+
+	ceilDiv := func(a, b int64) int64 { return (a + b - 1) / b }
+	partSize := max(_minPartSize, ceilDiv(totalSize, _maxParts))
+
+	var parts []part
+	var offset int64
+	index := 1
+	for offset < totalSize {
+		remaining := totalSize - offset
+		size := partSize
+		if remaining < size {
+			size = remaining
+		}
+		parts = append(parts, part{Index: index, Offset: offset, Size: size})
+		offset += size
+		index++
+	}
+
+	return parts, nil
 }

--- a/internal/storage/minio_test.go
+++ b/internal/storage/minio_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitIntoParts(t *testing.T) {
+	t.Run("TotalSizeLEMinPartSize", func(t *testing.T) {
+		_, err := splitIntoParts(1024)
+		assert.Error(t, err)
+
+		_, err = splitIntoParts(_minPartSize)
+		assert.Error(t, err)
+	})
+
+	t.Run("TotalSizeGTMinPartSize", func(t *testing.T) {
+		// min + 1
+		size := _minPartSize + 1
+		parts, err := splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), _maxParts)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+
+		// 1GB
+		size = 1 * _GiB
+		parts, err = splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), _maxParts)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+
+		// 10GB
+		size = 10 * _GiB
+		parts, err = splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), size)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+
+		// 100GB
+		size = 100 * _GiB
+		parts, err = splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), _maxParts)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+
+		// 1TB
+		size = 1 * _TiB
+		parts, err = splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), _maxParts)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+
+		// max - 1
+		size = _maxMultiCopySize - 1
+		parts, err = splitIntoParts(size)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, int64(len(parts)), _maxParts)
+		assert.Equal(t, size, lo.SumBy(parts, func(p part) int64 { return p.Size }))
+	})
+
+	t.Run("TotalSizeGTMaxPartSize", func(t *testing.T) {
+		_, err := splitIntoParts(_maxMultiCopySize + 1)
+		assert.Error(t, err)
+	})
+}

--- a/internal/storage/tencent.go
+++ b/internal/storage/tencent.go
@@ -24,12 +24,7 @@ func newTencentClient(cfg Config) (*MinioClient, error) {
 		return nil, fmt.Errorf("storage: tencent unsupported credential type %v", cfg.Credential.Type)
 	}
 
-	cli, err := minio.New(cfg.Endpoint, &opts)
-	if err != nil {
-		return nil, fmt.Errorf("storage: new tencent client %w", err)
-	}
-
-	return &MinioClient{cli: cli, cfg: cfg}, nil
+	return newInternalMinio(cfg, &opts)
 }
 
 // tencentCredProvider implements "github.com/minio/minio-go/v7/pkg/credentials".Provider


### PR DESCRIPTION
fix #831 