### PR TITLE
filter: unify filter implementation between backup and restore

### DIFF
--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/paramtable"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
@@ -76,10 +77,10 @@ func TestTask_filterDBBackup(t *testing.T) {
 	})
 
 	t.Run("Filter", func(t *testing.T) {
-		plan := &Plan{DBBackupFilter: map[string]struct{}{
-			"db1": {},
-			"db3": {},
-		}}
+		plan := &Plan{BackupFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
+			"db1": {AllowAll: true},
+			"db3": {AllowAll: true},
+		}}}
 		dbBackup := []*backuppb.DatabaseBackupInfo{
 			{DbName: "db1"},
 			{DbName: "db2"},
@@ -107,11 +108,11 @@ func TestTask_filterCollBackup(t *testing.T) {
 	})
 
 	t.Run("Filter", func(t *testing.T) {
-		p := &Plan{CollBackupFilter: map[string]CollFilter{
+		p := &Plan{BackupFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
 			"db1": {CollName: map[string]struct{}{
 				"coll1": {},
 			}},
-		}}
+		}}}
 		task := newTestTask()
 		task.args.Plan = p
 		collBackup := []*backuppb.CollectionBackupInfo{
@@ -126,9 +127,9 @@ func TestTask_filterCollBackup(t *testing.T) {
 	})
 
 	t.Run("AllowAll", func(t *testing.T) {
-		p := &Plan{CollBackupFilter: map[string]CollFilter{
+		p := &Plan{BackupFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
 			"db1": {AllowAll: true},
-		}}
+		}}}
 		task := newTestTask()
 		task.args.Plan = p
 		collBackup := []*backuppb.CollectionBackupInfo{
@@ -156,7 +157,10 @@ func TestTask_filterDBTask(t *testing.T) {
 	})
 
 	t.Run("Filter", func(t *testing.T) {
-		p := &Plan{DBTaskFilter: map[string]struct{}{"db1": {}, "db3": {}}}
+		p := &Plan{TaskFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
+			"db1": {AllowAll: true},
+			"db3": {AllowAll: true},
+		}}}
 		task := newTestTask()
 		task.args.Plan = p
 		dbTasks := []*databaseTask{
@@ -184,9 +188,9 @@ func TestTask_filterCollTask(t *testing.T) {
 	})
 
 	t.Run("Filter", func(t *testing.T) {
-		p := &Plan{CollTaskFilter: map[string]CollFilter{
+		p := &Plan{TaskFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
 			"db1": {CollName: map[string]struct{}{"coll1": {}}},
-		}}
+		}}}
 		task := newTestTask()
 		task.args.Plan = p
 		collTasks := []*collectionTask{
@@ -201,9 +205,9 @@ func TestTask_filterCollTask(t *testing.T) {
 	})
 
 	t.Run("AllowAll", func(t *testing.T) {
-		p := &Plan{CollTaskFilter: map[string]CollFilter{
+		p := &Plan{TaskFilter: filter.Filter{DBCollFilter: map[string]filter.CollFilter{
 			"db1": {AllowAll: true},
-		}}
+		}}}
 		task := newTestTask()
 		task.args.Plan = p
 		collTasks := []*collectionTask{

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -17,26 +17,32 @@ import (
 // rule 4. key: db1.
 
 var (
-	Rule1Regex = regexp.MustCompile(`^(\w+)\.\*$`)
-	Rule2Regex = regexp.MustCompile(`^(\w+)\.(\w+)$`)
-	Rule3Regex = regexp.MustCompile(`^(\w+)$`)
-	Rule4Regex = regexp.MustCompile(`^(\w+)\.$`)
+	_rule1Regex = regexp.MustCompile(`^(\w+)\.\*$`)
+	_rule2Regex = regexp.MustCompile(`^(\w+)\.(\w+)$`)
+	_rule3Regex = regexp.MustCompile(`^(\w+)$`)
+	_rule4Regex = regexp.MustCompile(`^(\w+)\.$`)
 )
 
+// inferFilterRuleType determines the type of filter rule from a string.
+// Rule types:
+//   - 1: db1.* (all collections in database)
+//   - 2: db1.coll1 (specific database and collection)
+//   - 3: coll1 (collection in default database)
+//   - 4: db1. (database only, empty collection list)
 func inferFilterRuleType(rule string) (int, error) {
-	if Rule1Regex.MatchString(rule) {
+	if _rule1Regex.MatchString(rule) {
 		return 1, nil
 	}
 
-	if Rule2Regex.MatchString(rule) {
+	if _rule2Regex.MatchString(rule) {
 		return 2, nil
 	}
 
-	if Rule3Regex.MatchString(rule) {
+	if _rule3Regex.MatchString(rule) {
 		return 3, nil
 	}
 
-	if Rule4Regex.MatchString(rule) {
+	if _rule4Regex.MatchString(rule) {
 		return 4, nil
 	}
 
@@ -152,4 +158,26 @@ func (f Filter) AllowNSS(nss []namespace.NS) []namespace.NS {
 		}
 	}
 	return filtered
+}
+
+// InferMapperRuleType determines if both key and value match the same rule type.
+// Used for rename/mapping operations.
+func InferMapperRuleType(k, v string) (int, error) {
+	if _rule1Regex.MatchString(k) && _rule1Regex.MatchString(v) {
+		return 1, nil
+	}
+
+	if _rule2Regex.MatchString(k) && _rule2Regex.MatchString(v) {
+		return 2, nil
+	}
+
+	if _rule3Regex.MatchString(k) && _rule3Regex.MatchString(v) {
+		return 3, nil
+	}
+
+	if _rule4Regex.MatchString(k) && _rule4Regex.MatchString(v) {
+		return 4, nil
+	}
+
+	return 0, fmt.Errorf("filter: invalid mapper rule: %s -> %s", k, v)
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 )
 
-func TestInferFilterRuleType(t *testing.T) {
+func Test_inferFilterRuleType(t *testing.T) {
 	t.Run("Rule1", func(t *testing.T) {
 		rule, err := inferFilterRuleType("db1.*")
 		assert.NoError(t, err)
@@ -151,5 +151,41 @@ func TestFilter_AllowNSS(t *testing.T) {
 			namespace.New("db2", "coll1"),
 		}
 		assert.ElementsMatch(t, expect, f.AllowNSS(ns))
+	})
+}
+
+func TestInferMapperRuleType(t *testing.T) {
+	t.Run("Rule1", func(t *testing.T) {
+		rule, err := InferMapperRuleType("db1.*", "db2.*")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, rule)
+	})
+
+	t.Run("Rule2", func(t *testing.T) {
+		rule, err := InferMapperRuleType("db1.coll1", "db2.coll2")
+		assert.NoError(t, err)
+		assert.Equal(t, 2, rule)
+	})
+
+	t.Run("Rule3", func(t *testing.T) {
+		rule, err := InferMapperRuleType("coll1", "coll2")
+		assert.NoError(t, err)
+		assert.Equal(t, 3, rule)
+	})
+
+	t.Run("Rule4", func(t *testing.T) {
+		rule, err := InferMapperRuleType("db1.", "db2.")
+		assert.NoError(t, err)
+		assert.Equal(t, 4, rule)
+	})
+
+	t.Run("MismatchedRules", func(t *testing.T) {
+		_, err := InferMapperRuleType("db1.*", "db2.coll1")
+		assert.Error(t, err)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := InferMapperRuleType("db1.*.", "db2.*.")
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

- Add `ParseDBFilter`, `ParseCollFilter`, `InferFilterRuleType`, `InferMapperRuleType` to `internal/filter` package
- Simplify `restore.Plan` to use `filter.Filter` instead of separate DB/Coll maps
- Remove duplicate regex patterns and parsing functions from `cmd/restore` and `core/server/restore`

This makes restore consistent with backup, which already uses `filter.Filter`.

relate #695 