### PR TITLE
storage: verify copy result with HeadObject

### DIFF
--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -38,30 +38,111 @@ func TestTrackReader_Read(t *testing.T) {
 }
 
 func TestRemoteCopier_Copy(t *testing.T) {
-	dest := NewMockClient(t)
-	src := NewMockClient(t)
-	rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+	t.Run("Success", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
 
-	in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b"}, DestKey: "c/d"}
-	dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
 
-	attr := CopyAttr{Src: ObjectAttr{Key: "a/b"}, DestKey: "c/d"}
-	err := rp.copy(context.Background(), attr)
-	assert.NoError(t, err)
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(context.Background(), attr)
+		assert.NoError(t, err)
+	})
+
+	t.Run("HeadObjectError", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{}, assert.AnError).Once()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(context.Background(), attr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "verify copy")
+	})
+
+	t.Run("SizeMismatch", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 3}, nil).Once()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(context.Background(), attr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "size mismatch")
+	})
 }
 
 func TestServerCopier_Copy(t *testing.T) {
-	dest := NewMockClient(t)
-	src := NewMockClient(t)
-	sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
+	t.Run("Success", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
 
-	body := io.NopCloser(bytes.NewReader([]byte("hello")))
-	obj := &Object{Body: body, Length: 5}
-	src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
+		body := io.NopCloser(bytes.NewReader([]byte("hello")))
+		obj := &Object{Body: body, Length: 5}
+		src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
 
-	i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
-	dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
-	attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-	err := sp.copy(context.Background(), attr)
-	assert.NoError(t, err)
+		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
+		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := sp.copy(context.Background(), attr)
+		assert.NoError(t, err)
+	})
+
+	t.Run("HeadObjectError", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		body := io.NopCloser(bytes.NewReader([]byte("hello")))
+		obj := &Object{Body: body, Length: 5}
+		src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
+
+		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
+		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{}, assert.AnError).Once()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := sp.copy(ctx, attr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "verify copy")
+	})
+
+	t.Run("SizeMismatch", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		body := io.NopCloser(bytes.NewReader([]byte("hello")))
+		obj := &Object{Body: body, Length: 5}
+		src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
+
+		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
+		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 3}, nil).Once()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := sp.copy(ctx, attr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "size mismatch")
+	})
 }


### PR DESCRIPTION
## Summary
Add HeadObject verification after copy to ensure data integrity.

Partial fix for #637 (Lack of Validation for minio.rootPath)

## Changes
- Add HeadObject check after remoteCopier.copy() to verify dest file exists and size matches
- Add HeadObject check after serverCopier.copy() to verify no bytes lost during upload