### PR TITLE
storage: make multipart copy threshold configurable

### DIFF
--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -72,11 +72,15 @@ minio:
   backupRootPath: "backup" # Rootpath to store backup data. Backup data will store to backupBucketName/backupRootPath
   backupUseSSL: false # Access to MinIO/S3 with SSL
 
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported. 
+  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported.
   # Set this option to true to enable data transfer through Milvus Backup.
   # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
   # However, if they are the same but belong to different services, you must manually set this option to `true`.
   crossStorage: false
+
+  # File size threshold (MiB) above which multipart copy is used for S3-compatible storage.
+  # Default is 500. GCP does not support multipart copy and will always use single copy.
+  multipartCopyThresholdMiB: 500
   
 backup:
   parallelism:

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -230,6 +230,10 @@ type MinioConfig struct {
 	BackupIAMEndpoint       Value[string]
 
 	CrossStorage Value[bool]
+
+	// MultipartCopyThresholdMiB is the file size threshold above which multipart copy is used.
+	// Default is 500 MiB. GCP does not support multipart copy and will always use single copy.
+	MultipartCopyThresholdMiB Value[int64]
 }
 
 func newMinioConfig() MinioConfig {
@@ -269,6 +273,8 @@ func newMinioConfig() MinioConfig {
 		BackupIAMEndpoint:       Value[string]{Default: "", Keys: []string{"minio.backupIamEndpoint"}, EnvKeys: []string{"MINIO_BACKUP_IAM_ENDPOINT"}},
 
 		CrossStorage: Value[bool]{Default: false, Keys: []string{"minio.crossStorage"}},
+
+		MultipartCopyThresholdMiB: Value[int64]{Default: 500, Keys: []string{"minio.multipartCopyThresholdMiB"}},
 	}
 }
 
@@ -301,6 +307,7 @@ func (c *MinioConfig) Resolve(s *source) error {
 		&c.BackupAccessKeyID, &c.BackupSecretAccessKey, &c.BackupToken, &c.BackupGcpCredentialJSON,
 		&c.BackupUseSSL, &c.BackupBucketName, &c.BackupRootPath, &c.BackupUseIAM, &c.BackupIAMEndpoint,
 		&c.CrossStorage,
+		&c.MultipartCopyThresholdMiB,
 	)
 }
 

--- a/internal/cfg/load.go
+++ b/internal/cfg/load.go
@@ -145,4 +145,3 @@ func flattenAny(prefix string, v any, out map[string]any) error {
 		return nil
 	}
 }
-

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -47,6 +47,10 @@ type Config struct {
 	Credential Credential
 
 	Bucket string
+
+	// MultipartCopyThresholdMiB is the file size threshold above which multipart copy is used.
+	// Default is 500 MiB if not set. GCP does not support multipart copy.
+	MultipartCopyThresholdMiB int64
 }
 
 type Credential struct {

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -41,12 +41,13 @@ func newBackupCredential(params *cfg.MinioConfig) Credential {
 func BackupStorageConfig(params *cfg.MinioConfig) Config {
 	ep := net.JoinHostPort(params.BackupAddress.Val, strconv.Itoa(params.BackupPort.Val))
 	return Config{
-		Provider:   params.BackupStorageType.Val,
-		Endpoint:   ep,
-		UseSSL:     params.BackupUseSSL.Val,
-		Bucket:     params.BackupBucketName.Val,
-		Credential: newBackupCredential(params),
-		Region:     params.BackupRegion.Val,
+		Provider:                  params.BackupStorageType.Val,
+		Endpoint:                  ep,
+		UseSSL:                    params.BackupUseSSL.Val,
+		Bucket:                    params.BackupBucketName.Val,
+		Credential:                newBackupCredential(params),
+		Region:                    params.BackupRegion.Val,
+		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
 	}
 }
 
@@ -98,12 +99,13 @@ func newMilvusCredential(params *cfg.MinioConfig) Credential {
 func MilvusStorageConfig(params *cfg.MinioConfig) Config {
 	ep := net.JoinHostPort(params.Address.Val, strconv.Itoa(params.Port.Val))
 	return Config{
-		Provider:   params.StorageType.Val,
-		Endpoint:   ep,
-		UseSSL:     params.UseSSL.Val,
-		Credential: newMilvusCredential(params),
-		Bucket:     params.BucketName.Val,
-		Region:     params.Region.Val,
+		Provider:                  params.StorageType.Val,
+		Endpoint:                  ep,
+		UseSSL:                    params.UseSSL.Val,
+		Credential:                newMilvusCredential(params),
+		Bucket:                    params.BucketName.Val,
+		Region:                    params.Region.Val,
+		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `minio.multipartCopyThresholdMiB` config option to control when multipart copy is triggered
- Previously hardcoded at 500 MiB, now configurable via backup.yaml

## Changes
- Add `MultipartCopyThresholdMiB` field to `cfg.MinioConfig` with default value 500
- Add `MultipartCopyThresholdMiB` field to `storage.Config`
- Update `BackupStorageConfig` and `MilvusStorageConfig` to pass the threshold
- Update `MinioClient.CopyObject` to use configurable threshold instead of hardcoded value
- Add config documentation in backup.yaml

/kind improvement