### PR TITLE
restore: parallelize secondary restore collection tasks

### DIFF
--- a/core/restore/secondary/coll_ddl_task.go
+++ b/core/restore/secondary/coll_ddl_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -28,6 +29,7 @@ type collDDLTask struct {
 	collBackup *backuppb.CollectionBackupInfo
 
 	tsAlloc *tsAlloc
+	sendMu  *sync.Mutex
 
 	streamCli milvus.Stream
 	logger    *zap.Logger
@@ -40,6 +42,7 @@ type ddlTaskArgs struct {
 
 	StreamCli milvus.Stream
 	TSAlloc   *tsAlloc
+	SendMu    *sync.Mutex
 }
 
 func newCollDDLTask(args ddlTaskArgs, dbBackup *backuppb.DatabaseBackupInfo, collBackup *backuppb.CollectionBackupInfo) *collDDLTask {
@@ -53,6 +56,7 @@ func newCollDDLTask(args ddlTaskArgs, dbBackup *backuppb.DatabaseBackupInfo, col
 		collBackup: collBackup,
 
 		tsAlloc: args.TSAlloc,
+		sendMu:  args.SendMu,
 
 		streamCli: args.StreamCli,
 		logger:    log.With(zap.String("task_id", args.TaskID), zap.String("ns", ns.String())),
@@ -114,6 +118,9 @@ func (ddlt *collDDLTask) createIndex(ctx context.Context, index *backuppb.IndexI
 	broadcast := builder.MustBuildBroadcast().WithBroadcastID(rand.Uint64())
 	msgs := broadcast.SplitIntoMutableMessage()
 
+	ddlt.sendMu.Lock()
+	defer ddlt.sendMu.Unlock()
+
 	for _, msg := range msgs {
 		ts := ddlt.tsAlloc.Alloc()
 		immutableMessage := msg.WithTimeTick(ts).
@@ -162,6 +169,9 @@ func (ddlt *collDDLTask) createColl(ctx context.Context) error {
 	appendDynamicField(schema)
 
 	ddlt.logger.Info("collection schema", zap.Any("schema", schema))
+
+	ddlt.sendMu.Lock()
+	defer ddlt.sendMu.Unlock()
 
 	req := &message.CreateCollectionRequest{
 		Base: &commonpb.MsgBase{

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -80,6 +81,7 @@ type dmlTaskArgs struct {
 	TaskID string
 
 	TSAlloc *tsAlloc
+	SendMu  *sync.Mutex
 
 	PchTS map[string]uint64
 
@@ -94,6 +96,7 @@ type collDMLTask struct {
 	taskID string
 
 	tsAlloc *tsAlloc
+	sendMu  *sync.Mutex
 
 	backupStorage storage.Client
 	backupDir     string
@@ -114,6 +117,7 @@ func newCollDMLTask(args dmlTaskArgs, collBackup *backuppb.CollectionBackupInfo)
 		taskID: args.TaskID,
 
 		tsAlloc: args.TSAlloc,
+		sendMu:  args.SendMu,
 
 		pchTS:      args.PchTS,
 		collBackup: collBackup,
@@ -400,6 +404,9 @@ func (dmlt *collDMLTask) sendImportMsg(ctx context.Context, partitionID int64, b
 	}
 	appendSysFields(schema)
 	appendDynamicField(schema)
+
+	dmlt.sendMu.Lock()
+	defer dmlt.sendMu.Unlock()
 
 	ts := dmlt.tsAlloc.Alloc()
 	header := &message.ImportMessageHeader{}

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -2,6 +2,7 @@ package secondary
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
@@ -123,6 +125,7 @@ func newTestDMLTask(t *testing.T, collBackup *backuppb.CollectionBackupInfo, str
 
 	return &collDMLTask{
 		tsAlloc:       newTTAlloc(),
+		sendMu:        &sync.Mutex{},
 		pchTS:         newTestPchTS(vchannels),
 		collBackup:    collBackup,
 		backupStorage: storageMock,
@@ -228,6 +231,91 @@ func TestExecute_EmptyPartitions(t *testing.T) {
 	err := task.Execute(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, stream.msgs, "no messages should be sent for empty partitions")
+}
+
+// TestConcurrentCollections_TimestampOrderingPerPch verifies that when multiple
+// collections are restored concurrently and share the same physical channels,
+// the sendMu ensures per-pch timestamps remain strictly increasing.
+func TestConcurrentCollections_TimestampOrderingPerPch(t *testing.T) {
+	// Shared resources — simulating what Task provides to all collection tasks.
+	tsAlloc := newTTAlloc()
+	sendMu := &sync.Mutex{}
+	stream := &recordingStream{}
+
+	storageMock := storage.NewMockClient(t)
+	storageMock.EXPECT().
+		ListPrefix(mock.Anything, mock.Anything, false).
+		Return(storage.NewMockObjectIterator(nil), nil).
+		Maybe()
+
+	// Create 4 collections with different vchannels mapping to the same 2 pchs.
+	numColls := 4
+	tasks := make([]*collDMLTask, numColls)
+	for i := range numColls {
+		collID := int64(100 + i)
+		vchannels := []string{
+			fmt.Sprintf("rootcoord-dml_0_%dv0", collID),
+			fmt.Sprintf("rootcoord-dml_1_%dv0", collID),
+		}
+
+		partitions := []*backuppb.PartitionBackupInfo{
+			{
+				PartitionId:   collID*10 + 1,
+				PartitionName: fmt.Sprintf("part_%d_1", collID),
+				SegmentBackups: []*backuppb.SegmentBackupInfo{
+					{PartitionId: collID*10 + 1, VChannel: vchannels[0], GroupId: collID*100 + 1, Size: 100, StorageVersion: 2},
+					{PartitionId: collID*10 + 1, VChannel: vchannels[1], GroupId: collID*100 + 2, Size: 100, StorageVersion: 2},
+					{PartitionId: collID*10 + 1, VChannel: vchannels[0], GroupId: collID*100 + 3, Size: 100, IsL0: true, StorageVersion: 2},
+				},
+			},
+			{
+				PartitionId:   collID*10 + 2,
+				PartitionName: fmt.Sprintf("part_%d_2", collID),
+				SegmentBackups: []*backuppb.SegmentBackupInfo{
+					{PartitionId: collID*10 + 2, VChannel: vchannels[0], GroupId: collID*100 + 4, Size: 100, StorageVersion: 2},
+					{PartitionId: collID*10 + 2, VChannel: vchannels[1], GroupId: collID*100 + 5, Size: 100, StorageVersion: 2},
+				},
+			},
+		}
+
+		collBackup := &backuppb.CollectionBackupInfo{
+			CollectionId:        collID,
+			DbName:              "default",
+			CollectionName:      fmt.Sprintf("coll_%d", collID),
+			Schema:              newTestSchema(),
+			VirtualChannelNames: vchannels,
+			PartitionBackups:    partitions,
+		}
+
+		tasks[i] = &collDMLTask{
+			tsAlloc:       tsAlloc,
+			sendMu:        sendMu,
+			pchTS:         newTestPchTS(vchannels),
+			collBackup:    collBackup,
+			backupStorage: storageMock,
+			backupDir:     "/backup",
+			streamCli:     stream,
+			restfulCli:    &completedRestful{},
+			logger:        zap.NewNop(),
+		}
+	}
+
+	// Run all collection DML tasks concurrently.
+	g, ctx := errgroup.WithContext(context.Background())
+	for _, task := range tasks {
+		g.Go(func() error {
+			return task.Execute(ctx)
+		})
+	}
+	assert.NoError(t, g.Wait())
+
+	// Verify: per physical channel, timestamps must be strictly increasing.
+	for pch, tss := range stream.timestampsByPch() {
+		for i := 1; i < len(tss); i++ {
+			assert.Greater(t, tss[i], tss[i-1],
+				"timestamps on pch %s should be strictly increasing, got %v", pch, tss)
+		}
+	}
 }
 
 func TestSendBatches(t *testing.T) {

--- a/core/restore/secondary/coll_load_task.go
+++ b/core/restore/secondary/coll_load_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"sort"
+	"sync"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -25,6 +26,7 @@ type loadTaskArgs struct {
 
 	StreamCli milvus.Stream
 	TSAlloc   *tsAlloc
+	SendMu    *sync.Mutex
 }
 
 type collLoadTask struct {
@@ -35,6 +37,7 @@ type collLoadTask struct {
 	collBackup *backuppb.CollectionBackupInfo
 
 	tsAlloc *tsAlloc
+	sendMu  *sync.Mutex
 
 	streamCli milvus.Stream
 	logger    *zap.Logger
@@ -51,6 +54,7 @@ func newCollLoadTask(args loadTaskArgs, dbBackup *backuppb.DatabaseBackupInfo, c
 		collBackup: collBackup,
 
 		tsAlloc: args.TSAlloc,
+		sendMu:  args.SendMu,
 
 		streamCli: args.StreamCli,
 		logger:    log.With(zap.String("task_id", args.TaskID), zap.String("ns", ns.String())),
@@ -74,6 +78,10 @@ func (clt *collLoadTask) Execute(ctx context.Context) error {
 
 	broadcast := builder.MustBuildBroadcast().WithBroadcastID(rand.Uint64())
 	msgs := broadcast.SplitIntoMutableMessage()
+
+	clt.sendMu.Lock()
+	defer clt.sendMu.Unlock()
+
 	for _, msg := range msgs {
 		ts := clt.tsAlloc.Alloc()
 		immutableMessage := msg.WithTimeTick(ts).

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -5,11 +5,13 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand/v2"
+	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/core/restore/conv"
@@ -46,6 +48,7 @@ type Task struct {
 	restful milvus.Restful
 
 	tsAlloc *tsAlloc
+	sendMu  sync.Mutex
 
 	streamCli milvus.Stream
 
@@ -182,6 +185,7 @@ func (t *Task) dmlTaskArgs() (dmlTaskArgs, error) {
 		TaskID: t.args.TaskID,
 
 		TSAlloc: t.tsAlloc,
+		SendMu:  &t.sendMu,
 
 		PchTS: pchTS,
 
@@ -199,6 +203,7 @@ func (t *Task) ddlTaskArgs() ddlTaskArgs {
 		BackupInfo: t.args.Backup,
 		StreamCli:  t.streamCli,
 		TSAlloc:    t.tsAlloc,
+		SendMu:     &t.sendMu,
 	}
 }
 
@@ -236,6 +241,7 @@ func (t *Task) loadTaskArgs() loadTaskArgs {
 		BackupInfo: t.args.Backup,
 		StreamCli:  t.streamCli,
 		TSAlloc:    t.tsAlloc,
+		SendMu:     &t.sendMu,
 	}
 }
 
@@ -251,13 +257,16 @@ func (t *Task) runCollTasks(ctx context.Context) error {
 	}
 	ddlArgs := t.ddlTaskArgs()
 	loadArgs := t.loadTaskArgs()
+
+	g, subCtx := errgroup.WithContext(ctx)
+	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
 	for _, coll := range t.args.Backup.GetCollectionBackups() {
-		if err := t.runCollTask(ctx, dbNameBackup[coll.GetDbName()], coll, ddlArgs, dmlArgs, loadArgs); err != nil {
-			return fmt.Errorf("secondary: run collection task: %w", err)
-		}
+		g.Go(func() error {
+			return t.runCollTask(subCtx, dbNameBackup[coll.GetDbName()], coll, ddlArgs, dmlArgs, loadArgs)
+		})
 	}
 
-	return nil
+	return g.Wait()
 }
 
 func (t *Task) sendRBACMsg(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- Parallelize collection-level restore in secondary restore, using `errgroup.SetLimit` with the existing `RestoreCollection` parallelism config (default 2)
- Add `sendMu` to protect ts allocation + stream send ordering, preventing timetick regression on shared physical channels

## Changes
- `task.go`: add `sendMu`, pass it to sub-tasks, convert `runCollTasks` from sequential to concurrent with `errgroup`
- `coll_ddl_task.go`: lock `sendMu` around ts alloc + send in `createColl` and `createIndex`
- `coll_dml_task.go`: lock `sendMu` around ts alloc + send in `sendImportMsg`
- `coll_load_task.go`: lock `sendMu` around ts alloc + send in `Execute`
- `coll_dml_task_test.go`: initialize `sendMu` in test helper

/kind improvement