### PR TITLE
cfg: rename http.debug_mode to http.debugMode for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Below is a summary of the configurations supported in `backup.yaml`:
 |                   | `console`                       | Whether to print logs to the console.                                                                        | `true`                  |
 |                   | `file.rootPath`                 | Path to the log file.                                                                                        | `logs/backup.log`       |
 | `http`            | `enabled`                       | Whether to enable the HTTP server.                                                                           | `true`                  |
-|                   | `debug_mode`                    | Whether to enable Gin debug mode.                                                                            | `false`                 |
+|                   | `debugMode`                     | Whether to enable Gin debug mode.                                                                            | `false`                 |
 |                   | `swaggerBasePath`               | Override the Swagger UI base path. Useful when running behind a reverse proxy with a path prefix.            | (empty)                 |
 | `milvus`          | `address`                       | Milvus proxy address.                                                                                        | `localhost`             |
 |                   | `port`                          | Milvus proxy port.                                                                                           | `19530`                 |

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -112,7 +112,7 @@ type HTTPConfig struct {
 func newHTTPConfig() HTTPConfig {
 	return HTTPConfig{
 		Enabled:         Value[bool]{Default: true, Keys: []string{"http.enabled"}},
-		DebugMode:       Value[bool]{Default: false, Keys: []string{"http.debug_mode"}},
+		DebugMode:       Value[bool]{Default: false, Keys: []string{"http.debugMode"}},
 		SwaggerBasePath: Value[string]{Default: "", Keys: []string{"http.swaggerBasePath"}},
 	}
 }


### PR DESCRIPTION
## Summary
Rename `http.debug_mode` config key to `http.debugMode` to be consistent with all other config keys in the project (e.g. `minio.bucketName`, `milvus.tlsMode`, `http.swaggerBasePath`).

## Changes
- Rename config key `http.debug_mode` → `http.debugMode` in `cfg.go`
- Update README config table accordingly

/kind improvement