### PR TITLE
ci: lower codecov coverage threshold from 90% to 80%

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ $ make fmt
 
 ## Run unit test with code coverage
 
-Before submitting your Pull Request, make sure you have run unit test, and your code coverage rate is >= 90%.
+Before submitting your Pull Request, make sure you have run unit test, and your code coverage rate is >= 80%.
 
 ### Run golang unit tests
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,10 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 80%
     patch:
       default:
-        target: 90%
+        target: 80%
 
 ignore:
   - "**/*.py"


### PR DESCRIPTION
## Summary
Lower the Codecov coverage threshold from 90% to 80% for both project and patch targets, as 90% is unrealistic for code paths with uncoverable error branches.

## Changes
- `codecov.yml`: reduce project and patch target from 90% to 80%
- `CONTRIBUTING.md`: update documentation to reflect the new 80% threshold

/kind improvement