### PR TITLE
docs: fix env variable typo for milvus.address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ examplebackup/
 
 dist/
 .DS_Store
+
+# Claude Code
+CLAUDE.local.md

--- a/docs/user_guide/env_variables.md
+++ b/docs/user_guide/env_variables.md
@@ -30,7 +30,7 @@ $ ./milvus-backup server
 
 | Config Key           | Env Variable        | Description                                 |
 |----------------------|---------------------|---------------------------------------------|
-| milvus.address       | MINIO_ADDRESS       | Milvus proxy address                        |
+| milvus.address       | MILVUS_ADDRESS      | Milvus proxy address                        |
 | milvus.port          | MILVUS_PORT         | Milvus proxy port                           |
 | milvus.user          | MILVUS_USER         | Milvus user name                            |
 | milvus.password      | MILVUS_PASSWORD     | Milvus password                             |


### PR DESCRIPTION
## Summary
Fix typo in environment variables documentation where `milvus.address` was incorrectly mapped to `MINIO_ADDRESS` instead of `MILVUS_ADDRESS`.

## Changes
- Fix env variable name from `MINIO_ADDRESS` to `MILVUS_ADDRESS` in docs/user_guide/env_variables.md