### PR TITLE
restore: strip backupDir instead of backupRootPath in temp path

### DIFF
--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -296,17 +296,16 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 	}
 
 	return restore.TaskArgs{
-		TaskID:         uuid.NewString(),
-		Backup:         backup,
-		Plan:           plan,
-		Option:         o.toOption(),
-		Params:         params,
-		BackupDir:      mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
-		BackupRootPath: params.Minio.BackupRootPath.Val,
-		BackupStorage:  backupStorage,
-		MilvusStorage:  milvusStorage,
-		Grpc:           milvusClient,
-		Restful:        restfulClient,
+		TaskID:        uuid.NewString(),
+		Backup:        backup,
+		Plan:          plan,
+		Option:        o.toOption(),
+		Params:        params,
+		BackupDir:     mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
+		BackupStorage: backupStorage,
+		MilvusStorage: milvusStorage,
+		Grpc:          milvusClient,
+		Restful:       restfulClient,
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}, nil

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -52,9 +52,8 @@ type collTask struct {
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
 
-	backupDir      string
-	backupRootPath string
-	backupStorage  storage.Client
+	backupDir     string
+	backupStorage storage.Client
 
 	milvusStorage storage.Client
 
@@ -86,10 +85,9 @@ type collTaskArgs struct {
 
 	taskMgr *taskmgr.Mgr
 
-	backupRootPath string
-	backupDir      string
-	keepTempFiles  bool
-	crossStorage   bool
+	backupDir     string
+	keepTempFiles bool
+	crossStorage  bool
 
 	backupStorage storage.Client
 	milvusStorage storage.Client
@@ -129,10 +127,9 @@ func newCollTask(args collTaskArgs) *collTask {
 		copySem:       args.copySem,
 		bulkInsertSem: args.bulkInsertSem,
 
-		crossStorage:   args.crossStorage,
-		keepTempFiles:  args.keepTempFiles,
-		backupDir:      args.backupDir,
-		backupRootPath: args.backupRootPath,
+		crossStorage:  args.crossStorage,
+		keepTempFiles: args.keepTempFiles,
+		backupDir:     args.backupDir,
 
 		backupStorage: args.backupStorage,
 		milvusStorage: args.milvusStorage,
@@ -306,7 +303,7 @@ func (ct *collTask) cleanTempFiles(dir string) tearDownFn {
 
 func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix string) (string, error) {
 	ct.logger.Info("milvus and backup store in different bucket, copy the data first", zap.String("temp_dir", tempDir))
-	dest := path.Join(tempDir, strings.Replace(srcPrefix, ct.backupRootPath, "", 1)) + "/"
+	dest := path.Join(tempDir, strings.Replace(srcPrefix, ct.backupDir, "", 1)) + "/"
 	opt := storage.CopyPrefixOpt{
 		Sem:          ct.copySem,
 		Src:          ct.backupStorage,

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -126,10 +126,9 @@ type TaskArgs struct {
 
 	Params *cfg.Config
 
-	BackupDir      string
-	BackupRootPath string
-	BackupStorage  storage.Client
-	MilvusStorage  storage.Client
+	BackupDir     string
+	BackupStorage storage.Client
+	MilvusStorage storage.Client
 
 	Grpc    milvus.Grpc
 	Restful milvus.Restful
@@ -247,22 +246,21 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 	for _, targetNS := range targetNSes {
 		t.logger.Debug("generate restore collection task", zap.String("source", sourceNS.String()), zap.String("target", targetNS.String()))
 		args := collTaskArgs{
-			taskID:         t.args.TaskID,
-			taskMgr:        t.args.TaskMgr,
-			targetNS:       targetNS,
-			dbBackup:       dbBackup,
-			collBackup:     collBackup,
-			option:         t.args.Option,
-			backupRootPath: t.args.BackupRootPath,
-			crossStorage:   t.args.Params.Minio.CrossStorage.Val,
-			keepTempFiles:  t.args.Params.Backup.KeepTempFiles.Val,
-			backupDir:      t.args.BackupDir,
-			backupStorage:  t.args.BackupStorage,
-			milvusStorage:  t.args.MilvusStorage,
-			copySem:        t.copySem,
-			bulkInsertSem:  t.bulkInsertSem,
-			grpcCli:        t.args.Grpc,
-			restfulCli:     t.args.Restful,
+			taskID:        t.args.TaskID,
+			taskMgr:       t.args.TaskMgr,
+			targetNS:      targetNS,
+			dbBackup:      dbBackup,
+			collBackup:    collBackup,
+			option:        t.args.Option,
+			crossStorage:  t.args.Params.Minio.CrossStorage.Val,
+			keepTempFiles: t.args.Params.Backup.KeepTempFiles.Val,
+			backupDir:     t.args.BackupDir,
+			backupStorage: t.args.BackupStorage,
+			milvusStorage: t.args.MilvusStorage,
+			copySem:       t.copySem,
+			bulkInsertSem: t.bulkInsertSem,
+			grpcCli:       t.args.Grpc,
+			restfulCli:    t.args.Restful,
 		}
 
 		tasks = append(tasks, newCollTask(args))


### PR DESCRIPTION
## Summary
- Use `backupDir` instead of `backupRootPath` when stripping prefix in `copyToMilvusBucket`, producing cleaner temp paths
- Remove the now-unused `BackupRootPath` field from `TaskArgs` and `collTaskArgs`

## Changes
- `core/restore/coll_task.go`: replace `backupRootPath` with `backupDir` in `copyToMilvusBucket`, remove `backupRootPath` from both structs
- `core/restore/task.go`: remove `BackupRootPath` from `TaskArgs`, drop assignment in `newCollTask`
- `cmd/restore/restore.go`: remove `BackupRootPath` assignment

/kind improvement