### PR TITLE
storage: accept 200 status code for DeleteObject response

### DIFF
--- a/internal/storage/minio_test.go
+++ b/internal/storage/minio_test.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,4 +67,25 @@ func TestSplitIntoParts(t *testing.T) {
 		_, err := splitIntoParts(_maxMultiCopySize + 1)
 		assert.Error(t, err)
 	})
+}
+
+func TestIsDeleteSuccessful(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, true},
+		{"200", minio.ErrorResponse{StatusCode: http.StatusOK}, true},
+		{"404", minio.ErrorResponse{StatusCode: http.StatusNotFound}, false},
+		{"403", minio.ErrorResponse{StatusCode: http.StatusForbidden}, false},
+		{"500", minio.ErrorResponse{StatusCode: http.StatusInternalServerError}, false},
+		{"non-minio", errors.New("error"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDeleteSuccessful(tt.err))
+		})
+	}
 }


### PR DESCRIPTION
Some S3-compatible storage returns 200 instead of 204 for DeleteObject, handle it as success.