### PR TITLE
ci: add CI summary job to decouple mergify from CI matrix

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -26,29 +26,8 @@ pull_request_rules:
 
   - name: Test passed for code changed-main
     conditions:
-      - check-success=Unit test go
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.2.16, master-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.2.16, 2.6-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.3.22, master-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.3.22, 2.6-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.4.23, master-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.4.23, 2.6-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.5.20, master-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, v2.5.20, 2.6-latest)
-      - check-success=Backup and restore cross version (docker-compose, standalone, standalone, 2.6-latest, master-latest)
-      - check-success=Backup and restore after upgrade (docker-compose, standalone, standalone, 2.5-latest, master-latest)
-      - check-success=Backup and restore after upgrade (docker-compose, standalone, standalone, 2.5-latest, 2.6-latest)
-      - check-success=Backup and restore cli (docker-compose, standalone, standalone, master-latest)
-      - check-success=Backup and restore with rbac config (helm, standalone, master-latest)
-      - check-success=Backup and restore api (docker-compose, standalone, master-latest, L0)
-      - check-success=Backup and restore api (docker-compose, standalone, master-latest, L1)
-      - check-success=Backup and restore api (docker-compose, standalone, master-latest, L2)
-      - check-success=Backup and restore api (docker-compose, standalone, master-latest, MASTER)
-      - check-success=Backup and restore api (docker-compose, standalone, master-latest, RBAC)
-      - check-success=Backup and restore api (docker-compose, standalone, 2.6-latest, L0)
-      - check-success=Backup and restore api (docker-compose, standalone, 2.6-latest, L1)
-      - check-success=Backup and restore api (docker-compose, standalone, 2.6-latest, L2)
-      - check-success=Backup and restore api (docker-compose, standalone, 2.6-latest, RBAC)
+      - base=main
+      - check-success=CI summary
     actions:
       label:
         add:
@@ -126,35 +105,12 @@ pull_request_rules:
         remove:
           - do-not-merge/missing-related-issue
 
-  - name: Remove ci-passed label when status for code checker or ut  is not success-main
+  - name: Remove ci-passed label when CI fails
     conditions:
       - label!=manual-pass
       - base=main
       - files~=^(?=.*((\.(go|h|cpp)|CMakeLists.txt))).*$
-      - or:
-        - check-success!=Unit test go
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.2.16, master-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.2.16, 2.6-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.3.22, master-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.3.22, 2.6-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.4.23, master-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.4.23, 2.6-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.5.20, master-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, v2.5.20, 2.6-latest)
-        - check-success!=Backup and restore cross version (docker-compose, standalone, standalone, 2.6-latest, master-latest)
-        - check-success!=Backup and restore after upgrade (docker-compose, standalone, standalone, 2.5-latest, master-latest)
-        - check-success!=Backup and restore after upgrade (docker-compose, standalone, standalone, 2.5-latest, 2.6-latest)
-        - check-success!=Backup and restore cli (docker-compose, standalone, standalone, master-latest)
-        - check-success!=Backup and restore with rbac config (helm, standalone, master-latest)
-        - check-success!=Backup and restore api (docker-compose, standalone, master-latest, L0)
-        - check-success!=Backup and restore api (docker-compose, standalone, master-latest, L1)
-        - check-success!=Backup and restore api (docker-compose, standalone, master-latest, L2)
-        - check-success!=Backup and restore api (docker-compose, standalone, master-latest, MASTER)
-        - check-success!=Backup and restore api (docker-compose, standalone, master-latest, RBAC)
-        - check-success!=Backup and restore api (docker-compose, standalone, 2.6-latest, L0)
-        - check-success!=Backup and restore api (docker-compose, standalone, 2.6-latest, L1)
-        - check-success!=Backup and restore api (docker-compose, standalone, 2.6-latest, L2)
-        - check-success!=Backup and restore api (docker-compose, standalone, 2.6-latest, RBAC)
+      - check-success!=CI summary
     actions:
       label:
         remove:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -957,3 +957,27 @@ jobs:
           path: |
             /tmp/ci_logs
             deployment/${{ matrix.milvus_mode }}/logs
+
+  ci-summary:
+    name: CI summary
+    if: always()
+    needs:
+      - lint
+      - unit-test-go
+      - test-backup-restore-cross-version
+      - test-backup-restore-after-upgrade
+      - test-backup-restore-cli
+      - test-backup-restore-secondary
+      - test-backup-restore-with-rbac-config
+      - test-backup-restore-api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          results=( ${{ join(needs.*.result, ' ') }} )
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "Job failed with status: $r"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
- Add a `ci-summary` job in the CI workflow that aggregates results from all test jobs
- Simplify mergify.yml to check only `CI summary` instead of listing 20+ individual matrix check names

## Changes
- `.github/workflows/main.yaml`: add `ci-summary` job that depends on all test jobs and fails if any dependency failed
- `.github/mergify.yml`: replace hardcoded check name lists with single `check-success=CI summary` condition, reducing 48 lines to 2

This eliminates the need to update mergify.yml every time the CI matrix versions change.

/kind improvement