### PR TITLE
docs: add FAQ for binlog file count mismatch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,32 @@ crossStorage: "true"                         # Required for minio to S3 backups
 ```
 
 
+## FAQ
+
+### Backup fails with `field xxx has different file num to other fields`
+
+This error means the backup tool detected inconsistent binlog files in a segment — some fields have more files than others.
+
+**Why does this happen?**
+
+Starting from v0.5.4, milvus-backup first tries to fetch the accurate binlog list from Milvus via the RESTful API (`GetSegmentInfo`, available since Milvus 2.5.8). If this API call fails or is unavailable, the tool falls back to listing files directly from object storage. The fallback may pick up orphaned binlog files left by DataNode upload retries during transient network errors. These extra files cause a count mismatch between fields, and the backup fails with this error as a safety check.
+
+**How to fix it?**
+
+1. **Upgrade Milvus to >= 2.5.8 and milvus-backup to the latest version.** This enables the precise binlog list API, completely avoiding the problem.
+2. **If already on Milvus >= 2.5.8**, check the backup logs for:
+   ```
+   get segment info via proxy node failed, pls check whether milvus restful api is enabled
+   ```
+   This means the RESTful API is unreachable. Common causes:
+   - A Layer-7 load balancer that only forwards gRPC but not HTTP/1.1 traffic. You need to configure routing rules to support both protocols on the same port (e.g., route `/milvus.proto.milvus.MilvusService/` to gRPC backend, and `/` to HTTP backend).
+   - Network policies or firewalls blocking HTTP access to the Milvus proxy.
+3. **If you cannot upgrade Milvus**, wait for Milvus GC to clean up the orphaned binlogs (or trigger a manual compaction), then retry the backup.
+
+**Related issues:** [#913](https://github.com/zilliztech/milvus-backup/issues/913), [#635](https://github.com/zilliztech/milvus-backup/issues/635), [#476](https://github.com/zilliztech/milvus-backup/issues/476)
+
+---
+
 ## Development
 
 ### Build


### PR DESCRIPTION
## Summary
Add a FAQ entry to README explaining the `field xxx has different file num to other fields` error during backup — its root cause, how to fix it, and related issues.

## Changes
- Add FAQ section to README.md with troubleshooting guide for binlog count mismatch error

Part of #971

/kind improvement