### PR TITLE
restore: warn instead of fail when bulk insert has no progress

### DIFF
--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -716,11 +716,13 @@ func (ct *collTask) checkBulkInsertViaGrpc(ctx context.Context, jobID int64) err
 			currentProgress := getProcess(state.Infos)
 			ct.taskMgr.UpdateRestoreTask(ct.taskID, taskmgr.UpdateRestoreImportJob(ct.targetNS, strconv.FormatInt(jobID, 10), currentProgress))
 			if currentProgress > lastProgress {
+				lastProgress = currentProgress
 				lastUpdateTime = time.Now()
 			} else if time.Since(lastUpdateTime) >= _bulkInsertTimeout {
-				ct.logger.Warn("bulk insert task timeout", zap.Int64("job_id", jobID),
+				ct.logger.Warn("bulk insert task no progress for too long, may milvus is not healthy",
+					zap.Int64("job_id", jobID),
 					zap.Duration("timeout", _bulkInsertTimeout))
-				return errors.New("restore_collection: bulk insert timeout")
+				lastUpdateTime = time.Now()
 			}
 			continue
 		}
@@ -794,11 +796,13 @@ func (ct *collTask) checkBulkInsertViaRestful(ctx context.Context, jobID string)
 			currentProgress := resp.Data.Progress
 			ct.taskMgr.UpdateRestoreTask(ct.taskID, taskmgr.UpdateRestoreImportJob(ct.targetNS, jobID, currentProgress))
 			if currentProgress > lastProgress {
+				lastProgress = currentProgress
 				lastUpdateTime = time.Now()
 			} else if time.Since(lastUpdateTime) >= _bulkInsertTimeout {
-				ct.logger.Warn("bulk insert task timeout", zap.String("job_id", jobID),
+				ct.logger.Warn("bulk insert task no progress for too long, may milvus is not healthy",
+					zap.String("job_id", jobID),
 					zap.Duration("timeout", _bulkInsertTimeout))
-				return errors.New("restore_collection: bulk insert timeout")
+				lastUpdateTime = time.Now()
 			}
 			continue
 		}

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -285,11 +285,13 @@ func (dmlt *collDMLTask) checkBulkInsertJob(ctx context.Context, jobID string) e
 		default:
 			currentProgress := resp.Data.Progress
 			if currentProgress > lastProgress {
+				lastProgress = currentProgress
 				lastUpdateTime = time.Now()
 			} else if time.Since(lastUpdateTime) >= _bulkInsertTimeout {
-				dmlt.logger.Warn("bulk insert task timeout", zap.String("job_id", jobID),
+				dmlt.logger.Warn("bulk insert task no progress for too long, may milvus is not healthy",
+					zap.String("job_id", jobID),
 					zap.Duration("timeout", _bulkInsertTimeout))
-				return errors.New("secondary: bulk insert timeout")
+				lastUpdateTime = time.Now()
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary
- When bulk insert has no progress for 60 minutes, log a warning and keep waiting instead of failing the restore task, consistent with flush behavior.

## Changes
- Remove `return errors.New(...)` on bulk insert timeout in `checkBulkInsertViaGrpc`, `checkBulkInsertViaRestful`, and `checkBulkInsertJob`
- Reset `lastUpdateTime` after warning so the warning repeats every 60 minutes instead of every 3 seconds
- Fix missing `lastProgress` update in progress tracking

/kind improvement