### PR TITLE
ci: unify minio version to RELEASE.2024-05-28T17-19-04Z

### DIFF
--- a/deployment/cluster/docker-compose.yml
+++ b/deployment/cluster/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2022-03-17T06-34-49Z
+    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/deployment/standalone/docker-compose-rbac.yml
+++ b/deployment/standalone/docker-compose-rbac.yml
@@ -15,7 +15,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2022-03-17T06-34-49Z
+    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/deployment/standalone/docker-compose-tei.yml
+++ b/deployment/standalone/docker-compose-tei.yml
@@ -15,7 +15,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2022-03-17T06-34-49Z
+    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
@@ -40,6 +40,7 @@ services:
       MINIO_ADDRESS: minio:9000
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+      - ./custom_config.yaml:/milvus/configs/user.yaml
     ports:
       - "19530:19530"
       - "9091:9091"


### PR DESCRIPTION
## Summary
- Unify MinIO image version across all docker-compose files to `RELEASE.2024-05-28T17-19-04Z`

## Changes
- Update `deployment/cluster/docker-compose.yml` from `RELEASE.2022-03-17T06-34-49Z`
- Update `deployment/standalone/docker-compose-rbac.yml` from `RELEASE.2022-03-17T06-34-49Z`
- Update `deployment/standalone/docker-compose-tei.yml` from `RELEASE.2022-03-17T06-34-49Z`

/kind improvement