### PR TITLE
restore: remove unused taskMgr field in collectionDDLTask

### DIFF
--- a/core/restore/secondary/collection_ddl_task.go
+++ b/core/restore/secondary/collection_ddl_task.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 type collectionDDLTask struct {
@@ -29,8 +28,6 @@ type collectionDDLTask struct {
 	collBackup *backuppb.CollectionBackupInfo
 
 	tsAlloc *tsAlloc
-
-	taskMgr *taskmgr.Mgr
 
 	streamCli milvus.Stream
 	logger    *zap.Logger


### PR DESCRIPTION
## Summary
- Remove unused `taskMgr` field from `collectionDDLTask` struct in secondary restore
- Remove unused `taskmgr` import

## Changes
- Removed `taskMgr *taskmgr.Mgr` field that was never initialized or used
- Cleaned up corresponding import statement

/kind improvement