### PR TITLE
ci: add golangci-lint to PR workflow and fix all lint issues

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go ${{ env.go-version }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.go-version }}
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
+
   unit-test-go:
     name: Unit test go
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,111 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    # defaults
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # additional
+    - misspell
+    - revive
+    - gocritic
+    - gocyclo
+    - unconvert
+    - nolintlint
+    - whitespace
+    - bodyclose
+    - durationcheck
+    - errname
+    - errorlint
+    - copyloopvar
+    - makezero
+    - nilerr
+    - prealloc
+    - reassign
+    - wastedassign
+  settings:
+    errcheck:
+      exclude-functions:
+        - io.Close
+        - io.Closer.Close
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (net/http.ResponseBody).Close
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (*text/tabwriter.Writer).Flush
+        - (*go.uber.org/zap.SugaredLogger).Sync
+        - (*go.uber.org/zap/zapcore.Core).Sync
+        - (*go.uber.org/zap/buffer.Buffer).Write
+    gocyclo:
+      min-complexity: 30
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: exported
+          disabled: true
+        - name: increment-decrement
+        - name: var-naming
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: superfluous-else
+        - name: unreachable-code
+    gocritic:
+      enabled-checks:
+        - badLock
+        - badRegexp
+        - builtinShadowDecl
+        - truncateCmp
+        - weakCond
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    paths:
+      - core/proto
+      - docs
+      - ".*_mock\\.go$"
+      - ".*_string\\.go$"
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gocritic
+          - gocyclo
+          - prealloc
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/zilliztech/milvus-backup
+  exclusions:
+    paths:
+      - core/proto
+      - docs
+      - ".*_mock\\.go$"
+      - ".*_string\\.go$"

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,9 @@ fmt:
 	@find . -name '*.go' -type f ! -exec grep -q "DO NOT EDIT" {} \; -print0 | xargs -0 goimports -w --local $(PKG)
 	@echo Format code done
 
-.PHONY: all build gen
+lint:
+	@echo Running linters...
+	@golangci-lint run ./...
+	@echo Lint passed
+
+.PHONY: all build gen lint

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -289,7 +289,6 @@ func NewCmd(opt *root.Options) *cobra.Command {
 			cobra.CheckErr(err)
 
 			return nil
-
 		},
 	}
 

--- a/cmd/inittarget/main.go
+++ b/cmd/inittarget/main.go
@@ -63,11 +63,11 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.Fatalf("failed to dial %s (%s): %v", name, addr, err)
 		}
