### PR TITLE
configs: use boolean type for crossStorage

### DIFF
--- a/configs/backup-azure.yaml
+++ b/configs/backup-azure.yaml
@@ -75,7 +75,7 @@ minio:
   # Set this option to true to enable data transfer through Milvus Backup.
   # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
   # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: "false"
+  crossStorage: false
   
 backup:
   parallelism:

--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -79,7 +79,7 @@ minio:
   # Set this option to true to enable data transfer through Milvus Backup.
   # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
   # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: "false"
+  crossStorage: false
   
 backup:
   parallelism:


### PR DESCRIPTION
## Summary
Use YAML native boolean type for `crossStorage` config instead of string "false".

## Changes
- Change `crossStorage: "false"` to `crossStorage: false` in `configs/backup.yaml`
- Change `crossStorage: "false"` to `crossStorage: false` in `configs/backup-azure.yaml`

Fixes #919