### PR TITLE
ci: exclude generated code and scripts from codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,10 @@ coverage:
     patch:
       default:
         target: 90%
+
+ignore:
+  - "**/*.py"
+  - "**/*.sh"
+  - "**/*.pb.go"
+  - "**/*_mock.go"
+  - "**/*_string.go"


### PR DESCRIPTION
## Summary
Exclude non-relevant files from Codecov coverage metrics to get more accurate Go code coverage.

## Changes
- Exclude Python files (`*.py`) and shell scripts (`*.sh`)
- Exclude auto-generated Go code: protobuf (`*.pb.go`), mocks (`*_mock.go`), and stringer (`*_string.go`)

/kind improvement