### PR TITLE
Support customizing Swagger BasePath for reverse proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Below is a summary of the configurations supported in `backup.yaml`:
 | `log`             | `level`                         | Logging level. Supported: `debug`, `info`, `warn`, `error`, `panic`, `fatal`.                                | `info`                  |
 |                   | `console`                       | Whether to print logs to the console.                                                                        | `true`                  |
 |                   | `file.rootPath`                 | Path to the log file.                                                                                        | `logs/backup.log`       |
-| `http`            | `simpleResponse`                | Whether to enable simple HTTP responses.                                                                     | `true`                  |
+| `http`            | `enabled`                       | Whether to enable the HTTP server.                                                                           | `true`                  |
+|                   | `debug_mode`                    | Whether to enable Gin debug mode.                                                                            | `false`                 |
+|                   | `swaggerBasePath`               | Override the Swagger UI base path. Useful when running behind a reverse proxy with a path prefix.            | (empty)                 |
 | `milvus`          | `address`                       | Milvus proxy address.                                                                                        | `localhost`             |
 |                   | `port`                          | Milvus proxy port.                                                                                           | `19530`                 |
 |                   | `user`                          | Username for Milvus.                                                                                         | `root`                  |

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
@@ -52,7 +51,7 @@ func (s *Server) initEngine() {
 
 	s.engine = engine
 
-	if bp := os.Getenv("SWAGGER_BASE_PATH"); bp != "" {
+	if bp := s.params.HTTP.SwaggerBasePath.Val; bp != "" {
 		docs.SwaggerInfo.BasePath = bp
 	}
 

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -104,19 +104,21 @@ func (c *LogConfig) Resolve(s *source) error {
 }
 
 type HTTPConfig struct {
-	Enabled   Value[bool]
-	DebugMode Value[bool]
+	Enabled         Value[bool]
+	DebugMode       Value[bool]
+	SwaggerBasePath Value[string]
 }
 
 func newHTTPConfig() HTTPConfig {
 	return HTTPConfig{
-		Enabled:   Value[bool]{Default: true, Keys: []string{"http.enabled"}},
-		DebugMode: Value[bool]{Default: false, Keys: []string{"http.debug_mode"}},
+		Enabled:         Value[bool]{Default: true, Keys: []string{"http.enabled"}},
+		DebugMode:       Value[bool]{Default: false, Keys: []string{"http.debug_mode"}},
+		SwaggerBasePath: Value[string]{Default: "", Keys: []string{"http.swaggerBasePath"}},
 	}
 }
 
 func (c *HTTPConfig) Resolve(s *source) error {
-	return resolve(s, &c.Enabled, &c.DebugMode)
+	return resolve(s, &c.Enabled, &c.DebugMode, &c.SwaggerBasePath)
 }
 
 type CloudConfig struct {


### PR DESCRIPTION
Closes: #970 

As discussed in the issue, if the backup is behind a reverse proxy  (e.g., `/{namespace}/backup/`), the swagger does not recognize the proxy path.

The proxy strips the prefix before forwarding to the backup server, so the server has no knowledge of its external path. Since `SwaggerInfo.BasePath` is hardcoded to `/api/v1`, Swagger UI constructs request URLs as `http://{host}/api/v1/restore` instead of `http://{host}/{namespace}/backup/api/v1/restore`.

A simple approach would be to read an env var to override base path at startup.