### PR TITLE
ci: disable storage v3 (useLoonFFI) for master-latest CI tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -177,6 +177,7 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           if [ "${{ matrix.target_image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
+            yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
           cat custom_config.yaml || true
           mkdir -p volumes/etcd volumes/minio volumes/milvus
@@ -308,6 +309,7 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           if [ "${{ matrix.target_image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
+            yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
           cat custom_config.yaml || true
           sudo chmod -R 777 volumes
@@ -405,6 +407,7 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
+            yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
           cat custom_config.yaml || true
           mkdir -p volumes/etcd volumes/minio volumes/milvus
@@ -565,6 +568,10 @@ jobs:
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
           yq -i ".services.upstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           yq -i ".services.downstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
+            yq -i '.common.storage.useLoonFFI = false' upstream.yaml
+            yq -i '.common.storage.useLoonFFI = false' downstream.yaml
+          fi
           mkdir -p volumes/etcd volumes/minio volumes/upstream volumes/downstream volumes/upstream-runtime volumes/downstream-runtime
           sudo chmod -R 777 volumes
           sudo docker compose -f docker-compose.yml up -d --wait
@@ -743,6 +750,9 @@ jobs:
             helm repo update
             tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
             yq -i ".image.all.tag=\"${tag}\"" rbac-values.yaml
+            if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
+              yq -i '.extraConfigFiles."user.yaml" += "  storage:\n    useLoonFFI: false\n"' rbac-values.yaml
+            fi
             helm install --wait --debug --timeout 600s milvus-backup milvus/milvus -f rbac-values.yaml
             helm install --wait --debug --timeout 600s milvus-restore milvus/milvus -f rbac-values.yaml
             kubectl get pods
@@ -888,6 +898,7 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
+            yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
           cat custom_config.yaml || true
           mkdir -p volumes/etcd volumes/minio volumes/milvus

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -67,6 +67,7 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           if [ "${{ matrix.milvus_version }}" == "master" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
+            yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
           cat custom_config.yaml || true
           mkdir -p volumes/etcd volumes/minio volumes/milvus


### PR DESCRIPTION
## Summary
Disable Milvus Storage v3 (Loon FFI) in CI when testing against master-latest to unblock nightly and PR CI jobs.

## Changes
- Set `common.storage.useLoonFFI = false` in custom_config.yaml for all master-latest test jobs
- Applies to main.yaml (4 places) and nightly.yaml (1 place)

Milvus master enabled `useLoonFFI` by default in [milvus-io/milvus#47984](https://github.com/milvus-io/milvus/pull/47984) (2026-03-06), which changes the binlog path format to `_data/{index}_{uuid}.parquet`. milvus-backup does not yet support parsing this new path format.

Part of #974