### PR TITLE
storage: add retry to remote copier copy and verify

### DIFF
--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -60,16 +60,12 @@ type remoteCopier struct {
 func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	rp.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
 
-	return retry.Do(ctx, func() error {
+	start := time.Now()
+	err := retry.Do(ctx, func() error {
 		i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
-		start := time.Now()
 		if err := rp.dest.CopyObject(ctx, i); err != nil {
 			return fmt.Errorf("storage: remote copier copy object %w", err)
-		}
-		if rp.opt.traceFn != nil {
-			cost := time.Since(start)
-			rp.opt.traceFn(copyAttr.Src.Length, cost)
 		}
 
 		attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
@@ -82,6 +78,12 @@ func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 
 		return nil
 	})
+
+	if err == nil && rp.opt.traceFn != nil {
+		rp.opt.traceFn(copyAttr.Src.Length, time.Since(start))
+	}
+
+	return err
 }
 
 // serverCopier copy data from src to dest by backup server

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -59,26 +59,29 @@ type remoteCopier struct {
 
 func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	rp.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
-	i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
-	start := time.Now()
-	if err := rp.dest.CopyObject(ctx, i); err != nil {
-		return fmt.Errorf("storage: remote copier copy object %w", err)
-	}
-	if rp.opt.traceFn != nil {
-		cost := time.Since(start)
-		rp.opt.traceFn(copyAttr.Src.Length, cost)
-	}
+	return retry.Do(ctx, func() error {
+		i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
-	attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
-	if err != nil {
-		return fmt.Errorf("storage: remote copier verify copy: %w", err)
-	}
-	if attr.Length != copyAttr.Src.Length {
-		return fmt.Errorf("storage: remote copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
-	}
+		start := time.Now()
+		if err := rp.dest.CopyObject(ctx, i); err != nil {
+			return fmt.Errorf("storage: remote copier copy object %w", err)
+		}
+		if rp.opt.traceFn != nil {
+			cost := time.Since(start)
+			rp.opt.traceFn(copyAttr.Src.Length, cost)
+		}
 
-	return nil
+		attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
+		if err != nil {
+			return fmt.Errorf("storage: remote copier verify copy: %w", err)
+		}
+		if attr.Length != copyAttr.Src.Length {
+			return fmt.Errorf("storage: remote copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
+		}
+
+		return nil
+	})
 }
 
 // serverCopier copy data from src to dest by backup server

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -52,6 +52,83 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("CopyObjectError", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(ctx, attr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "copy object")
+	})
+
+	t.Run("RetryThenSuccess", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(context.Background(), attr)
+		assert.NoError(t, err)
+	})
+
+	t.Run("SuccessWithTraceFn", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+
+		var traced bool
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+			traceFn: func(size int64, cost time.Duration) {
+				traced = true
+				assert.Equal(t, int64(5), size)
+			},
+		}}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
+		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(context.Background(), attr)
+		assert.NoError(t, err)
+		assert.True(t, traced)
+	})
+
+	t.Run("ErrorNoTraceFn", func(t *testing.T) {
+		dest := NewMockClient(t)
+		src := NewMockClient(t)
+
+		var traced bool
+		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+			traceFn: func(size int64, cost time.Duration) {
+				traced = true
+			},
+		}}
+
+		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
+		err := rp.copy(ctx, attr)
+		assert.Error(t, err)
+		assert.False(t, traced)
+	})
+
 	t.Run("HeadObjectError", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -61,8 +61,11 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
 		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{}, assert.AnError).Once()
 
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := rp.copy(context.Background(), attr)
+		err := rp.copy(ctx, attr)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "verify copy")
 	})
@@ -76,8 +79,11 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
 		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 3}, nil).Once()
 
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := rp.copy(context.Background(), attr)
+		err := rp.copy(ctx, attr)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size mismatch")
 	})


### PR DESCRIPTION
## Summary
- Add `retry.Do` wrapper to `remoteCopier.copy()` for transient error resilience

## Changes
- Wrap `CopyObject` + `HeadObject` verification in `remoteCopier.copy()` with `retry.Do`, consistent with `serverCopier`
- Update error-case tests to use cancelled context to prevent retry loops

/kind improvement