### PR TITLE
ci: revert milvus master image pin, use master-latest

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,9 +14,6 @@ on:
 
 env:
   go-version: 1.25
-  # Pinned to last working master image before milvus-io/milvus#48477 (PR #48005 broke insert_log path).
-  # Revert to master-latest once the issue is fixed.
-  MILVUS_MASTER_IMAGE_TAG: master-20260322-aed7c8bc
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -68,7 +65,7 @@ jobs:
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
         source_image_tag: [v2.2.16, v2.3.22, v2.4.23, v2.5.20, 2.6-latest]
-        target_image_tag: [master-20260322-aed7c8bc, 2.6-latest]
+        target_image_tag: [master-latest, 2.6-latest]
         exclude:
           - source_image_tag: 2.6-latest
             target_image_tag: 2.6-latest
@@ -195,7 +192,7 @@ jobs:
         run: |
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.target_image_tag }}) && echo $tag
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.target_image_tag }}" == "master-20260322-aed7c8bc" ]; then
+          if [ "${{ matrix.target_image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
             yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
@@ -254,7 +251,7 @@ jobs:
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
         source_image_tag: [2.5-latest, 2.5-latest]
-        target_image_tag: [master-20260322-aed7c8bc, 2.6-latest]
+        target_image_tag: [master-latest, 2.6-latest]
         exclude:
           - source_image_tag: 2.6-latest
             target_image_tag: 2.6-latest
@@ -327,7 +324,7 @@ jobs:
           sudo docker compose -f docker-compose.yml down
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.target_image_tag }}) && echo $tag
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.target_image_tag }}" == "master-20260322-aed7c8bc" ]; then
+          if [ "${{ matrix.target_image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
             yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
@@ -401,7 +398,7 @@ jobs:
         deploy_tools: [docker-compose]
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
-        image_tag: [master-20260322-aed7c8bc]
+        image_tag: [master-latest]
         # mq_type: [pulsar, kafka]  # TODO: add pulsar and kafka
 
     steps:
@@ -441,7 +438,7 @@ jobs:
         run: |
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.image_tag }}" == "master-20260322-aed7c8bc" ]; then
+          if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
             yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi
@@ -580,7 +577,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_tag: [master-20260322-aed7c8bc]
+        image_tag: [master-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -620,7 +617,7 @@ jobs:
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
           yq -i ".services.upstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           yq -i ".services.downstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.image_tag }}" == "master-20260322-aed7c8bc" ]; then
+          if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.useLoonFFI = false' upstream.yaml
             yq -i '.common.storage.useLoonFFI = false' downstream.yaml
           fi
@@ -766,7 +763,7 @@ jobs:
       matrix:
         deploy_tools: [helm]
         milvus_mode: [standalone]
-        image_tag: [master-20260322-aed7c8bc]
+        image_tag: [master-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -818,7 +815,7 @@ jobs:
             helm repo update
             tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
             yq -i ".image.all.tag=\"${tag}\"" rbac-values.yaml
-            if [ "${{ matrix.image_tag }}" == "master-20260322-aed7c8bc" ]; then
+            if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
               yq -i '.extraConfigFiles."user.yaml" += "  storage:\n    useLoonFFI: false\n"' rbac-values.yaml
             fi
             helm install --wait --debug --timeout 600s milvus-backup milvus/milvus -f rbac-values.yaml
@@ -929,7 +926,7 @@ jobs:
       matrix:
         deploy_tools: [docker-compose]
         milvus_mode: [standalone]
-        image_tag: [master-20260322-aed7c8bc, 2.6-latest]
+        image_tag: [master-latest, 2.6-latest]
         case_tag: [L0, L1, L2, MASTER, RELEASE, RBAC]
         exclude:
           - image_tag: 2.6-latest
@@ -981,7 +978,7 @@ jobs:
           fi
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.image_tag }}" == "master-20260322-aed7c8bc" ]; then
+          if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.enablev2 = true' custom_config.yaml
             yq -i '.common.storage.useLoonFFI = false' custom_config.yaml
           fi


### PR DESCRIPTION
## Summary
- Revert the pinning of milvus master image (`master-20260322-aed7c8bc` → `master-latest`)
- The upstream issue milvus-io/milvus#48477 should be fixed, this PR verifies by running CI against `master-latest`

/kind improvement