### PR TITLE
scripts: use 'docker compose' instead of deprecated 'docker-compose'

### DIFF
--- a/scripts/check_healthy.sh
+++ b/scripts/check_healthy.sh
@@ -4,8 +4,8 @@
 function check_healthy {
     Expect=$(yq '.services | length' 'docker-compose.yml')
     Expect_health=$(yq '.services' 'docker-compose.yml' |grep 'healthcheck'|wc -l)
-    cnt=$(docker-compose ps | grep -E "running|Running|Up|up" | wc -l)
-    healthy=$(docker-compose ps | grep "healthy" | wc -l)
+    cnt=$(docker compose ps | grep -E "running|Running|Up|up" | wc -l)
+    healthy=$(docker compose ps | grep "healthy" | wc -l)
     time_cnt=0
     echo "running num $cnt expect num $Expect"
     echo "healthy num $healthy expect num $Expect_health"
@@ -20,8 +20,8 @@ function check_healthy {
         printf "timeout,there are some issues with deployment!"
         exit 1
     fi
-    cnt=$(docker-compose ps | grep -E "running|Running|Up|up" | wc -l)
-    healthy=$(docker-compose ps | grep "healthy" | wc -l)
+    cnt=$(docker compose ps | grep -E "running|Running|Up|up" | wc -l)
+    healthy=$(docker compose ps | grep "healthy" | wc -l)
     echo "running num $cnt expect num $Expect"
     echo "healthy num $healthy expect num $Expect_health"
     done

--- a/scripts/export_log_docker.sh
+++ b/scripts/export_log_docker.sh
@@ -4,7 +4,7 @@
 set -e
 
 log_dir=${1:-"logs"}
-array=($(docker-compose ps -a|awk 'NR == 1 {next} {print $1}'))
+array=($(docker compose ps -a|awk 'NR == 1 {next} {print $1}'))
 echo ${array[@]}
 if [ ! -d $log_dir ];
 then


### PR DESCRIPTION
## Summary
Replace deprecated `docker-compose` command with `docker compose` in CI helper scripts. The standalone `docker-compose` binary is no longer available on Ubuntu 24.04 GitHub runners, causing Milvus server log export to fail silently in CI.

## Changes
- `scripts/export_log_docker.sh`: `docker-compose ps -a` → `docker compose ps -a`
- `scripts/check_healthy.sh`: `docker-compose ps` → `docker compose ps` (4 occurrences)

/kind improvement