### PR TITLE
tests: add test case for backup/restore with dynamically added fields

### DIFF
--- a/tests/base/client_base.py
+++ b/tests/base/client_base.py
@@ -1,8 +1,9 @@
 import sys
 import time
 import pytest
+import pymilvus
 from pymilvus import DefaultConfig, DataType, db, MilvusClient
-
+from pymilvus import utility
 sys.path.append("..")
 from base.connections_wrapper import ApiConnectionsWrapper
 from base.collection_wrapper import ApiCollectionWrapper
@@ -105,6 +106,7 @@ class TestcaseBase(Base):
             token=f"{user}:{password}",
         )
         self.milvus_uri = f"http://{host}:{port}"
+        log.info(f"milvus uri: {self.milvus_uri}")
         self.milvus_token = f"{user}:{password}"
 
     def _connect(self):
@@ -113,6 +115,12 @@ class TestcaseBase(Base):
             uri=self.milvus_uri,
             token=self.milvus_token
         )
+        log.info("--------------------------------")
+        log.info(f"milvus uri: {self.milvus_uri}")
+        sdk_version = pymilvus.__version__
+        log.info(f"sdk version: {sdk_version}")
+        server_version = utility.get_server_version()
+        log.info(f"server version: {server_version}")
         return res
 
     def init_collection_wrap(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,8 +12,8 @@ allure-pytest==2.7.0
 pytest-print==0.2.1
 pytest-level==0.1.3
 pytest-xdist==2.5.0
-pymilvus==2.6.3rc16
-pymilvus[bulk_writer]==2.6.3rc16
+pymilvus==2.6.5
+pymilvus[bulk_writer]==2.6.5
 pytest-rerunfailures==9.1.1
 git+https://github.com/Projectplace/pytest-tags
 ndg-httpsclient


### PR DESCRIPTION
Add test_milvus_restore_backup_with_add_field to verify that collections with dynamically added fields can be properly backed up and restored.

Test covers multiple field types in single case:
- INT64, VARCHAR, FLOAT, BOOL, JSON
- Parametrized by with_default_value (True/False)
- Uses V2 restore mode