### PR TITLE
backup: fix nil pointer panic in metaBuilder for unknown collection ID

### DIFF
--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -356,7 +356,9 @@ func (dmlt *collDMLTask) Execute(ctx context.Context) error {
 		return fmt.Errorf("backup: get segments %w", err)
 	}
 
-	dmlt.metaBuilder.addSegments(segments)
+	if err := dmlt.metaBuilder.addSegments(segments); err != nil {
+		return fmt.Errorf("backup: add segments meta: %w", err)
+	}
 
 	size := lo.SumBy(segments, func(seg *backuppb.SegmentBackupInfo) int64 { return seg.GetSize() })
 	dmlt.taskMgr.UpdateBackupTask(dmlt.taskID, taskmgr.SetBackupCollDMLExecuting(dmlt.ns, size))

--- a/core/backup/coll_strategy.go
+++ b/core/backup/coll_strategy.go
@@ -216,7 +216,9 @@ func (sf *serialFlushStrategy) flushAndBackupPOS(ctx context.Context, ns namespa
 		maxChannelTS = max(maxChannelTS, checkpoint.GetTimestamp())
 	}
 
-	sf.args.MetaBuilder.addPOS(ns, channelCP, maxChannelTS, uint64(resp.GetCollSealTimes()[ns.CollName()]))
+	if err := sf.args.MetaBuilder.addPOS(ns, channelCP, maxChannelTS, uint64(resp.GetCollSealTimes()[ns.CollName()])); err != nil {
+		return fmt.Errorf("backup: add POS meta: %w", err)
+	}
 	return nil
 }
 

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -78,26 +78,35 @@ func (builder *metaBuilder) addCollection(ns namespace.NS, collectionBackup *bac
 	}
 }
 
-func (builder *metaBuilder) addPOS(ns namespace.NS, channelCP map[string]string, maxChannelTS uint64, sealTime uint64) {
+func (builder *metaBuilder) addPOS(ns namespace.NS, channelCP map[string]string, maxChannelTS uint64, sealTime uint64) error {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
 	collID := builder.nsToCollID[ns]
-	collBackup := builder.collectionBackups[collID]
+	collBackup, ok := builder.collectionBackups[collID]
+	if !ok {
+		return fmt.Errorf("backup: collection backup not found for namespace %s, collection_id: %d", ns, collID)
+	}
 
 	collBackup.ChannelCheckpoints = channelCP
 	collBackup.BackupTimestamp = maxChannelTS
 	collBackup.BackupPhysicalTimestamp = sealTime
+
+	return nil
 }
 
-func (builder *metaBuilder) addSegments(segments []*backuppb.SegmentBackupInfo) {
+func (builder *metaBuilder) addSegments(segments []*backuppb.SegmentBackupInfo) error {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
 	for _, segment := range segments {
-		builder.data.Size += segment.GetSize()
+		collBackup, ok := builder.collectionBackups[segment.GetCollectionId()]
+		if !ok {
+			return fmt.Errorf("backup: collection backup not found for segment %d, collection_id: %d",
+				segment.GetSegmentId(), segment.GetCollectionId())
+		}
 
-		collBackup := builder.collectionBackups[segment.GetCollectionId()]
+		builder.data.Size += segment.GetSize()
 		collBackup.Size += segment.GetSize()
 
 		if segment.GetIsL0() && segment.GetPartitionId() == _allPartitionID {
@@ -117,6 +126,8 @@ func (builder *metaBuilder) addSegments(segments []*backuppb.SegmentBackupInfo) 
 			partBackup.Size += segment.GetSize()
 		}
 	}
+
+	return nil
 }
 
 func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) {

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 )
 
-func newTestMetaBuilder() *metaBuilder {
+func newTestMetaBuilder(t *testing.T) *metaBuilder {
 	builder := newMetaBuilder("task1", "backup1")
 
 	ns := namespace.New("db1", "coll1")
@@ -60,13 +60,44 @@ func newTestMetaBuilder() *metaBuilder {
 			},
 		},
 	}
-	builder.addSegments(append(segments, l0Segments...))
+	assert.NoError(t, builder.addSegments(append(segments, l0Segments...)))
 
 	return builder
 }
 
+func TestAddSegments(t *testing.T) {
+	t.Run("UnknownCollectionID", func(t *testing.T) {
+		builder := newMetaBuilder("task1", "backup1")
+
+		segments := []*backuppb.SegmentBackupInfo{
+			{
+				SegmentId:    100,
+				CollectionId: 999,
+				PartitionId:  10,
+				Size:         4096,
+			},
+		}
+
+		err := builder.addSegments(segments)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "backup: collection backup not found")
+		assert.Contains(t, err.Error(), "999")
+	})
+}
+
+func TestAddPOS(t *testing.T) {
+	t.Run("UnknownNamespace", func(t *testing.T) {
+		builder := newMetaBuilder("task1", "backup1")
+
+		ns := namespace.New("db_unknown", "coll_unknown")
+		err := builder.addPOS(ns, map[string]string{"ch1": "cp1"}, 100, 200)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "backup: collection backup not found")
+	})
+}
+
 func TestBuildCollectionMetaStripsSegments(t *testing.T) {
-	builder := newTestMetaBuilder()
+	builder := newTestMetaBuilder(t)
 
 	data, err := builder.buildCollectionMeta()
 	assert.NoError(t, err)
@@ -88,7 +119,7 @@ func TestBuildCollectionMetaStripsSegments(t *testing.T) {
 }
 
 func TestBuildPartitionMetaStripsSegments(t *testing.T) {
-	builder := newTestMetaBuilder()
+	builder := newTestMetaBuilder(t)
 
 	data, err := builder.buildPartitionMeta()
 	assert.NoError(t, err)
@@ -105,7 +136,7 @@ func TestBuildPartitionMetaStripsSegments(t *testing.T) {
 }
 
 func TestBuildSegmentMetaContainsAllSegments(t *testing.T) {
-	builder := newTestMetaBuilder()
+	builder := newTestMetaBuilder(t)
 
 	data, err := builder.buildSegmentMeta()
 	assert.NoError(t, err)
@@ -124,7 +155,7 @@ func TestBuildSegmentMetaContainsAllSegments(t *testing.T) {
 }
 
 func TestBuildFullMetaContainsEverything(t *testing.T) {
-	builder := newTestMetaBuilder()
+	builder := newTestMetaBuilder(t)
 
 	data, err := builder.buildFullMeta()
 	assert.NoError(t, err)
@@ -146,7 +177,7 @@ func TestBuildFullMetaContainsEverything(t *testing.T) {
 }
 
 func TestSequentialBuildDoesNotCorruptData(t *testing.T) {
-	builder := newTestMetaBuilder()
+	builder := newTestMetaBuilder(t)
 
 	// Simulate production call order: collection → partition → segment → full
 	_, err := builder.buildCollectionMeta()


### PR DESCRIPTION
## Summary
Fix nil pointer dereference panic in `metaBuilder.addSegments` and `addPOS` when `collectionBackups` map has no entry for a segment's collection ID.

## Changes
- Add comma-ok guard in `addSegments` and `addPOS` to return a clear error instead of panicking on nil map lookup
- Propagate errors to callers in `collDMLTask.Execute` and `serialFlushStrategy.flushAndBackupPOS`
- Add unit tests for unknown collection ID / namespace scenarios

Fixes #1007

/kind bug