### PR TITLE
owners: replace Thomas-HuWei with alohaha22

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,9 +4,9 @@ filters:
       - huanghaoyuanhhy
       - zhuwenxing
       - lentitude2tk
-      - Thomas-HuWei
+      - alohaha22
     approvers:
       - huanghaoyuanhhy
       - zhuwenxing
       - lentitude2tk
-      - Thomas-HuWei
+      - alohaha22


### PR DESCRIPTION
## Summary
Replace Thomas-HuWei with alohaha22 in OWNERS file for both reviewers and approvers.

## Changes
- Remove Thomas-HuWei from reviewers and approvers
- Add alohaha22 to reviewers and approvers

/kind improvement