### PR TITLE
restore: fix struct literal alignment

### DIFF
--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -178,14 +178,14 @@ func (h *restoreHandler) newTask(ctx context.Context, backupDir string) (*restor
 	}
 
 	args := restore.TaskArgs{
-		TaskID:         h.request.GetId(),
-		Backup:         backup,
-		Plan:           plan,
-		Option:         newOptionFromRequest(h.request),
-		Params:         h.params,
+		TaskID:        h.request.GetId(),
+		Backup:        backup,
+		Plan:          plan,
+		Option:        newOptionFromRequest(h.request),
+		Params:        h.params,
 		BackupDir:     backupDir,
 		BackupStorage: h.backupStorage,
-		MilvusStorage:  h.milvusStorage,
+		MilvusStorage: h.milvusStorage,
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}


### PR DESCRIPTION
## Summary
- Fix struct literal field alignment in `core/server/restore.go`

## Changes
- Align struct field values to use consistent tab spacing

/kind improvement