### PR TITLE
fix(deps): replace jax/jaxlib with ml-dtypes for bfloat16 support

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -50,8 +50,7 @@ tenacity==8.1.0
 
 
 # for bf16 datatype
-jax==0.4.13
-jaxlib==0.4.13
+ml-dtypes==0.2.0
 
 # for text match
 bm25s==0.2.0

--- a/tests/testcases/test_restore_backup.py
+++ b/tests/testcases/test_restore_backup.py
@@ -2,7 +2,7 @@ import time
 import pytest
 import json
 import numpy as np
-import jax.numpy as jnp
+import ml_dtypes
 import pandas as pd
 import random
 from collections import defaultdict
@@ -952,9 +952,7 @@ class TestRestoreBackup(TestcaseBase):
                 for _ in range(nb)
             ],
             [
-                np.array(
-                    jnp.array([random.random() for _ in range(128)], dtype=jnp.bfloat16)
-                )
+                np.array([random.random() for _ in range(128)], dtype=ml_dtypes.bfloat16)
                 for _ in range(nb)
             ],
         ]
@@ -972,9 +970,7 @@ class TestRestoreBackup(TestcaseBase):
                         [random.random() for _ in range(128)], dtype=np.float16
                     ),
                     "brain_float16_vector": np.array(
-                        jnp.array(
-                            [random.random() for _ in range(128)], dtype=jnp.bfloat16
-                        )
+                        [random.random() for _ in range(128)], dtype=ml_dtypes.bfloat16
                     ),
                     f"dynamic_{str(i)}": i,
                 }


### PR DESCRIPTION
## Summary
- Replace `jax` and `jaxlib` with `ml-dtypes` for bfloat16 support
- Update test code to use `ml_dtypes.bfloat16` instead of `jnp.bfloat16`

## Reason
`jaxlib==0.4.13` has been removed from PyPI, causing CI pipeline failures with:
```
ERROR: Could not find a version that satisfies the requirement jaxlib==0.4.13
ERROR: No matching distribution found for jaxlib==0.4.13
```

## Solution
Replace `jax/jaxlib` with `ml-dtypes==0.2.0`:
- `ml-dtypes` is a much lighter package (only provides dtype support)
- Works well with existing `numpy==1.24.4`
- Provides the same `bfloat16` dtype functionality

## Changes
- `tests/requirements.txt`: Replace jax/jaxlib with ml-dtypes
- `tests/testcases/test_restore_backup.py`: Update imports and usage