### PR TITLE
backup: remove duplicate SetBackupSuccess call in skipFlushStrategy

### DIFF
--- a/core/backup/collection_strategy.go
+++ b/core/backup/collection_strategy.go
@@ -176,8 +176,6 @@ func (sf *skipFlushStrategy) Execute(ctx context.Context) error {
 		return fmt.Errorf("backup: execute dml task %w", err)
 	}
 
-	sf.args.TaskMgr.UpdateBackupTask(sf.args.TaskID, taskmgr.SetBackupSuccess())
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

Set backup task success status only at the task level to avoid inconsistency issues caused by multiple calls. 

The `SetBackupSuccess()` call in `skipFlushStrategy.Execute()` was redundant since the task-level success status is already managed by `Task.Execute()` after all collection tasks complete successfully.

## Changes

- Removed duplicate `SetBackupSuccess()` call from `skipFlushStrategy.Execute()`
- Task success status is now only set at the task level (`Task.Execute()`) to ensure consistency

Signed-off-by: haoyuan.huang@zilliz.com