### PR TITLE
test: mark add_field test case as MASTER only, add 2.6 to nightly matrix

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        milvus_version: ["master", "2.5"]
+        milvus_version: ["master", "2.6", "2.5"]
         case_tag: [L0, L1, L2, MASTER, RBAC]
         exclude:
           - milvus_version: 2.5

--- a/tests/testcases/test_restore_backup.py
+++ b/tests/testcases/test_restore_backup.py
@@ -1960,7 +1960,7 @@ class TestRestoreBackup(TestcaseBase):
             == str(ttl_seconds)
         )
 
-    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.tags(CaseLabel.MASTER)
     @pytest.mark.parametrize("with_default_value", [True, False])
     def test_milvus_restore_backup_with_add_field(self, with_default_value):
         """


### PR DESCRIPTION
## Summary
- `add_field` API is not supported in Milvus 2.5, only available in master/2.6
- Mark `test_milvus_restore_backup_with_add_field` with `CaseLabel.MASTER` to skip on 2.5
- Add `2.6` to `milvus_version` matrix in nightly workflow

## Changes
- `tests/testcases/test_restore_backup.py`: Changed tag from `L1` to `MASTER`
- `.github/workflows/nightly.yaml`: Added `2.6` to the version matrix

/kind improvement