### PR TITLE
backup: add collection listing to Task with filter support

### DIFF
--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -296,7 +296,7 @@ func (t *Task) listFilteredDBAndNSS(ctx context.Context, f filter.Filter) ([]str
 				return nil, nil, fmt.Errorf("backup: check collection %s.%s: %w", dbName, collName, err)
 			}
 			if !exists {
-				return nil, nil, fmt.Errorf("backup: filter collection %s not found in milvus", collName)
+				return nil, nil, fmt.Errorf("backup: filter collection %s.%s not found in milvus", dbName, collName)
 			}
 			nss = append(nss, namespace.New(dbName, collName))
 		}

--- a/core/backup/task_test.go
+++ b/core/backup/task_test.go
@@ -152,6 +152,6 @@ func TestTask_listDBAndNSS(t *testing.T) {
 
 		_, _, err := task.listDBAndNSS(ctx)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "filter collection not_exist not found")
+		assert.Contains(t, err.Error(), "filter collection db1.not_exist not found")
 	})
 }


### PR DESCRIPTION
## Summary
- Optimize collection listing by querying directly based on filter instead of listing all then filtering
- When filter specifies exact collections (db.coll), use HasCollection API to verify existence
- When filter specifies db.*, list collections only for that database
- Remove redundant list-then-filter pattern for better performance

## Changes
- Refactor `listDBAndNSS` to check filter first and choose appropriate strategy
- Add `listAllDBAndNSS` for no-filter case (list all databases and collections)
- Add `listFilteredDBAndNSS` for filtered case (query only needed data)
- Update tests to reflect new behavior