### PR TITLE
storage: avoid listing all objects in BucketExist

### DIFF
--- a/internal/storage/funcs_test.go
+++ b/internal/storage/funcs_test.go
@@ -130,6 +130,33 @@ func TestExist(t *testing.T) {
 	})
 }
 
+func TestCreateBucketIfNotExist(t *testing.T) {
+	t.Run("BucketExists", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().BucketExist(mock.Anything, "").Return(true, nil)
+
+		err := CreateBucketIfNotExist(context.Background(), cli, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("BucketNotExistThenCreate", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().BucketExist(mock.Anything, "").Return(false, nil)
+		cli.EXPECT().CreateBucket(mock.Anything).Return(nil)
+
+		err := CreateBucketIfNotExist(context.Background(), cli, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("BucketExistError", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().BucketExist(mock.Anything, "").Return(false, assert.AnError)
+
+		err := CreateBucketIfNotExist(context.Background(), cli, "")
+		assert.Error(t, err)
+	})
+}
+
 func TestRead(t *testing.T) {
 	cli := NewMockClient(t)
 

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -321,20 +320,30 @@ func (m *MinioClient) ListPrefix(ctx context.Context, prefix string, recursive b
 	return newMinioObjectIterator(m, objCh)
 }
 
+// BucketExist checks if the bucket exists by listing a single object.
+// We use ListObjects instead of BucketExists (HEAD bucket) to minimize
+// required S3 permissions. MaxKeys=1 ensures only one object is fetched
+// to avoid iterating the entire bucket, which can timeout on large buckets.
 func (m *MinioClient) BucketExist(ctx context.Context, prefix string) (bool, error) {
-	bucketExists := true
-	var errs error
-	for obj := range m.cli.ListObjects(ctx, m.cfg.Bucket, minio.ListObjectsOptions{Prefix: prefix}) {
+	opts := minio.ListObjectsOptions{Prefix: prefix, MaxKeys: 1}
+	// MaxKeys=1 ensures at most one result, so the channel closes naturally.
+	// We must drain the channel to avoid goroutine leaks (see minio-go docs).
+	exists := true
+	var retErr error
+	for obj := range m.cli.ListObjects(ctx, m.cfg.Bucket, opts) {
 		if obj.Err != nil {
 			if minio.ToErrorResponse(obj.Err).Code == "NoSuchBucket" {
-				bucketExists = false
+				exists = false
 			} else {
-				errs = errors.Join(errs, fmt.Errorf("storage: %s list objects %w", m.cfg.Provider, obj.Err))
+				retErr = fmt.Errorf("storage: %s list objects %w", m.cfg.Provider, obj.Err)
 			}
 		}
 	}
 
-	return bucketExists, errs
+	if retErr != nil {
+		return false, retErr
+	}
+	return exists, nil
 }
 
 func (m *MinioClient) CreateBucket(ctx context.Context) error {


### PR DESCRIPTION
## Summary
`BucketExist` was iterating through every object in the bucket via `ListObjects` to check bucket existence, which caused unnecessary overhead on large buckets.

## Changes
- Set `MaxKeys=1` in `BucketExist` and return immediately after the first result, making the check O(1) regardless of bucket size
- Add unit tests for `CreateBucketIfNotExist`

Related to #954