### PR TITLE
restore: add missing SetRestoreExecuting in secondary restore task

### DIFF
--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -105,6 +105,8 @@ func (t *Task) Execute(ctx context.Context) error {
 		return err
 	}
 
+	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreExecuting())
+
 	if err := t.runDBTasks(ctx); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
 		return fmt.Errorf("secondary: run database tasks: %w", err)


### PR DESCRIPTION
## Summary

The secondary restore task `Execute()` never transitions state from `INITIAL` to `EXECUTING`. It jumps directly from `INITIAL` to `SUCCESS` only at the very end after `WaitConfirm()` completes.

This causes external callers polling via `GET /api/v1/get_restore` to see `stateCode=INITIAL(0)` while collection sub-tasks already show `state_code=SUCCESS(2)` with `progress=100`, making it impossible for them to track execution progress correctly.

### Root Cause

In `core/restore/secondary/task.go`, the `Execute()` method was missing `SetRestoreExecuting()`:

```go
func (t *Task) Execute(ctx context.Context) error {
    defer t.closeClients()
    if err := t.initClients(); err != nil {
        return err
    }
    // Missing: SetRestoreExecuting()
    if err := t.runDBTasks(ctx); err != nil { ... }
    if err := t.runCollTasks(ctx); err != nil { ... }
    ...
    t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreSuccess())
    return nil
}
```

Compare with the primary restore task (`core/restore/task.go`), which correctly calls `SetRestoreExecuting()` at the start of `privateExecute()`.

### Fix

Add `SetRestoreExecuting()` after `initClients()` succeeds, matching the primary restore task behavior.

State transition before fix: `INITIAL -> SUCCESS`
State transition after fix: `INITIAL -> EXECUTING -> SUCCESS`

Signed-off-by: huanghaoyuanhhy <haoyuan.huang@zilliz.com>