### PR TITLE
backup: fail when segment has no insert logs

### DIFF
--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -461,6 +461,9 @@ func (dmlt *collDMLTask) backupSegmentData(ctx context.Context, seg *backuppb.Se
 	if err != nil {
 		return fmt.Errorf("backup: backup insert logs %w", err)
 	}
+	if len(insertAttrs) == 0 && !seg.GetIsL0() {
+		return fmt.Errorf("backup: segment %d has no insert logs", seg.GetSegmentId())
+	}
 	deltaAttrs, err := dmlt.deltaLogAttrs(seg)
 	if err != nil {
 		return fmt.Errorf("backup: backup delta logs %w", err)


### PR DESCRIPTION
## Summary
Fail the backup when a segment has no insert logs, instead of silently succeeding with empty data.

## Changes
- Add empty insert logs check in `backupSegmentData` to return an error when a segment has no insert logs

Fixes #47