### PR TITLE
backup: change cipher detection from cipher.enabled to cipher.ezID/key

### DIFF
--- a/core/backup/database_task.go
+++ b/core/backup/database_task.go
@@ -12,7 +12,10 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
 )
 
-const _cipherEnabledKey = "cipher.enabled"
+const (
+	_cipherEzIDKey = "cipher.ezID"
+	_cipherKeyKey  = "cipher.key"
+)
 
 type databaseTask struct {
 	taskID string
@@ -43,13 +46,17 @@ func newDatabaseTask(taskID, dbName string, grpc milvus.Grpc, manage milvus.Mana
 }
 
 func (dt *databaseTask) cipherEnabled(properties []*backuppb.KeyValuePair) bool {
+	var hasEzID, hasKey bool
 	for _, prop := range properties {
-		if prop.GetKey() == _cipherEnabledKey && prop.GetValue() == "true" {
-			return true
+		if prop.GetKey() == _cipherEzIDKey && prop.GetValue() != "" {
+			hasEzID = true
+		}
+		if prop.GetKey() == _cipherKeyKey && prop.GetValue() != "" {
+			hasKey = true
 		}
 	}
 
-	return false
+	return hasEzID && hasKey
 }
 
 func (dt *databaseTask) Execute(ctx context.Context) error {

--- a/core/backup/database_task_test.go
+++ b/core/backup/database_task_test.go
@@ -60,15 +60,29 @@ func TestDatabaseTask_Execute(t *testing.T) {
 func TestDatabaseTask_cipherEnabled(t *testing.T) {
 	task := &databaseTask{}
 
-	t.Run("Enabled", func(t *testing.T) {
+	t.Run("BothExist", func(t *testing.T) {
 		assert.True(t, task.cipherEnabled([]*backuppb.KeyValuePair{
-			{Key: _cipherEnabledKey, Value: "true"},
+			{Key: _cipherEzIDKey, Value: "ez123"},
+			{Key: _cipherKeyKey, Value: "key456"},
 		}))
 	})
 
-	t.Run("Disabled", func(t *testing.T) {
+	t.Run("OnlyEzID", func(t *testing.T) {
 		assert.False(t, task.cipherEnabled([]*backuppb.KeyValuePair{
-			{Key: _cipherEnabledKey, Value: "false"},
+			{Key: _cipherEzIDKey, Value: "ez123"},
+		}))
+	})
+
+	t.Run("OnlyKey", func(t *testing.T) {
+		assert.False(t, task.cipherEnabled([]*backuppb.KeyValuePair{
+			{Key: _cipherKeyKey, Value: "key456"},
+		}))
+	})
+
+	t.Run("BothEmpty", func(t *testing.T) {
+		assert.False(t, task.cipherEnabled([]*backuppb.KeyValuePair{
+			{Key: _cipherEzIDKey, Value: ""},
+			{Key: _cipherKeyKey, Value: ""},
 		}))
 	})
 


### PR DESCRIPTION
## Summary
- Follow the milvus encryption plugin changes
- Change the cipher detection logic from checking `cipher.enabled` property to checking the presence of both `cipher.ezID` and `cipher.key` properties
- Update related unit tests to cover the new logic

## Test plan
- [x] Unit tests pass (`go test -v ./core/backup/... -run TestDatabaseTask`)