### PR TITLE
backup: strip segment info from collection and partition level meta

### DIFF
--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -196,9 +196,23 @@ func (builder *metaBuilder) buildCollectionMeta() ([]byte, error) {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
-	// TODO: don't know why we need segment info in collection meta. maybe just a bug.
-	// we should remove it in the future.
-	info := &backuppb.CollectionLevelBackupInfo{Infos: builder.data.GetCollectionBackups()}
+	// Shallow-copy each collection, keep partition metadata but strip all segment data.
+	// Segments are stored separately in segment_meta.json and full_meta.json.
+	stripped := make([]*backuppb.CollectionBackupInfo, 0, len(builder.data.GetCollectionBackups()))
+	for _, coll := range builder.data.GetCollectionBackups() {
+		c := *coll
+		c.L0Segments = nil
+		strippedParts := make([]*backuppb.PartitionBackupInfo, 0, len(coll.GetPartitionBackups()))
+		for _, part := range coll.GetPartitionBackups() {
+			p := *part
+			p.SegmentBackups = nil
+			strippedParts = append(strippedParts, &p)
+		}
+		c.PartitionBackups = strippedParts
+		stripped = append(stripped, &c)
+	}
+
+	info := &backuppb.CollectionLevelBackupInfo{Infos: stripped}
 	data, err := json.Marshal(info)
 	if err != nil {
 		return nil, fmt.Errorf("backup: build collection meta: %w", err)
@@ -211,10 +225,14 @@ func (builder *metaBuilder) buildPartitionMeta() ([]byte, error) {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
-	collections := builder.data.GetCollectionBackups()
-	partitions := make([]*backuppb.PartitionBackupInfo, 0, len(collections))
-	for _, collection := range collections {
-		partitions = append(partitions, collection.GetPartitionBackups()...)
+	// Shallow-copy each partition and strip nested segment data.
+	partitions := make([]*backuppb.PartitionBackupInfo, 0)
+	for _, coll := range builder.data.GetCollectionBackups() {
+		for _, part := range coll.GetPartitionBackups() {
+			p := *part
+			p.SegmentBackups = nil
+			partitions = append(partitions, &p)
+		}
 	}
 
 	info := &backuppb.PartitionLevelBackupInfo{Infos: partitions}

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -1,0 +1,174 @@
+package backup
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/namespace"
+)
+
+func newTestMetaBuilder() *metaBuilder {
+	builder := newMetaBuilder("task1", "backup1")
+
+	ns := namespace.New("db1", "coll1")
+	coll := &backuppb.CollectionBackupInfo{
+		CollectionId:   1,
+		DbName:         "db1",
+		CollectionName: "coll1",
+		PartitionBackups: []*backuppb.PartitionBackupInfo{
+			{PartitionId: 10, PartitionName: "part1", CollectionId: 1},
+			{PartitionId: 11, PartitionName: "part2", CollectionId: 1},
+		},
+	}
+	builder.addCollection(ns, coll)
+
+	segments := []*backuppb.SegmentBackupInfo{
+		{
+			SegmentId:    100,
+			CollectionId: 1,
+			PartitionId:  10,
+			NumOfRows:    1000,
+			Size:         4096,
+			Binlogs: []*backuppb.FieldBinlog{
+				{FieldID: 1, Binlogs: []*backuppb.Binlog{{LogId: 1001, LogPath: "data/1/10/100/1/1001"}}},
+			},
+		},
+		{
+			SegmentId:    101,
+			CollectionId: 1,
+			PartitionId:  11,
+			NumOfRows:    2000,
+			Size:         8192,
+			Binlogs: []*backuppb.FieldBinlog{
+				{FieldID: 1, Binlogs: []*backuppb.Binlog{{LogId: 1002, LogPath: "data/1/11/101/1/1002"}}},
+			},
+		},
+	}
+	l0Segments := []*backuppb.SegmentBackupInfo{
+		{
+			SegmentId:    200,
+			CollectionId: 1,
+			PartitionId:  _allPartitionID,
+			IsL0:         true,
+			NumOfRows:    500,
+			Size:         2048,
+			Deltalogs: []*backuppb.FieldBinlog{
+				{FieldID: 0, Binlogs: []*backuppb.Binlog{{LogId: 2001, LogPath: "delta/1/200/2001"}}},
+			},
+		},
+	}
+	builder.addSegments(append(segments, l0Segments...))
+
+	return builder
+}
+
+func TestBuildCollectionMetaStripsSegments(t *testing.T) {
+	builder := newTestMetaBuilder()
+
+	data, err := builder.buildCollectionMeta()
+	assert.NoError(t, err)
+
+	var result backuppb.CollectionLevelBackupInfo
+	assert.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Len(t, result.Infos, 1)
+	coll := result.Infos[0]
+	assert.Equal(t, int64(1), coll.GetCollectionId())
+	assert.Equal(t, "coll1", coll.GetCollectionName())
+	// Partitions are kept but without nested segments
+	assert.Len(t, coll.GetPartitionBackups(), 2)
+	for _, part := range coll.GetPartitionBackups() {
+		assert.Empty(t, part.GetSegmentBackups())
+	}
+	// L0 segments must be stripped
+	assert.Empty(t, coll.GetL0Segments())
+}
+
+func TestBuildPartitionMetaStripsSegments(t *testing.T) {
+	builder := newTestMetaBuilder()
+
+	data, err := builder.buildPartitionMeta()
+	assert.NoError(t, err)
+
+	var result backuppb.PartitionLevelBackupInfo
+	assert.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Len(t, result.Infos, 2)
+	for _, part := range result.Infos {
+		assert.Equal(t, int64(1), part.GetCollectionId())
+		// Must not contain nested segments
+		assert.Empty(t, part.GetSegmentBackups())
+	}
+}
+
+func TestBuildSegmentMetaContainsAllSegments(t *testing.T) {
+	builder := newTestMetaBuilder()
+
+	data, err := builder.buildSegmentMeta()
+	assert.NoError(t, err)
+
+	var result backuppb.SegmentLevelBackupInfo
+	assert.NoError(t, json.Unmarshal(data, &result))
+
+	// 2 regular segments (L0 segments are stored at collection level, not partition level)
+	assert.Len(t, result.Infos, 2)
+	ids := make([]int64, 0, len(result.Infos))
+	for _, seg := range result.Infos {
+		ids = append(ids, seg.GetSegmentId())
+		assert.NotEmpty(t, seg.GetBinlogs())
+	}
+	assert.ElementsMatch(t, []int64{100, 101}, ids)
+}
+
+func TestBuildFullMetaContainsEverything(t *testing.T) {
+	builder := newTestMetaBuilder()
+
+	data, err := builder.buildFullMeta()
+	assert.NoError(t, err)
+
+	var result backuppb.BackupInfo
+	assert.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Len(t, result.GetCollectionBackups(), 1)
+	coll := result.GetCollectionBackups()[0]
+	assert.Len(t, coll.GetPartitionBackups(), 2)
+	assert.Len(t, coll.GetL0Segments(), 1)
+	assert.Equal(t, int64(200), coll.GetL0Segments()[0].GetSegmentId())
+
+	var totalSegs int
+	for _, part := range coll.GetPartitionBackups() {
+		totalSegs += len(part.GetSegmentBackups())
+	}
+	assert.Equal(t, 2, totalSegs)
+}
+
+func TestSequentialBuildDoesNotCorruptData(t *testing.T) {
+	builder := newTestMetaBuilder()
+
+	// Simulate production call order: collection → partition → segment → full
+	_, err := builder.buildCollectionMeta()
+	assert.NoError(t, err)
+	_, err = builder.buildPartitionMeta()
+	assert.NoError(t, err)
+	_, err = builder.buildSegmentMeta()
+	assert.NoError(t, err)
+
+	data, err := builder.buildFullMeta()
+	assert.NoError(t, err)
+
+	var result backuppb.BackupInfo
+	assert.NoError(t, json.Unmarshal(data, &result))
+
+	coll := result.GetCollectionBackups()[0]
+	assert.Len(t, coll.GetPartitionBackups(), 2)
+	assert.Len(t, coll.GetL0Segments(), 1)
+
+	var totalSegs int
+	for _, part := range coll.GetPartitionBackups() {
+		totalSegs += len(part.GetSegmentBackups())
+	}
+	assert.Equal(t, 2, totalSegs)
+}


### PR DESCRIPTION
## Summary
- Strip nested segment data from `collection_meta.json` and `partition_meta.json` to reduce memory usage during backup metadata serialization
- This fixes OOM on large backups where segment binlog info was being serialized 3 extra times beyond `full_meta.json`

## Changes
- `buildCollectionMeta()`: manually construct collection objects without `PartitionBackups` and `L0Segments`, instead of directly serializing the full nested tree
- `buildPartitionMeta()`: manually construct partition objects without `SegmentBackups`
- Add unit tests verifying collection/partition meta are stripped while segment meta and full meta remain complete

## Background
The redundancy was introduced in aaadb04 (Support L0 segments, 2024-06) which changed collection cloning from manual field construction to `proto.Clone`, inadvertently carrying the full partition→segment subtree into `collection_meta.json`. This is backward-compatible because:
1. New backups always have `full_meta.json`, which the read path prefers
2. The level-file fallback `levelToTree()` rebuilds segments from `segment_meta.json` and overwrites whatever is in collection/partition meta
3. L0 segments (2024-06) post-date `full_meta.json` (2023-07), so any backup with L0 segments also has `full_meta.json`