### PR TITLE
storage: add multipart copy support for azure

### DIFF
--- a/internal/storage/azure_test.go
+++ b/internal/storage/azure_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAzureMultipartCopyThreshold(t *testing.T) {
+	t.Run("DefaultThreshold", func(t *testing.T) {
+		cli := &AzureClient{cfg: Config{}}
+		assert.Equal(t, _azureMaxSyncCopySize, cli.multipartCopyThreshold())
+	})
+
+	t.Run("ConfiguredBelowLimit", func(t *testing.T) {
+		cli := &AzureClient{cfg: Config{MultipartCopyThresholdMiB: 100}}
+		assert.Equal(t, int64(100*_MiB), cli.multipartCopyThreshold())
+	})
+
+	t.Run("ConfiguredAtLimit", func(t *testing.T) {
+		cli := &AzureClient{cfg: Config{MultipartCopyThresholdMiB: 256}}
+		assert.Equal(t, _azureMaxSyncCopySize, cli.multipartCopyThreshold())
+	})
+
+	t.Run("ConfiguredAboveLimitCapped", func(t *testing.T) {
+		cli := &AzureClient{cfg: Config{MultipartCopyThresholdMiB: 500}}
+		assert.Equal(t, _azureMaxSyncCopySize, cli.multipartCopyThreshold())
+	})
+}


### PR DESCRIPTION
## Summary
- Add multipart copy support for Azure Blob Storage using `StageBlockFromURL` + `CommitBlockList`
- Files >= 256 MB now use multipart copy instead of `CopyFromURL` (which has a 256 MB limit)
- Threshold is configurable via `MultipartCopyThresholdMiB`, capped at 256 MB for Azure

## Changes
- Add `multiPartCopy` method using Azure's block blob API
- Add `multipartCopyThreshold` method with 256 MB cap for Azure
- Add logger to AzureClient for debug logging
- Add unit tests for threshold logic

/kind improvement