### PR TITLE
ci: add codecov coverage check with 90% threshold

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,8 +45,13 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
           cache: true
-      - name: Unit test
-        run: make test
+      - name: Unit test with coverage
+        run: go test --race -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          fail_ci_if_error: true
 
   test-backup-restore-cross-version:
     needs: unit-test-go

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
## Summary
Add Codecov integration to the PR workflow to enforce unit test coverage.

## Changes
- Replace `make test` with `go test --race -coverprofile=coverage.out -covermode=atomic ./...` to generate coverage profile
- Add `codecov/codecov-action@v5` step to upload coverage to Codecov
- Add `codecov.yml` with 90% threshold for both project and patch coverage

/kind improvement