### PR TITLE
milvus: increase create collection retry attempts to 20

### DIFF
--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -869,7 +869,7 @@ func (g *GrpcClient) CreateCollection(ctx context.Context, input CreateCollectio
 		g.limiters.createCollection.Success()
 
 		return nil
-	})
+	}, retry.Attempts(20))
 }
 
 func (g *GrpcClient) AlterCollection(ctx context.Context, db, collName string, properties []*commonpb.KeyValuePair) error {


### PR DESCRIPTION
## Summary
- Increase `CreateCollection` gRPC retry attempts from default 10 to 20 to improve reliability under rate limiting

## Changes
- Pass `retry.Attempts(20)` to `retry.Do` in `GrpcClient.CreateCollection`

/kind improvement