### PR TITLE
restore: Guess dynamic field ID for restore

### DIFF
--- a/core/backup/collection_index_extra_task.go
+++ b/core/backup/collection_index_extra_task.go
@@ -49,6 +49,10 @@ func (ciet *collectionIndexExtraTask) Execute(ctx context.Context) error {
 		if err := proto.Unmarshal(kv.Value, index); err != nil {
 			return fmt.Errorf("backup: unmarshal index %w", err)
 		}
+		if index.GetDeleted() {
+			ciet.logger.Info("skip deleted index", zap.Int64("index_id", index.GetIndexInfo().GetIndexID()))
+			continue
+		}
 		indexes = append(indexes, index)
 	}
 

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
-
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"

--- a/core/restore/collection_ddl_task_test.go
+++ b/core/restore/collection_ddl_task_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
@@ -41,12 +42,12 @@ func TestCollectionDDLTask_fields(t *testing.T) {
 		ddlt.collBackup = &backuppb.CollectionBackupInfo{
 			Schema: &backuppb.CollectionSchema{
 				Fields: []*backuppb.FieldSchema{
-					{Name: "field1", FieldID: 1},
-					{Name: "field2", FieldID: 2},
-					{Name: "field3", FieldID: 3},
-					// $meta field's field id is 4
-					{Name: "field5", FieldID: 5},
-					{Name: "field6", FieldID: 6},
+					{Name: "field1", FieldID: common.StartOfUserFieldID},
+					{Name: "field2", FieldID: common.StartOfUserFieldID + 1},
+					{Name: "field3", FieldID: common.StartOfUserFieldID + 2},
+					// $meta field's field id is common.StartOfUserFieldID + 3
+					{Name: "field4", FieldID: common.StartOfUserFieldID + 4},
+					{Name: "field5", FieldID: common.StartOfUserFieldID + 5},
 				},
 				EnableDynamicField: true,
 			},
@@ -60,8 +61,7 @@ func TestCollectionDDLTask_fields(t *testing.T) {
 		assert.Equal(t, "field1", createFields[0].GetName())
 		assert.Equal(t, "field2", createFields[1].GetName())
 		assert.Equal(t, "field3", createFields[2].GetName())
-		assert.Equal(t, "field5", addFields[0].GetName())
-		assert.Equal(t, "field6", addFields[1].GetName())
+		assert.Equal(t, "field4", addFields[0].GetName())
 	})
 
 	t.Run("WithoutDynamicField", func(t *testing.T) {
@@ -69,7 +69,10 @@ func TestCollectionDDLTask_fields(t *testing.T) {
 
 		ddlt.collBackup = &backuppb.CollectionBackupInfo{
 			Schema: &backuppb.CollectionSchema{
-				Fields:             []*backuppb.FieldSchema{{Name: "field1", FieldID: 1}, {Name: "field2", FieldID: 2}},
+				Fields: []*backuppb.FieldSchema{
+					{Name: "field1", FieldID: common.StartOfUserFieldID},
+					{Name: "field2", FieldID: common.StartOfUserFieldID + 1},
+				},
 				EnableDynamicField: false,
 			},
 		}
@@ -97,7 +100,12 @@ func TestCollectionTask_createColl(t *testing.T) {
 		ct.targetNS = namespace.New("db1", "coll1")
 		ct.collBackup = &backuppb.CollectionBackupInfo{
 			Schema: &backuppb.CollectionSchema{
-				Fields:             []*backuppb.FieldSchema{{Name: "field", DataType: backuppb.DataType_Int64, IsPrimaryKey: true}},
+				Fields: []*backuppb.FieldSchema{{
+					FieldID:      common.StartOfUserFieldID,
+					Name:         "field",
+					DataType:     backuppb.DataType_Int64,
+					IsPrimaryKey: true},
+				},
 				Properties:         []*backuppb.KeyValuePair{{Key: "key", Value: "val"}},
 				Functions:          []*backuppb.FunctionSchema{{Name: "func", InputFieldNames: []string{"hello"}}},
 				EnableDynamicField: true,

--- a/core/restore/funcs/funcs.go
+++ b/core/restore/funcs/funcs.go
@@ -1,0 +1,40 @@
+package funcs
+
+import (
+	"sort"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+)
+
+// GuessDynFieldID guess the dynamic field id.
+// The describeCollection API does not return the $meta field, so we need to guess it.
+func GuessDynFieldID(fields []*schemapb.FieldSchema) int64 {
+	fieldIDs := make([]int64, 0, len(fields))
+
+	// if $meta field exists, return its field id
+	for _, field := range fields {
+		if field.GetIsDynamic() {
+			return field.GetFieldID()
+		}
+		if common.IsSystemField(field.GetFieldID()) {
+			continue
+		}
+
+		fieldIDs = append(fieldIDs, field.GetFieldID())
+	}
+
+	sort.Slice(fieldIDs, func(i, j int) bool { return fieldIDs[i] < fieldIDs[j] })
+	// if collection has gap in field id, means the collection added field after created.
+	// so the first gap is the dynamic field id.
+	// for example, if field ids are [1, 2, 4, 5], return 3
+	for i := range len(fieldIDs) - 1 {
+		if fieldIDs[i+1] != fieldIDs[i]+1 {
+			return fieldIDs[i] + 1
+		}
+	}
+
+	// if no gap, means the collection did not add field after created.
+	// so the max field id + 1 is the dynamic field id.
+	return fieldIDs[len(fieldIDs)-1] + 1
+}

--- a/core/restore/funcs/funcs_test.go
+++ b/core/restore/funcs/funcs_test.go
@@ -1,0 +1,49 @@
+package funcs
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGuessDynFieldID(t *testing.T) {
+	t.Run("HaveDynField", func(t *testing.T) {
+		fields := []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField},
+			{FieldID: common.TimeStampField},
+			{FieldID: common.StartOfUserFieldID},
+			{FieldID: common.StartOfUserFieldID + 1},
+			{FieldID: common.StartOfUserFieldID + 2, IsDynamic: true},
+			{FieldID: common.StartOfUserFieldID + 3},
+		}
+		id := GuessDynFieldID(fields)
+		assert.Equal(t, int64(common.StartOfUserFieldID+2), id)
+	})
+
+	t.Run("NoDynFieldButHaveGap", func(t *testing.T) {
+		fields := []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField},
+			{FieldID: common.TimeStampField},
+			{FieldID: common.StartOfUserFieldID},
+			{FieldID: common.StartOfUserFieldID + 1},
+			// $meta field id is common.StartOfUserFieldID + 2
+			{FieldID: common.StartOfUserFieldID + 3},
+		}
+		id := GuessDynFieldID(fields)
+		assert.Equal(t, int64(common.StartOfUserFieldID+2), id)
+	})
+
+	t.Run("NoDynFieldAndNoGap", func(t *testing.T) {
+		fields := []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField},
+			{FieldID: common.TimeStampField},
+			{FieldID: common.StartOfUserFieldID},
+			{FieldID: common.StartOfUserFieldID + 1},
+			{FieldID: common.StartOfUserFieldID + 2},
+		}
+		id := GuessDynFieldID(fields)
+		assert.Equal(t, int64(common.StartOfUserFieldID+3), id)
+	})
+}

--- a/core/restore/secondary/collection_dml_task.go
+++ b/core/restore/secondary/collection_dml_task.go
@@ -392,6 +392,8 @@ func (dmlt *collectionDMLTask) sendImportMsg(partitionID int64, b batch) (int64,
 	if err != nil {
 		return 0, fmt.Errorf("secondary: convert schema: %w", err)
 	}
+	appendSysFields(schema)
+	appendDynamicField(schema)
 
 	ts := dmlt.tsAlloc.Alloc()
 	header := &message.ImportMessageHeader{}

--- a/core/restore/secondary/funcs.go
+++ b/core/restore/secondary/funcs.go
@@ -1,0 +1,37 @@
+package secondary
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/zilliztech/milvus-backup/core/restore/funcs"
+)
+
+func appendSysFields(schema *schemapb.CollectionSchema) {
+	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+		FieldID:      int64(common.RowIDField),
+		Name:         common.RowIDFieldName,
+		IsPrimaryKey: false,
+		Description:  "row id",
+		DataType:     schemapb.DataType_Int64,
+	})
+
+	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+		FieldID:      int64(common.TimeStampField),
+		Name:         common.TimeStampFieldName,
+		IsPrimaryKey: false,
+		Description:  "time stamp",
+		DataType:     schemapb.DataType_Int64,
+	})
+}
+
+func appendDynamicField(schema *schemapb.CollectionSchema) {
+	if schema.GetEnableDynamicField() {
+		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+			FieldID:     funcs.GuessDynFieldID(schema.Fields),
+			Name:        common.MetaFieldName,
+			Description: "dynamic schema",
+			DataType:    schemapb.DataType_JSON,
+			IsDynamic:   true,
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces a new function `GuessDynFieldID` to intelligently determine the dynamic field ID during the restore process.

The `$meta` field is not explicitly returned by the `describeCollection` API, the dynamic field ID is not readily available. This function addresses this issue by inferring the ID based on the existing field schema.

The guessing logic works as follows:
1.  If a field is explicitly marked with `IsDynamic: true`, its ID is used.
2.  If no field is marked as dynamic, the function searches for gaps in the sequence of field IDs. The first gap found is assumed to be the dynamic field ID. This covers cases where fields have been added.
3.  If there are no gaps in the field IDs, the dynamic field ID is assumed to be the maximum field ID plus one.