### PR TITLE
paramtable: remove unused functions

### DIFF
--- a/core/paramtable/base_table.go
+++ b/core/paramtable/base_table.go
@@ -134,38 +134,9 @@ func (gp *BaseTable) Load(key string) (string, error) {
 	return gp.params.Load(strings.ToLower(key))
 }
 
-// LoadWithPriority loads an object with multiple @keys, return the first successful value.
-// If all keys not exist, return error.
-// This is to be compatible with old configuration file.
-func (gp *BaseTable) LoadWithPriority(keys []string) (string, error) {
-	for _, key := range keys {
-		if str, err := gp.params.Load(strings.ToLower(key)); err == nil {
-			return str, nil
-		}
-	}
-	return "", fmt.Errorf("invalid keys: %v", keys)
-}
-
 // LoadWithDefault loads an object with @key. If the object does not exist, @defaultValue will be returned.
 func (gp *BaseTable) LoadWithDefault(key, defaultValue string) string {
 	return gp.params.LoadWithDefault(strings.ToLower(key), defaultValue)
-}
-
-// LoadWithDefault2 loads an object with multiple @keys, return the first successful value.
-// If all keys not exist, return @defaultValue.
-// This is to be compatible with old configuration file.
-func (gp *BaseTable) LoadWithDefault2(keys []string, defaultValue string) string {
-	for _, key := range keys {
-		if str, err := gp.params.Load(strings.ToLower(key)); err == nil {
-			return str
-		}
-	}
-	return defaultValue
-}
-
-// LoadRange loads objects with range @startKey to @endKey with @limit number of objects.
-func (gp *BaseTable) LoadRange(key, endKey string, limit int) ([]string, []string, error) {
-	return gp.params.LoadRange(strings.ToLower(key), strings.ToLower(endKey), limit)
 }
 
 func (gp *BaseTable) LoadYaml(fileName string) error {
@@ -234,27 +205,6 @@ func (gp *BaseTable) ParseBool(key string, defaultValue bool) bool {
 	return value
 }
 
-func (gp *BaseTable) ParseFloat(key string) float64 {
-	valueStr, err := gp.Load(key)
-	if err != nil {
-		panic(err)
-	}
-	value, err := strconv.ParseFloat(valueStr, 64)
-	if err != nil {
-		panic(err)
-	}
-	return value
-}
-
-func (gp *BaseTable) ParseFloatWithDefault(key string, defaultValue float64) float64 {
-	valueStr := gp.LoadWithDefault(key, fmt.Sprintf("%f", defaultValue))
-	value, err := strconv.ParseFloat(valueStr, 64)
-	if err != nil {
-		panic(err)
-	}
-	return value
-}
-
 func (gp *BaseTable) ParseInt64(key string) int64 {
 	valueStr, err := gp.Load(key)
 	if err != nil {
@@ -316,35 +266,6 @@ func (gp *BaseTable) ParseIntWithDefault(key string, defaultValue int) int {
 		panic(err)
 	}
 	return value
-}
-
-func (gp *BaseTable) ParseDataSizeWithDefault(key string, defaultValue string) (int64, error) {
-	valueStr := strings.ToLower(gp.LoadWithDefault(key, defaultValue))
-	if strings.HasSuffix(valueStr, "g") || strings.HasSuffix(valueStr, "gb") {
-		size, err := strconv.ParseInt(strings.Split(valueStr, "g")[0], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return size * 1024 * 1024 * 1024, nil
-	} else if strings.HasSuffix(valueStr, "m") || strings.HasSuffix(valueStr, "mb") {
-		size, err := strconv.ParseInt(strings.Split(valueStr, "m")[0], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return size * 1024 * 1024, nil
-	} else if strings.HasSuffix(valueStr, "k") || strings.HasSuffix(valueStr, "kb") {
-		size, err := strconv.ParseInt(strings.Split(valueStr, "k")[0], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return size * 1024, nil
-	}
-
-	size, err := strconv.ParseInt(strings.Split(valueStr, "k")[0], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return size, nil
 }
 
 func (gp *BaseTable) loadMinioConfig() {

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -18,7 +18,6 @@ package memkv
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/google/btree"
@@ -38,34 +37,9 @@ func NewMemoryKV() *MemoryKV {
 	}
 }
 
-type Value interface {
-	String() string
-	ByteSlice() []byte
-}
-
-type StringValue string
-
-func (v StringValue) String() string {
-	return string(v)
-}
-
-func (v StringValue) ByteSlice() []byte {
-	return []byte(v)
-}
-
-type ByteSliceValue []byte
-
-func (v ByteSliceValue) String() string {
-	return string(v)
-}
-
-func (v ByteSliceValue) ByteSlice() []byte {
-	return v
-}
-
 type memoryKVItem struct {
 	key   string
-	value Value
+	value string
 }
 
 var _ btree.Item = (*memoryKVItem)(nil)
@@ -83,18 +57,7 @@ func (kv *MemoryKV) Load(key string) (string, error) {
 	if item == nil {
 		return "", fmt.Errorf("invalid key: %s", key)
 	}
-	return item.(memoryKVItem).value.String(), nil
-}
-
-// LoadBytes loads an object with @key.
-func (kv *MemoryKV) LoadBytes(key string) ([]byte, error) {
-	kv.RLock()
-	defer kv.RUnlock()
-	item := kv.tree.Get(memoryKVItem{key: key})
-	if item == nil {
-		return []byte{}, fmt.Errorf("invalid key: %s", key)
-	}
-	return item.(memoryKVItem).value.ByteSlice(), nil
+	return item.(memoryKVItem).value, nil
 }
 
 // Get return value if key exists, or return empty string
@@ -105,7 +68,7 @@ func (kv *MemoryKV) Get(key string) string {
 	if item == nil {
 		return ""
 	}
-	return item.(memoryKVItem).value.String()
+	return item.(memoryKVItem).value
 }
 
 // LoadWithDefault loads an object with @key. If the object does not exist, @defaultValue will be returned.
@@ -116,67 +79,14 @@ func (kv *MemoryKV) LoadWithDefault(key, defaultValue string) string {
 	if item == nil {
 		return defaultValue
 	}
-	return item.(memoryKVItem).value.String()
-}
-
-// LoadBytesWithDefault loads an object with @key. If the object does not exist, @defaultValue will be returned.
-func (kv *MemoryKV) LoadBytesWithDefault(key string, defaultValue []byte) []byte {
-	kv.RLock()
-	defer kv.RUnlock()
-	item := kv.tree.Get(memoryKVItem{key: key})
-	if item == nil {
-		return defaultValue
-	}
-	return item.(memoryKVItem).value.ByteSlice()
-}
-
-// LoadRange loads objects with range @startKey to @endKey with @limit number of objects.
-func (kv *MemoryKV) LoadRange(key, endKey string, limit int) ([]string, []string, error) {
-	kv.RLock()
-	defer kv.RUnlock()
-	keys := make([]string, 0, limit)
-	values := make([]string, 0, limit)
-	kv.tree.AscendRange(memoryKVItem{key: key}, memoryKVItem{key: endKey}, func(item btree.Item) bool {
-		keys = append(keys, item.(memoryKVItem).key)
-		values = append(values, item.(memoryKVItem).value.String())
-		if limit > 0 {
-			return len(keys) < limit
-		}
-		return true
-	})
-	return keys, values, nil
-}
-
-// LoadBytesRange loads objects with range @startKey to @endKey with @limit number of objects.
-func (kv *MemoryKV) LoadBytesRange(key, endKey string, limit int) ([]string, [][]byte, error) {
-	kv.RLock()
-	defer kv.RUnlock()
-	keys := make([]string, 0, limit)
-	values := make([][]byte, 0, limit)
-	kv.tree.AscendRange(memoryKVItem{key: key}, memoryKVItem{key: endKey}, func(item btree.Item) bool {
-		keys = append(keys, item.(memoryKVItem).key)
-		values = append(values, item.(memoryKVItem).value.ByteSlice())
-		if limit > 0 {
-			return len(keys) < limit
-		}
-		return true
-	})
-	return keys, values, nil
+	return item.(memoryKVItem).value
 }
 
 // Save object with @key to btree. Object value is @value.
 func (kv *MemoryKV) Save(key, value string) error {
 	kv.Lock()
 	defer kv.Unlock()
-	kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
-	return nil
-}
-
-// SaveBytes object with @key to btree. Object value is @value.
-func (kv *MemoryKV) SaveBytes(key string, value []byte) error {
-	kv.Lock()
-	defer kv.Unlock()
-	kv.tree.ReplaceOrInsert(memoryKVItem{key, ByteSliceValue(value)})
+	kv.tree.ReplaceOrInsert(memoryKVItem{key, value})
 	return nil
 }
 
@@ -186,197 +96,5 @@ func (kv *MemoryKV) Remove(key string) error {
 	defer kv.Unlock()
 
 	kv.tree.Delete(memoryKVItem{key: key})
-	return nil
-}
-
-// MultiLoad loads objects with multi @keys.
-func (kv *MemoryKV) MultiLoad(keys []string) ([]string, error) {
-	kv.RLock()
-	defer kv.RUnlock()
-	result := make([]string, 0, len(keys))
-	for _, key := range keys {
-		item := kv.tree.Get(memoryKVItem{key: key})
-		result = append(result, item.(memoryKVItem).value.String())
-	}
-	return result, nil
-}
-
-// MultiLoadBytes loads objects with multi @keys.
-func (kv *MemoryKV) MultiLoadBytes(keys []string) ([][]byte, error) {
-	kv.RLock()
-	defer kv.RUnlock()
-	result := make([][]byte, 0, len(keys))
-	for _, key := range keys {
-		item := kv.tree.Get(memoryKVItem{key: key})
-		result = append(result, item.(memoryKVItem).value.ByteSlice())
-	}
-	return result, nil
-}
-
-// MultiSave saves given key-value pairs in MemoryKV atomicly.
-func (kv *MemoryKV) MultiSave(kvs map[string]string) error {
-	kv.Lock()
-	defer kv.Unlock()
-	for key, value := range kvs {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
-	}
-	return nil
-}
-
-// MultiSaveBytes saves given key-value pairs in MemoryKV atomicly.
-func (kv *MemoryKV) MultiSaveBytes(kvs map[string][]byte) error {
-	kv.Lock()
-	defer kv.Unlock()
-	for key, value := range kvs {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, ByteSliceValue(value)})
-	}
-	return nil
-}
-
-// MultiRemove removes given @keys in MemoryKV atomicly.
-func (kv *MemoryKV) MultiRemove(keys []string) error {
-	kv.Lock()
-	defer kv.Unlock()
-	for _, key := range keys {
-		kv.tree.Delete(memoryKVItem{key: key})
-	}
-	return nil
-}
-
-// MultiSaveAndRemove saves and removes given key-value pairs in MemoryKV atomicly.
-func (kv *MemoryKV) MultiSaveAndRemove(saves map[string]string, removals []string) error {
-	kv.Lock()
-	defer kv.Unlock()
-	for key, value := range saves {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
-	}
-	for _, key := range removals {
-		kv.tree.Delete(memoryKVItem{key: key})
-	}
-	return nil
-}
-
-// MultiSaveBytesAndRemove saves and removes given key-value pairs in MemoryKV atomicly.
-func (kv *MemoryKV) MultiSaveBytesAndRemove(saves map[string][]byte, removals []string) error {
-	kv.Lock()
-	defer kv.Unlock()
-	for key, value := range saves {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, ByteSliceValue(value)})
-	}
-	for _, key := range removals {
-		kv.tree.Delete(memoryKVItem{key: key})
-	}
-	return nil
-}
-
-// LoadWithPrefix returns all keys & values with given prefix.
-func (kv *MemoryKV) LoadWithPrefix(key string) ([]string, []string, error) {
-	kv.Lock()
-	defer kv.Unlock()
-
-	var keys []string
-	var values []string
-
-	kv.tree.Ascend(func(i btree.Item) bool {
-		if strings.HasPrefix(i.(memoryKVItem).key, key) {
-			keys = append(keys, i.(memoryKVItem).key)
-			values = append(values, i.(memoryKVItem).value.String())
-		}
-		return true
-	})
-	return keys, values, nil
-}
-
-// LoadBytesWithPrefix returns all keys & values with given prefix.
-func (kv *MemoryKV) LoadBytesWithPrefix(key string) ([]string, [][]byte, error) {
-	kv.Lock()
-	defer kv.Unlock()
-
-	var keys []string
-	var values [][]byte
-
-	kv.tree.Ascend(func(i btree.Item) bool {
-		if strings.HasPrefix(i.(memoryKVItem).key, key) {
-			keys = append(keys, i.(memoryKVItem).key)
-			values = append(values, i.(memoryKVItem).value.ByteSlice())
-		}
-		return true
-	})
-	return keys, values, nil
-}
-
-// Close dummy close
-func (kv *MemoryKV) Close() {
-}
-
-// MultiRemoveWithPrefix not implemented
-func (kv *MemoryKV) MultiRemoveWithPrefix(keys []string) error {
-	panic("not implement")
-}
-
-// MultiSaveAndRemoveWithPrefix saves key-value pairs in @saves, & remove key with prefix in @removals in MemoryKV atomically.
-func (kv *MemoryKV) MultiSaveAndRemoveWithPrefix(saves map[string]string, removals []string) error {
-	kv.Lock()
-	defer kv.Unlock()
-
-	var keys []memoryKVItem
-	for _, key := range removals {
-		kv.tree.Ascend(func(i btree.Item) bool {
-			if strings.HasPrefix(i.(memoryKVItem).key, key) {
-				keys = append(keys, i.(memoryKVItem))
-			}
-			return true
-		})
-	}
-	for _, item := range keys {
-		kv.tree.Delete(item)
-	}
-
-	for key, value := range saves {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
-	}
-	return nil
-}
-
-// MultiSaveBytesAndRemoveWithPrefix saves key-value pairs in @saves, & remove key with prefix in @removals in MemoryKV atomically.
-func (kv *MemoryKV) MultiSaveBytesAndRemoveWithPrefix(saves map[string][]byte, removals []string) error {
-	kv.Lock()
-	defer kv.Unlock()
-
-	var keys []memoryKVItem
-	for _, key := range removals {
-		kv.tree.Ascend(func(i btree.Item) bool {
-			if strings.HasPrefix(i.(memoryKVItem).key, key) {
-				keys = append(keys, i.(memoryKVItem))
-			}
-			return true
-		})
-	}
-	for _, item := range keys {
-		kv.tree.Delete(item)
-	}
-
-	for key, value := range saves {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, ByteSliceValue(value)})
-	}
-	return nil
-}
-
-// RemoveWithPrefix remove key of given prefix in MemoryKV atomicly.
-func (kv *MemoryKV) RemoveWithPrefix(key string) error {
-	kv.Lock()
-	defer kv.Unlock()
-
-	var keys []btree.Item
-
-	kv.tree.Ascend(func(i btree.Item) bool {
-		if strings.HasPrefix(i.(memoryKVItem).key, key) {
-			keys = append(keys, i.(memoryKVItem))
-		}
-		return true
-	})
-	for _, item := range keys {
-		kv.tree.Delete(item)
-	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Remove unused functions from configuration loading code to reduce code complexity.

## Changes
- Remove unused `LoadWithPriority`, `LoadWithDefault2`, `LoadRange`, `ParseFloat`, `ParseFloatWithDefault`, `ParseDataSizeWithDefault` from `base_table.go`
- Simplify `mem_kv.go` by removing all unused methods (Bytes-related, Multi*, Range, Prefix operations)
- Remove `Value` interface and `ByteSliceValue` type that were only needed for removed methods

Part of #926