### PR TITLE
docs: default reproduce dropdown to "Not tested on the latest version"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,6 +22,7 @@ body:
   attributes:
     label: Can you reproduce this issue on the latest version?
     description: Please check the latest released Milvus-Backup version.
+    default: 2
     options:
       - "Yes, it also happens on the latest version"
       - "No, it only happens on my current version"


### PR DESCRIPTION
## Summary
- Default the "Can you reproduce this issue on the latest version?" dropdown to "Not tested on the latest version" in the bug report template

## Changes
- Add `default: 2` to the reproduce dropdown in `.github/ISSUE_TEMPLATE/bug_report.yaml`

/kind improvement