-		defer conn.Close()
+		defer conn.Close() //nolint:errcheck // best-effort close on exit
 
 		client := milvuspb.NewMilvusServiceClient(conn)
 		resp, err := client.UpdateReplicateConfiguration(ctx, &milvuspb.UpdateReplicateConfigurationRequest{
@@ -76,7 +76,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to update replicate configuration on %s: %v", name, err)
 		}
-		if resp.GetErrorCode() != commonpb.ErrorCode_Success {
+		if resp.GetErrorCode() != commonpb.ErrorCode_Success { //nolint:staticcheck // SA1019: GetErrorCode needed for backward compatibility
 			log.Fatalf("update replicate configuration on %s returned error: %s", name, resp.GetReason())
 		}
 		log.Printf("replicate configuration updated on %s successfully", name)

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -43,7 +43,6 @@ func (o *secondaryOption) validate() error {
 }
 
 func (o *secondaryOption) toArgs(params *cfg.Config) (secondary.TaskArgs, error) {
-
 	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
 	if err != nil {
 		return secondary.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)

--- a/core/backup/coll_ddl_task.go
+++ b/core/backup/coll_ddl_task.go
@@ -136,7 +136,7 @@ func (ddlt *collDDLTask) convSchema(schema *schemapb.CollectionSchema) (*backupp
 	bakSchema := &backuppb.CollectionSchema{
 		Name:               schema.GetName(),
 		Description:        schema.GetDescription(),
-		AutoID:             schema.GetAutoID(),
+		AutoID:             schema.GetAutoID(), //nolint:staticcheck // SA1019: deprecated but needed for backward compatibility
 		Fields:             fields,
 		Properties:         pbconv.MilvusKVToBakKV(schema.GetProperties()),
 		EnableDynamicField: schema.GetEnableDynamicField(),

--- a/core/backup/coll_ddl_task_test.go
+++ b/core/backup/coll_ddl_task_test.go
@@ -27,7 +27,7 @@ func TestCollDDLTask_convSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, schema.GetName(), bakSchema.GetName())
 	assert.Equal(t, schema.GetDescription(), bakSchema.GetDescription())
-	assert.Equal(t, schema.GetAutoID(), bakSchema.GetAutoID())
+	assert.Equal(t, schema.GetAutoID(), bakSchema.GetAutoID()) //nolint:staticcheck // SA1019: testing deprecated field
 	assert.Equal(t, schema.GetEnableDynamicField(), bakSchema.GetEnableDynamicField())
 	assert.ElementsMatch(t, schema.GetProperties(), pbconv.BakKVToMilvusKV(bakSchema.GetProperties()))
 }

--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -179,9 +179,8 @@ func (dmlt *collDMLTask) getSegment(ctx context.Context, seg *milvuspb.Persisten
 		bakSeg, err = dmlt.getSegmentInfoByAPI(ctx, seg)
 		if err == nil {
 			return bakSeg, nil
-		} else {
-			dmlt.logger.Warn("get segment info via proxy node failed, pls check whether milvus restful api is enabled", zap.Error(err))
 		}
+		dmlt.logger.Warn("get segment info via proxy node failed, pls check whether milvus restful api is enabled", zap.Error(err))
 	}
 
 	var err error
@@ -469,7 +468,9 @@ func (dmlt *collDMLTask) backupSegmentData(ctx context.Context, seg *backuppb.Se
 		return fmt.Errorf("backup: backup delta logs %w", err)
 	}
 
-	attrs := append(insertAttrs, deltaAttrs...)
+	attrs := make([]storage.CopyAttr, 0, len(insertAttrs)+len(deltaAttrs))
+	attrs = append(attrs, insertAttrs...)
+	attrs = append(attrs, deltaAttrs...)
 	opt := storage.CopyObjectsOpt{
 		Src:          dmlt.milvusStorage,
 		Dest:         dmlt.backupStorage,

--- a/core/backup/coll_dml_task_test.go
+++ b/core/backup/coll_dml_task_test.go
@@ -91,7 +91,6 @@ func TestCollDMLTask_listInsertLogByListFile(t *testing.T) {
 		_, _, err := dmlt.listInsertLogByListFile(context.Background(), dir)
 		assert.Error(t, err)
 	})
-
 }
 
 func TestCollDMLTask_listDeltaLogByListFile(t *testing.T) {

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -211,8 +211,9 @@ func (builder *metaBuilder) buildPartitionMeta() ([]byte, error) {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
-	partitions := make([]*backuppb.PartitionBackupInfo, 0)
-	for _, collection := range builder.data.GetCollectionBackups() {
+	collections := builder.data.GetCollectionBackups()
+	partitions := make([]*backuppb.PartitionBackupInfo, 0, len(collections))
+	for _, collection := range collections {
 		partitions = append(partitions, collection.GetPartitionBackups()...)
 	}
 

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -385,7 +385,6 @@ func (ct *collTask) restoreNotL0SegV1(ctx context.Context, part *backuppb.Partit
 	}
 
 	return nil
-
 }
 
 func toPaths(dir partitionDir) []string {
@@ -634,10 +633,9 @@ func (ct *collTask) notL0SegmentBatches(ctx context.Context, part *backuppb.Part
 
 	if withGroupID {
 		return ct.notL0SegBatchesWithGroupID(ctx, notL0Segs)
-	} else {
-		// backward compatible old backup without group id
-		return ct.notL0SegBatchesWithoutGroupID(ctx, part)
 	}
+	// backward compatible old backup without group id
+	return ct.notL0SegBatchesWithoutGroupID(ctx, part)
 }
 
 func (ct *collTask) l0SegmentBatches(l0Segs []*backuppb.SegmentBackupInfo) ([]batch, error) {
@@ -871,7 +869,6 @@ func (ct *collTask) buildBackupPartitionDir(ctx context.Context, size int64, pat
 
 	if exist {
 		return partitionDir{insertLogDir: insertLogDir, deltaLogDir: deltaLogDir, size: size}, nil
-	} else {
-		return partitionDir{insertLogDir: insertLogDir, size: size}, nil
 	}
+	return partitionDir{insertLogDir: insertLogDir, size: size}, nil
 }

--- a/core/restore/conv/conv.go
+++ b/core/restore/conv/conv.go
@@ -28,9 +28,10 @@ func DefaultValue(field *backuppb.FieldSchema) (*schemapb.ValueField, error) {
 	}
 
 	// backward compatibility
+	//nolint:staticcheck // SA1019: GetDefaultValueProto is deprecated but needed for backward compatibility with old backups
 	if field.GetDefaultValueProto() != "" {
 		var defaultValue schemapb.ValueField
-		err := proto.Unmarshal([]byte(field.GetDefaultValueProto()), &defaultValue)
+		err := proto.Unmarshal([]byte(field.GetDefaultValueProto()), &defaultValue) //nolint:staticcheck // SA1019
 		if err != nil {
 			return nil, fmt.Errorf("restore: failed to unmarshal default value: %w", err)
 		}

--- a/core/restore/secondary/coll_load_task.go
+++ b/core/restore/secondary/coll_load_task.go
@@ -87,7 +87,6 @@ func (clt *collLoadTask) Execute(ctx context.Context) error {
 	}
 
 	return nil
-
 }
 
 func (clt *collLoadTask) buildLoadFields() []*messagespb.LoadFieldConfig {

--- a/core/restore/secondary/fake_message_id.go
+++ b/core/restore/secondary/fake_message_id.go
@@ -22,27 +22,15 @@ func (f *fakeMessageID) WALName() message.WALName {
 }
 
 func (f *fakeMessageID) LT(id message.MessageID) bool {
-	if f.tt < id.(*fakeMessageID).tt {
-		return true
-	}
-
-	return false
+	return f.tt < id.(*fakeMessageID).tt
 }
 
 func (f *fakeMessageID) LTE(id message.MessageID) bool {
-	if f.tt <= id.(*fakeMessageID).tt {
-		return true
-	}
-
-	return false
+	return f.tt <= id.(*fakeMessageID).tt
 }
 
 func (f *fakeMessageID) EQ(id message.MessageID) bool {
-	if f.tt == id.(*fakeMessageID).tt {
-		return true
-	}
-
-	return false
+	return f.tt == id.(*fakeMessageID).tt
 }
 
 func (f *fakeMessageID) Marshal() string {

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -234,7 +234,7 @@ func (t *Task) newDBTask(dbBak *backuppb.DatabaseBackupInfo) []*databaseTask {
 }
 
 func (t *Task) newDBTasks(dbBackups []*backuppb.DatabaseBackupInfo) []*databaseTask {
-	var dbTasks []*databaseTask
+	dbTasks := make([]*databaseTask, 0, len(dbBackups))
 	for _, dbBackup := range dbBackups {
 		tasks := t.newDBTask(dbBackup)
 		dbTasks = append(dbTasks, tasks...)

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -91,12 +91,12 @@ func (h *createBackupHandler) toFilter() (filter.Filter, error) {
 		return h.filterToFilter()
 	}
 
-	dbCollectionsStr := utils.GetDBCollections(h.request.GetDbCollections())
+	dbCollectionsStr := utils.GetDBCollections(h.request.GetDbCollections()) //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 	if len(dbCollectionsStr) > 0 {
 		return h.dbCollectionsToFilter(dbCollectionsStr)
 	}
 
-	if len(h.request.GetCollectionNames()) > 0 {
+	if len(h.request.GetCollectionNames()) > 0 { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		return h.collectionNamesToFilter()
 	}
 
@@ -127,7 +127,7 @@ func (h *createBackupHandler) dbCollectionsToFilter(dbCollectionsStr string) (fi
 
 func (h *createBackupHandler) collectionNamesToFilter() (filter.Filter, error) {
 	dbCollFilter := make(map[string]filter.CollFilter)
-	for _, nsStr := range h.request.GetCollectionNames() {
+	for _, nsStr := range h.request.GetCollectionNames() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		ns, err := namespace.Parse(nsStr)
 		if err != nil {
 			return filter.Filter{}, fmt.Errorf("server: invalid collection name %s", nsStr)
@@ -156,12 +156,12 @@ func (h *createBackupHandler) toStrategy() (backup.Strategy, error) {
 		return backup.ParseStrategy(h.request.GetStrategy())
 	}
 
-	if h.request.GetForce() {
+	if h.request.GetForce() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		log.Warn("force option is deprecated, pls use strategy=skip_flush instead")
 		return backup.StrategySkipFlush, nil
 	}
 
-	if h.request.GetMetaOnly() {
+	if h.request.GetMetaOnly() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		log.Warn("meta_only option is deprecated, pls use strategy=meta_only instead")
 		return backup.StrategyMetaOnly, nil
 	}
@@ -315,7 +315,6 @@ func (h *createBackupHandler) run(ctx context.Context) *backuppb.BackupInfoRespo
 
 	if h.request.GetAsync() {
 		return h.runAsync(args)
-	} else {
-		return h.runSync(ctx, args)
 	}
+	return h.runSync(ctx, args)
 }

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -91,9 +91,8 @@ func (h *restoreHandler) run(ctx context.Context) *backuppb.RestoreBackupRespons
 
 	if h.request.GetAsync() {
 		return h.runAsync(task)
-	} else {
-		return h.runSync(ctx, task)
 	}
+	return h.runSync(ctx, task)
 }
 
 func (h *restoreHandler) validate() error {

--- a/core/utils/request_util.go
+++ b/core/utils/request_util.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck // SA1019: legacy protobuf package used for backward compatibility
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 

--- a/internal/aimd/limiter.go
+++ b/internal/aimd/limiter.go
@@ -61,7 +61,7 @@ func (a *Limiter) Wait(ctx context.Context) error {
 	case <-a.bucket:
 		return nil
 	case <-ctx.Done():
-		return fmt.Errorf("aimd_limter: context cancelled: %w", ctx.Err())
+		return fmt.Errorf("aimd_limiter: context canceled: %w", ctx.Err())
 	}
 }
 

--- a/internal/client/cloud/api.go
+++ b/internal/client/cloud/api.go
@@ -44,10 +44,10 @@ func mask(s string) string {
 
 func (cred *Credentials) String() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("expireTime: %s, ", cred.ExpireTime))
-	sb.WriteString(fmt.Sprintf("sessionToken: %s, ", mask(cred.SessionToken)))
-	sb.WriteString(fmt.Sprintf("tmpAK: %s, ", mask(cred.TmpAK)))
-	sb.WriteString(fmt.Sprintf("tmpSK: %s", mask(cred.TmpSK)))
+	fmt.Fprintf(&sb, "expireTime: %s, ", cred.ExpireTime)
+	fmt.Fprintf(&sb, "sessionToken: %s, ", mask(cred.SessionToken))
+	fmt.Fprintf(&sb, "tmpAK: %s, ", mask(cred.TmpAK))
+	fmt.Fprintf(&sb, "tmpSK: %s", mask(cred.TmpSK))
 
 	return sb.String()
 }
@@ -73,13 +73,13 @@ type ApplyVolumeResp struct {
 
 func (a *ApplyVolumeResp) String() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("bucketName: %s, ", mask(a.BucketName)))
-	sb.WriteString(fmt.Sprintf("cloud: %s, ", a.Cloud))
-	sb.WriteString(fmt.Sprintf("condition: %s, ", a.Condition.String()))
-	sb.WriteString(fmt.Sprintf("credentials: %s, ", a.Credentials.String()))
-	sb.WriteString(fmt.Sprintf("endpoint: %s, ", a.Endpoint))
-	sb.WriteString(fmt.Sprintf("region: %s, ", a.Region))
-	sb.WriteString(fmt.Sprintf("uploadPath: %s", mask(a.UploadPath)))
+	fmt.Fprintf(&sb, "bucketName: %s, ", mask(a.BucketName))
+	fmt.Fprintf(&sb, "cloud: %s, ", a.Cloud)
+	fmt.Fprintf(&sb, "condition: %s, ", a.Condition.String())
+	fmt.Fprintf(&sb, "credentials: %s, ", a.Credentials.String())
+	fmt.Fprintf(&sb, "endpoint: %s, ", a.Endpoint)
+	fmt.Fprintf(&sb, "region: %s, ", a.Region)
+	fmt.Fprintf(&sb, "uploadPath: %s", mask(a.UploadPath))
 
 	return sb.String()
 }

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // SA1019: legacy protobuf package used for backward compatibility
 	grpcretry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -146,7 +146,7 @@ const (
 )
 
 func statusOk(status *commonpb.Status) bool {
-	// nolint
+	//nolint:staticcheck // SA1019: GetErrorCode is needed for backward compatibility with older Milvus versions
 	return status.GetCode() == 0 && status.GetErrorCode() == 0
 }
 
@@ -480,9 +480,8 @@ func (g *GrpcClient) CreateDatabase(ctx context.Context, dbName string) error {
 			if isRateLimitError(err) {
 				g.limiters.createDatabase.Failure()
 				return fmt.Errorf("client: create database failed due to rate limit: %w", err)
-			} else {
-				return retry.Unrecoverable(fmt.Errorf("client: create database: %w", err))
 			}
+			return retry.Unrecoverable(fmt.Errorf("client: create database: %w", err))
 		}
 		g.limiters.createDatabase.Success()
 
@@ -535,7 +534,7 @@ func (g *GrpcClient) ListIndex(ctx context.Context, db, collName string) ([]*mil
 		return nil, fmt.Errorf("client: describe index failed: %w", err)
 	}
 	// Some Milvus versions return IndexNotExist error code when collection has no index
-	// nolint
+	//nolint:staticcheck // SA1019: GetErrorCode is needed for backward compatibility with older Milvus versions
 	if resp.GetStatus().GetErrorCode() == commonpb.ErrorCode_IndexNotExist {
 		return nil, nil
 	}
@@ -908,9 +907,8 @@ func (g *GrpcClient) CreatePartition(ctx context.Context, db, collName, partitio
 			if isRateLimitError(err) {
 				g.limiters.createPartition.Failure()
 				return fmt.Errorf("client: create partition failed due to rate limit: %w", err)
-			} else {
-				return retry.Unrecoverable(fmt.Errorf("client: create partition: %w", err))
 			}
+			return retry.Unrecoverable(fmt.Errorf("client: create partition: %w", err))
 		}
 		g.limiters.createPartition.Success()
 
@@ -982,9 +980,8 @@ func (g *GrpcClient) CreateIndex(ctx context.Context, input CreateIndexInput) er
 			if isRateLimitError(err) {
 				g.limiters.createIndex.Failure()
 				return fmt.Errorf("client: create index failed due to rate limit: %w", err)
-			} else {
-				return retry.Unrecoverable(fmt.Errorf("client: create index: %w", err))
 			}
+			return retry.Unrecoverable(fmt.Errorf("client: create index: %w", err))
 		}
 		g.limiters.createIndex.Success()
 
@@ -1024,7 +1021,7 @@ func (g *GrpcClient) RestoreRBAC(ctx context.Context, rbacMeta *milvuspb.RBACMet
 
 func (g *GrpcClient) ReplicateMessage(ctx context.Context, channelName string) (string, error) {
 	ctx = g.newCtx(ctx)
-	resp, err := g.srv.ReplicateMessage(ctx, &milvuspb.ReplicateMessageRequest{ChannelName: channelName})
+	resp, err := g.srv.ReplicateMessage(ctx, &milvuspb.ReplicateMessageRequest{ChannelName: channelName}) //nolint:staticcheck // SA1019: deprecated CDC API still needed
 	if err := checkResponse(resp, err); err != nil {
 		return "", fmt.Errorf("client: replicate message: %w", err)
 	}

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -113,7 +113,6 @@ func TestGrpcClient_newCtx(t *testing.T) {
 		assert.Equal(t, "identifier", md.Get(_identifierHeader)[0])
 		assert.Len(t, md.Get(_identifierHeader), 1)
 	})
-
 }
 
 func TestGrpcClient_newCtxWithDB(t *testing.T) {

--- a/internal/log/zap_text_core.go
+++ b/internal/log/zap_text_core.go
@@ -72,7 +72,7 @@ func (c *textIOCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	if ent.Level > zapcore.ErrorLevel {
 		// Since we may be crashing the program, sync the output. Ignore Sync
 		// errors, pending a clean solution to issue https://github.com/uber-go/zap/issues/370.
-		c.Sync()
+		_ = c.Sync()
 	}
 	return nil
 }

--- a/internal/log/zap_text_encoder.go
+++ b/internal/log/zap_text_encoder.go
@@ -452,10 +452,6 @@ func (enc *textEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (
 	return ret, nil
 }
 
-func (enc *textEncoder) truncate() {
-	enc.buf.Reset()
-}
-
 func (enc *textEncoder) closeOpenNamespaces() {
 	for i := 0; i < enc.openNamespaces; i++ {
 		enc.buf.AppendByte('}')

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -72,7 +72,6 @@ func levelToTree(l *levelBackupInfo) *backuppb.BackupInfo {
 	l.backupInfo.Size = lo.SumBy(collections, func(coll *backuppb.CollectionBackupInfo) int64 { return coll.GetSize() })
 	l.backupInfo.CollectionBackups = collections
 	return l.backupInfo
-
 }
 
 func readLevel[T any](ctx context.Context, backupDir string, cli storage.Client, metaType mpath.MetaType) (T, error) {
@@ -127,9 +126,8 @@ func Read(ctx context.Context, cli storage.Client, backupDir string) (*backuppb.
 
 	if exist {
 		return readFromFull(ctx, backupDir, cli)
-	} else {
-		return readFromLevel(ctx, backupDir, cli)
 	}
+	return readFromLevel(ctx, backupDir, cli)
 }
 
 func Exist(ctx context.Context, cli storage.Client, backupDir string) (bool, error) {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -25,7 +25,6 @@ import (
 // fn is the func to run.
 // Option can control the retry times and timeout.
 func Do(ctx context.Context, fn func() error, opts ...Option) error {
-
 	c := newDefaultConfig()
 
 	for _, opt := range opts {

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -401,7 +401,7 @@ func (flatIter *AzureObjectFlatIterator) Next() (ObjectAttr, error) {
 	}
 
 	attr := flatIter.currPage[flatIter.nextIdx]
-	flatIter.nextIdx += 1
+	flatIter.nextIdx++
 
 	return attr, nil
 }
@@ -465,7 +465,7 @@ func (hierIter *AzureObjectHierarchyIterator) Next() (ObjectAttr, error) {
 	}
 
 	attr := hierIter.currPage[hierIter.nextIdx]
-	hierIter.nextIdx += 1
+	hierIter.nextIdx++
 
 	return attr, nil
 }

--- a/internal/storage/gcp_native.go
+++ b/internal/storage/gcp_native.go
@@ -112,7 +112,6 @@ func (g *GcpNativeObjectIterator) Next() (ObjectAttr, error) {
 	g.hasNext = true
 
 	return ObjectAttr{Key: currObj.Name, Length: currObj.Size}, nil
-
 }
 
 func (gcm *GCPNativeClient) ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error) {
@@ -143,9 +142,8 @@ func (gcm *GCPNativeClient) BucketExist(ctx context.Context, _ string) (bool, er
 	if err != nil {
 		if errors.Is(err, storage.ErrBucketNotExist) {
 			return false, nil
-		} else {
-			return false, fmt.Errorf("storage: gcp native get bucket attrs %w", err)
 		}
+		return false, fmt.Errorf("storage: gcp native get bucket attrs %w", err)
 	}
 
 	return true, nil
@@ -177,13 +175,12 @@ func newGCPNativeClient(ctx context.Context, cfg Config) (*GCPNativeClient, erro
 	// Read the credentials file
 	jsonData, err := os.ReadFile(cfg.Credential.GCPCredJSON)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read credentials file:: %v", err)
+		return nil, fmt.Errorf("unable to read credentials file: %w", err)
 	}
 
 	creds, err := google.CredentialsFromJSON(ctx, jsonData, storage.ScopeReadWrite)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create credentials from JSON: %v", err)
-
+		return nil, fmt.Errorf("failed to create credentials from JSON: %w", err)
 	}
 	projectID, err := getProjectID(jsonData)
 	if err != nil {

--- a/internal/storage/hwc.go
+++ b/internal/storage/hwc.go
@@ -45,7 +45,7 @@ func (c *HwcCredentialProvider) Retrieve() (minioCred.Value, error) {
 }
 
 func (c *HwcCredentialProvider) IsExpired() bool {
-	now := time.Now().Add(time.Minute * 2) //prepare 2 minute get the new credential
+	now := time.Now().Add(time.Minute * 2) // prepare 2 minute get the new credential
 	expired := now.After(c.expireTime)
 	return expired
 }

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -189,7 +189,6 @@ func (m *MinioClient) multiPartCopy(ctx context.Context, srcCli *MinioClient, i 
 				m.logger.Error("abort multipart upload failed", zap.Error(err))
 			}
 		}
-
 	}()
 
 	completedParts := make([]minio.CompletePart, 0, len(parts))

--- a/internal/storage/mpath/path.go
+++ b/internal/storage/mpath/path.go
@@ -57,7 +57,8 @@ const (
 )
 
 func Join(base string, options ...Option) string {
-	elem := []string{base}
+	elem := make([]string, 0, 8)
+	elem = append(elem, base)
 
 	var o opt
 	for _, option := range options {
@@ -229,7 +230,7 @@ var (
 )
 
 func parseBinlogPath(reg *regexp.Regexp, p string) (binlogPath, []string, error) {
-	if strings.HasSuffix("/", p) {
+	if strings.HasSuffix(p, "/") {
 		return binlogPath{}, nil, fmt.Errorf("mpath: log path %s should not end with /", p)
 	}
 

--- a/internal/taskmgr/mgr.go
+++ b/internal/taskmgr/mgr.go
@@ -10,7 +10,7 @@ import (
 
 var ErrTaskNotFound = errors.New("task not found")
 
-var DefaultMgr = sync.OnceValue(func() *Mgr { return NewMgr() })
+var DefaultMgr = sync.OnceValue(NewMgr)
 
 func NewMgr() *Mgr {
 	return &Mgr{


### PR DESCRIPTION
## Summary
- Add golangci-lint (strict mode) to CI, running as a parallel job on every PR
- Fix all 54+ existing lint issues across the codebase
- Add `make lint` target for local usage

## Changes
- Add `.golangci.yml` with 20+ linters enabled (errcheck, govet, staticcheck, revive, gocritic, gocyclo, errorlint, misspell, prealloc, etc.)
- Add `lint` job to `.github/workflows/main.yaml` using `golangci/golangci-lint-action@v7`
- Add `make lint` target to `Makefile`
- Fix a real bug: `strings.HasSuffix` had swapped arguments in `internal/storage/mpath/path.go`
- Fix all lint issues: whitespace, indent-error-flow, increment-decrement, simplified bool returns, `%v` → `%w` for error wrapping, preallocated slices, removed unused function, fixed nolint directives, replaced deprecated `grpc.DialContext` with `grpc.NewClient`
- Add `nolint:staticcheck` annotations for intentional deprecated API usage (backward compatibility)

/kind improvement