### PR TITLE
ci: add etcd schema verification for secondary restore

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -601,6 +601,7 @@ jobs:
           go get
           go build
           go build -o inittarget ./cmd/inittarget
+          go build -o etcd-schema-verify ./cmd/etcd-schema-verify
 
       - name: Install dependency
         timeout-minutes: 5
@@ -712,6 +713,22 @@ jobs:
             --source_cluster_id backup-test-upstream \
             --target_cluster_id backup-test-downstream
 
+      - name: Verify etcd schema alignment
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          set -o pipefail
+          for coll in hello_milvus hello_milvus2; do
+            echo "=== Verifying schema: ${coll} ==="
+            ./etcd-schema-verify \
+              -src-endpoints localhost:2379 \
+              -dst-endpoints localhost:2379 \
+              -src-root-path backup-test-upstream \
+              -dst-root-path backup-test-downstream \
+              -collection "${coll}" | tee /tmp/schema_verify_${coll}.json
+            echo "Schema aligned for ${coll}"
+          done
+
       - name: Init upstream replicate configuration
         timeout-minutes: 1
         shell: bash
@@ -752,6 +769,7 @@ jobs:
           name: secondary-restore-logs-${{ matrix.image_tag }}
           path: |
             /tmp/ci_logs
+            /tmp/schema_verify_*.json
             ./server.log
 
   test-backup-restore-with-rbac-config:

--- a/cmd/etcd-schema-verify/diff.go
+++ b/cmd/etcd-schema-verify/diff.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func diffCollections(src, dst *CollectionDump) []Diff {
+	var diffs []Diff
+
+	// collection-level fields
+	cmp(&diffs, "id", src.ID, dst.ID)
+	cmp(&diffs, "db_id", src.DBID, dst.DBID)
+	cmp(&diffs, "name", src.Name, dst.Name)
+	cmp(&diffs, "description", src.Description, dst.Description)
+	cmp(&diffs, "state", src.State, dst.State)
+	cmp(&diffs, "shards_num", src.ShardsNum, dst.ShardsNum)
+	cmp(&diffs, "consistency_level", src.ConsistencyLevel, dst.ConsistencyLevel)
+	diffMap(&diffs, "properties", src.Properties, dst.Properties)
+
+	// fields: match by field ID (CDC preserves IDs)
+	diffFields(&diffs, src.Fields, dst.Fields)
+
+	// partitions: match by partition ID
+	diffPartitions(&diffs, src.Partitions, dst.Partitions)
+
+	// indexes: match by index ID
+	diffIndexes(&diffs, src.Indexes, dst.Indexes)
+
+	// functions: match by function ID
+	diffFunctions(&diffs, src.Functions, dst.Functions)
+
+	return diffs
+}
+
+func diffFields(diffs *[]Diff, src, dst []FieldDump) {
+	srcMap := make(map[int64]FieldDump, len(src))
+	for _, f := range src {
+		srcMap[f.FieldID] = f
+	}
+	dstMap := make(map[int64]FieldDump, len(dst))
+	for _, f := range dst {
+		dstMap[f.FieldID] = f
+	}
+
+	allIDs := collectIDs(srcMap, dstMap)
+	for _, id := range allIDs {
+		sf, inSrc := srcMap[id]
+		df, inDst := dstMap[id]
+
+		label := fmt.Sprintf("fields[id=%d]", id)
+		if inSrc {
+			label = fmt.Sprintf("fields[id=%d,name=%s]", id, sf.Name)
+		} else if inDst {
+			label = fmt.Sprintf("fields[id=%d,name=%s]", id, df.Name)
+		}
+
+		if !inSrc {
+			*diffs = append(*diffs, Diff{Path: label, Src: "<missing>", Dst: df.Name})
+			continue
+		}
+		if !inDst {
+			*diffs = append(*diffs, Diff{Path: label, Src: sf.Name, Dst: "<missing>"})
+			continue
+		}
+
+		cmp(diffs, label+".name", sf.Name, df.Name)
+		cmp(diffs, label+".description", sf.Description, df.Description)
+		cmp(diffs, label+".data_type", sf.DataType, df.DataType)
+		cmp(diffs, label+".element_type", sf.ElementType, df.ElementType)
+		diffMap(diffs, label+".type_params", sf.TypeParams, df.TypeParams)
+		diffMap(diffs, label+".index_params", sf.IndexParams, df.IndexParams)
+		cmp(diffs, label+".is_primary_key", sf.IsPrimaryKey, df.IsPrimaryKey)
+		cmp(diffs, label+".auto_id", sf.AutoID, df.AutoID)
+		cmp(diffs, label+".is_partition_key", sf.IsPartitionKey, df.IsPartitionKey)
+		cmp(diffs, label+".is_clustering_key", sf.IsClusteringKey, df.IsClusteringKey)
+		cmp(diffs, label+".is_function_output", sf.IsFunctionOutput, df.IsFunctionOutput)
+		cmp(diffs, label+".nullable", sf.Nullable, df.Nullable)
+		cmp(diffs, label+".default_value", sf.DefaultValue, df.DefaultValue)
+		cmp(diffs, label+".state", sf.State, df.State)
+	}
+}
+
+func diffPartitions(diffs *[]Diff, src, dst []PartitionDump) {
+	srcMap := make(map[int64]PartitionDump, len(src))
+	for _, p := range src {
+		srcMap[p.PartitionID] = p
+	}
+	dstMap := make(map[int64]PartitionDump, len(dst))
+	for _, p := range dst {
+		dstMap[p.PartitionID] = p
+	}
+
+	allIDs := collectIDs(srcMap, dstMap)
+	for _, id := range allIDs {
+		sp, inSrc := srcMap[id]
+		dp, inDst := dstMap[id]
+
+		label := fmt.Sprintf("partitions[id=%d]", id)
+		if inSrc {
+			label = fmt.Sprintf("partitions[id=%d,name=%s]", id, sp.PartitionName)
+		} else if inDst {
+			label = fmt.Sprintf("partitions[id=%d,name=%s]", id, dp.PartitionName)
+		}
+
+		if !inSrc {
+			*diffs = append(*diffs, Diff{Path: label, Src: "<missing>", Dst: dp.PartitionName})
+			continue
+		}
+		if !inDst {
+			*diffs = append(*diffs, Diff{Path: label, Src: sp.PartitionName, Dst: "<missing>"})
+			continue
+		}
+
+		cmp(diffs, label+".partition_name", sp.PartitionName, dp.PartitionName)
+		cmp(diffs, label+".state", sp.State, dp.State)
+	}
+}
+
+func diffIndexes(diffs *[]Diff, src, dst []IndexDump) {
+	srcMap := make(map[int64]IndexDump, len(src))
+	for _, idx := range src {
+		srcMap[idx.IndexID] = idx
+	}
+	dstMap := make(map[int64]IndexDump, len(dst))
+	for _, idx := range dst {
+		dstMap[idx.IndexID] = idx
+	}
+
+	allIDs := collectIDs(srcMap, dstMap)
+	for _, id := range allIDs {
+		si, inSrc := srcMap[id]
+		di, inDst := dstMap[id]
+
+		label := fmt.Sprintf("indexes[id=%d]", id)
+		if inSrc {
+			label = fmt.Sprintf("indexes[id=%d,name=%s]", id, si.IndexName)
+		} else if inDst {
+			label = fmt.Sprintf("indexes[id=%d,name=%s]", id, di.IndexName)
+		}
+
+		if !inSrc {
+			*diffs = append(*diffs, Diff{Path: label, Src: "<missing>", Dst: di.IndexName})
+			continue
+		}
+		if !inDst {
+			*diffs = append(*diffs, Diff{Path: label, Src: si.IndexName, Dst: "<missing>"})
+			continue
+		}
+
+		cmp(diffs, label+".index_name", si.IndexName, di.IndexName)
+		cmp(diffs, label+".field_id", si.FieldID, di.FieldID)
+		diffMap(diffs, label+".type_params", si.TypeParams, di.TypeParams)
+		diffMap(diffs, label+".index_params", si.IndexParams, di.IndexParams)
+		diffMap(diffs, label+".user_index_params", si.UserIndexParams, di.UserIndexParams)
+		cmp(diffs, label+".is_auto_index", si.IsAutoIndex, di.IsAutoIndex)
+		cmp(diffs, label+".state", si.State, di.State)
+		cmp(diffs, label+".deleted", si.Deleted, di.Deleted)
+	}
+}
+
+func diffFunctions(diffs *[]Diff, src, dst []FunctionDump) {
+	srcMap := make(map[int64]FunctionDump, len(src))
+	for _, f := range src {
+		srcMap[f.ID] = f
+	}
+	dstMap := make(map[int64]FunctionDump, len(dst))
+	for _, f := range dst {
+		dstMap[f.ID] = f
+	}
+
+	allIDs := collectIDs(srcMap, dstMap)
+	for _, id := range allIDs {
+		sf, inSrc := srcMap[id]
+		df, inDst := dstMap[id]
+
+		label := fmt.Sprintf("functions[id=%d]", id)
+		if inSrc {
+			label = fmt.Sprintf("functions[id=%d,name=%s]", id, sf.Name)
+		} else if inDst {
+			label = fmt.Sprintf("functions[id=%d,name=%s]", id, df.Name)
+		}
+
+		if !inSrc {
+			*diffs = append(*diffs, Diff{Path: label, Src: "<missing>", Dst: df.Name})
+			continue
+		}
+		if !inDst {
+			*diffs = append(*diffs, Diff{Path: label, Src: sf.Name, Dst: "<missing>"})
+			continue
+		}
+
+		cmp(diffs, label+".name", sf.Name, df.Name)
+		cmp(diffs, label+".description", sf.Description, df.Description)
+		cmp(diffs, label+".type", sf.Type, df.Type)
+		diffInt64Slice(diffs, label+".input_field_ids", sf.InputFieldIDs, df.InputFieldIDs)
+		diffStrSlice(diffs, label+".input_field_names", sf.InputFieldNames, df.InputFieldNames)
+		diffInt64Slice(diffs, label+".output_field_ids", sf.OutputFieldIDs, df.OutputFieldIDs)
+		diffStrSlice(diffs, label+".output_field_names", sf.OutputFieldNames, df.OutputFieldNames)
+		diffMap(diffs, label+".params", sf.Params, df.Params)
+	}
+}
+
+// --- comparison helpers ---
+
+func cmp[T comparable](diffs *[]Diff, path string, src, dst T) {
+	if src != dst {
+		*diffs = append(*diffs, Diff{Path: path, Src: fmt.Sprintf("%v", src), Dst: fmt.Sprintf("%v", dst)})
+	}
+}
+
+func diffMap(diffs *[]Diff, prefix string, src, dst map[string]string) {
+	allKeys := make(map[string]struct{})
+	for k := range src {
+		allKeys[k] = struct{}{}
+	}
+	for k := range dst {
+		allKeys[k] = struct{}{}
+	}
+
+	sorted := make([]string, 0, len(allKeys))
+	for k := range allKeys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	for _, k := range sorted {
+		sv, inSrc := src[k]
+		dv, inDst := dst[k]
+		path := prefix + "." + k
+
+		switch {
+		case !inSrc:
+			*diffs = append(*diffs, Diff{Path: path, Src: "<missing>", Dst: dv})
+		case !inDst:
+			*diffs = append(*diffs, Diff{Path: path, Src: sv, Dst: "<missing>"})
+		case sv != dv:
+			*diffs = append(*diffs, Diff{Path: path, Src: sv, Dst: dv})
+		}
+	}
+}
+
+func diffStrSlice(diffs *[]Diff, path string, src, dst []string) {
+	if len(src) != len(dst) {
+		*diffs = append(*diffs, Diff{Path: path, Src: fmt.Sprintf("%v", src), Dst: fmt.Sprintf("%v", dst)})
+		return
+	}
+	for i := range src {
+		if src[i] != dst[i] {
+			*diffs = append(*diffs, Diff{Path: path, Src: fmt.Sprintf("%v", src), Dst: fmt.Sprintf("%v", dst)})
+			return
+		}
+	}
+}
+
+func diffInt64Slice(diffs *[]Diff, path string, src, dst []int64) {
+	if len(src) != len(dst) {
+		*diffs = append(*diffs, Diff{Path: path, Src: fmt.Sprintf("%v", src), Dst: fmt.Sprintf("%v", dst)})
+		return
+	}
+	for i := range src {
+		if src[i] != dst[i] {
+			*diffs = append(*diffs, Diff{Path: path, Src: fmt.Sprintf("%v", src), Dst: fmt.Sprintf("%v", dst)})
+			return
+		}
+	}
+}
+
+// collectIDs gathers all keys from two maps and returns them sorted.
+func collectIDs[V any](a, b map[int64]V) []int64 {
+	seen := make(map[int64]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+
+	ids := make([]int64, 0, len(seen))
+	for k := range seen {
+		ids = append(ids, k)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}

--- a/cmd/etcd-schema-verify/diff_test.go
+++ b/cmd/etcd-schema-verify/diff_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffCollections(t *testing.T) {
+	base := func() *CollectionDump {
+		return &CollectionDump{
+			ID: 100, DBID: 1, Name: "coll", State: "CollectionCreated",
+			ShardsNum: 2, ConsistencyLevel: "Strong",
+			Properties: map[string]string{"ttl": "3600"},
+			Fields: []FieldDump{
+				{FieldID: 1, Name: "pk", DataType: "Int64", IsPrimaryKey: true},
+				{FieldID: 2, Name: "vec", DataType: "FloatVector", TypeParams: map[string]string{"dim": "128"}},
+			},
+			Partitions: []PartitionDump{
+				{PartitionID: 10, PartitionName: "_default", State: "PartitionCreated"},
+			},
+			Indexes: []IndexDump{
+				{IndexID: 1, IndexName: "idx_vec", FieldID: 2, State: "Finished"},
+			},
+			Functions: []FunctionDump{
+				{ID: 1, Name: "bm25", Type: "BM25", InputFieldNames: []string{"text"}},
+			},
+		}
+	}
+
+	t.Run("Aligned", func(t *testing.T) {
+		diffs := diffCollections(base(), base())
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("CollectionLevelDiffs", func(t *testing.T) {
+		dst := base()
+		dst.ID = 101
+		dst.ShardsNum = 4
+		dst.ConsistencyLevel = "Bounded"
+		dst.Properties = map[string]string{"ttl": "7200"}
+
+		diffs := diffCollections(base(), dst)
+		dm := toDiffMap(diffs)
+		assert.Equal(t, "100", dm["id"].Src)
+		assert.Equal(t, "101", dm["id"].Dst)
+		assert.Equal(t, "2", dm["shards_num"].Src)
+		assert.Equal(t, "4", dm["shards_num"].Dst)
+		assert.Equal(t, "Strong", dm["consistency_level"].Src)
+		assert.Equal(t, "Bounded", dm["consistency_level"].Dst)
+		assert.Equal(t, "3600", dm["properties.ttl"].Src)
+		assert.Equal(t, "7200", dm["properties.ttl"].Dst)
+	})
+
+	t.Run("DescriptionDiff", func(t *testing.T) {
+		src := base()
+		src.Description = "old"
+		dst := base()
+		dst.Description = "new"
+
+		diffs := diffCollections(src, dst)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "description")
+	})
+
+	t.Run("DBIDDiff", func(t *testing.T) {
+		dst := base()
+		dst.DBID = 2
+
+		diffs := diffCollections(base(), dst)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "db_id")
+	})
+}
+
+func TestDiffFields(t *testing.T) {
+	t.Run("MissingSrc", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs, nil, []FieldDump{{FieldID: 1, Name: "pk"}})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Src)
+		assert.Equal(t, "pk", diffs[0].Dst)
+		assert.Contains(t, diffs[0].Path, "id=1")
+	})
+
+	t.Run("MissingDst", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs, []FieldDump{{FieldID: 1, Name: "pk"}}, nil)
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "pk", diffs[0].Src)
+		assert.Equal(t, "<missing>", diffs[0].Dst)
+	})
+
+	t.Run("DataTypeDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs,
+			[]FieldDump{{FieldID: 2, Name: "vec", DataType: "FloatVector"}},
+			[]FieldDump{{FieldID: 2, Name: "vec", DataType: "Float16Vector"}},
+		)
+		assert.Len(t, diffs, 1)
+		assert.Contains(t, diffs[0].Path, "data_type")
+	})
+
+	t.Run("BoolFieldsDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs,
+			[]FieldDump{{FieldID: 1, Name: "pk", IsPrimaryKey: true, AutoID: true, IsPartitionKey: false, IsClusteringKey: false, IsFunctionOutput: false, Nullable: false}},
+			[]FieldDump{{FieldID: 1, Name: "pk", IsPrimaryKey: false, AutoID: false, IsPartitionKey: true, IsClusteringKey: true, IsFunctionOutput: true, Nullable: true}},
+		)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "fields[id=1,name=pk].is_primary_key")
+		assert.Contains(t, dm, "fields[id=1,name=pk].auto_id")
+		assert.Contains(t, dm, "fields[id=1,name=pk].is_partition_key")
+		assert.Contains(t, dm, "fields[id=1,name=pk].is_clustering_key")
+		assert.Contains(t, dm, "fields[id=1,name=pk].is_function_output")
+		assert.Contains(t, dm, "fields[id=1,name=pk].nullable")
+	})
+
+	t.Run("TypeParamsDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs,
+			[]FieldDump{{FieldID: 2, Name: "vec", TypeParams: map[string]string{"dim": "128"}}},
+			[]FieldDump{{FieldID: 2, Name: "vec", TypeParams: map[string]string{"dim": "256"}}},
+		)
+		assert.Len(t, diffs, 1)
+		assert.Contains(t, diffs[0].Path, "type_params.dim")
+	})
+
+	t.Run("IndexParamsDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs,
+			[]FieldDump{{FieldID: 2, Name: "f", IndexParams: map[string]string{"a": "1"}}},
+			[]FieldDump{{FieldID: 2, Name: "f", IndexParams: map[string]string{"a": "2"}}},
+		)
+		assert.Len(t, diffs, 1)
+		assert.Contains(t, diffs[0].Path, "index_params.a")
+	})
+
+	t.Run("DescriptionAndStateDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFields(&diffs,
+			[]FieldDump{{FieldID: 1, Name: "f", Description: "old", State: "FieldCreated", DefaultValue: "0", ElementType: "Int64"}},
+			[]FieldDump{{FieldID: 1, Name: "f", Description: "new", State: "FieldDropping", DefaultValue: "1", ElementType: "VarChar"}},
+		)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "fields[id=1,name=f].description")
+		assert.Contains(t, dm, "fields[id=1,name=f].state")
+		assert.Contains(t, dm, "fields[id=1,name=f].default_value")
+		assert.Contains(t, dm, "fields[id=1,name=f].element_type")
+	})
+
+	t.Run("Aligned", func(t *testing.T) {
+		f := []FieldDump{{FieldID: 1, Name: "pk", DataType: "Int64"}}
+		var diffs []Diff
+		diffFields(&diffs, f, f)
+		assert.Empty(t, diffs)
+	})
+}
+
+func TestDiffPartitions(t *testing.T) {
+	t.Run("Aligned", func(t *testing.T) {
+		p := []PartitionDump{{PartitionID: 1, PartitionName: "_default", State: "PartitionCreated"}}
+		var diffs []Diff
+		diffPartitions(&diffs, p, p)
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("MissingSrc", func(t *testing.T) {
+		var diffs []Diff
+		diffPartitions(&diffs, nil, []PartitionDump{{PartitionID: 1, PartitionName: "p1"}})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Src)
+	})
+
+	t.Run("MissingDst", func(t *testing.T) {
+		var diffs []Diff
+		diffPartitions(&diffs,
+			[]PartitionDump{{PartitionID: 2, PartitionName: "part_a", State: "PartitionCreated"}},
+			nil,
+		)
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "part_a", diffs[0].Src)
+		assert.Equal(t, "<missing>", diffs[0].Dst)
+	})
+
+	t.Run("NameAndStateDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffPartitions(&diffs,
+			[]PartitionDump{{PartitionID: 1, PartitionName: "p1", State: "PartitionCreated"}},
+			[]PartitionDump{{PartitionID: 1, PartitionName: "p2", State: "PartitionDropping"}},
+		)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "partitions[id=1,name=p1].partition_name")
+		assert.Contains(t, dm, "partitions[id=1,name=p1].state")
+	})
+}
+
+func TestDiffIndexes(t *testing.T) {
+	t.Run("Aligned", func(t *testing.T) {
+		idx := []IndexDump{{IndexID: 1, IndexName: "idx", FieldID: 2, State: "Finished"}}
+		var diffs []Diff
+		diffIndexes(&diffs, idx, idx)
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("MissingSrc", func(t *testing.T) {
+		var diffs []Diff
+		diffIndexes(&diffs, nil, []IndexDump{{IndexID: 1, IndexName: "idx"}})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Src)
+	})
+
+	t.Run("MissingDst", func(t *testing.T) {
+		var diffs []Diff
+		diffIndexes(&diffs, []IndexDump{{IndexID: 1, IndexName: "idx"}}, nil)
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Dst)
+	})
+
+	t.Run("AllFieldsDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffIndexes(&diffs,
+			[]IndexDump{{IndexID: 1, IndexName: "a", FieldID: 2, State: "Finished", IsAutoIndex: false, Deleted: false,
+				IndexParams: map[string]string{"nlist": "128"}, TypeParams: map[string]string{"t": "1"}, UserIndexParams: map[string]string{"u": "1"}}},
+			[]IndexDump{{IndexID: 1, IndexName: "b", FieldID: 3, State: "InProgress", IsAutoIndex: true, Deleted: true,
+				IndexParams: map[string]string{"nlist": "256"}, TypeParams: map[string]string{"t": "2"}, UserIndexParams: map[string]string{"u": "2"}}},
+		)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "indexes[id=1,name=a].index_name")
+		assert.Contains(t, dm, "indexes[id=1,name=a].field_id")
+		assert.Contains(t, dm, "indexes[id=1,name=a].state")
+		assert.Contains(t, dm, "indexes[id=1,name=a].is_auto_index")
+		assert.Contains(t, dm, "indexes[id=1,name=a].deleted")
+		assert.Contains(t, dm, "indexes[id=1,name=a].index_params.nlist")
+		assert.Contains(t, dm, "indexes[id=1,name=a].type_params.t")
+		assert.Contains(t, dm, "indexes[id=1,name=a].user_index_params.u")
+	})
+}
+
+func TestDiffFunctions(t *testing.T) {
+	t.Run("Aligned", func(t *testing.T) {
+		f := []FunctionDump{{ID: 1, Name: "bm25", Type: "BM25",
+			InputFieldNames: []string{"text"}, OutputFieldNames: []string{"sparse"},
+			InputFieldIDs: []int64{3}, OutputFieldIDs: []int64{4},
+			Params: map[string]string{"k": "v"},
+		}}
+		var diffs []Diff
+		diffFunctions(&diffs, f, f)
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("MissingSrc", func(t *testing.T) {
+		var diffs []Diff
+		diffFunctions(&diffs, nil, []FunctionDump{{ID: 1, Name: "fn"}})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Src)
+	})
+
+	t.Run("MissingDst", func(t *testing.T) {
+		var diffs []Diff
+		diffFunctions(&diffs, []FunctionDump{{ID: 1, Name: "fn"}}, nil)
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Dst)
+	})
+
+	t.Run("AllFieldsDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffFunctions(&diffs,
+			[]FunctionDump{{ID: 1, Name: "fn", Description: "a", Type: "BM25",
+				InputFieldIDs: []int64{3}, InputFieldNames: []string{"text"},
+				OutputFieldIDs: []int64{4}, OutputFieldNames: []string{"sparse"},
+				Params: map[string]string{"k": "v1"}}},
+			[]FunctionDump{{ID: 1, Name: "fn2", Description: "b", Type: "Embed",
+				InputFieldIDs: []int64{5}, InputFieldNames: []string{"doc"},
+				OutputFieldIDs: []int64{6}, OutputFieldNames: []string{"dense"},
+				Params: map[string]string{"k": "v2"}}},
+		)
+		dm := toDiffMap(diffs)
+		assert.Contains(t, dm, "functions[id=1,name=fn].name")
+		assert.Contains(t, dm, "functions[id=1,name=fn].description")
+		assert.Contains(t, dm, "functions[id=1,name=fn].type")
+		assert.Contains(t, dm, "functions[id=1,name=fn].input_field_ids")
+		assert.Contains(t, dm, "functions[id=1,name=fn].input_field_names")
+		assert.Contains(t, dm, "functions[id=1,name=fn].output_field_ids")
+		assert.Contains(t, dm, "functions[id=1,name=fn].output_field_names")
+		assert.Contains(t, dm, "functions[id=1,name=fn].params.k")
+	})
+}
+
+func TestDiffMap(t *testing.T) {
+	t.Run("BothNil", func(t *testing.T) {
+		var diffs []Diff
+		diffMap(&diffs, "p", nil, nil)
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("SrcOnly", func(t *testing.T) {
+		var diffs []Diff
+		diffMap(&diffs, "p", map[string]string{"a": "1"}, nil)
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "1", diffs[0].Src)
+		assert.Equal(t, "<missing>", diffs[0].Dst)
+	})
+
+	t.Run("DstOnly", func(t *testing.T) {
+		var diffs []Diff
+		diffMap(&diffs, "p", nil, map[string]string{"a": "1"})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "<missing>", diffs[0].Src)
+	})
+
+	t.Run("ValueDiff", func(t *testing.T) {
+		var diffs []Diff
+		diffMap(&diffs, "p", map[string]string{"k": "v1"}, map[string]string{"k": "v2"})
+		assert.Len(t, diffs, 1)
+		assert.Equal(t, "p.k", diffs[0].Path)
+	})
+
+	t.Run("Equal", func(t *testing.T) {
+		var diffs []Diff
+		diffMap(&diffs, "p", map[string]string{"k": "v"}, map[string]string{"k": "v"})
+		assert.Empty(t, diffs)
+	})
+}
+
+func TestDiffStrSlice(t *testing.T) {
+	t.Run("Equal", func(t *testing.T) {
+		var diffs []Diff
+		diffStrSlice(&diffs, "f", []string{"a", "b"}, []string{"a", "b"})
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("DifferentLength", func(t *testing.T) {
+		var diffs []Diff
+		diffStrSlice(&diffs, "f", []string{"a"}, []string{"a", "b"})
+		assert.Len(t, diffs, 1)
+	})
+
+	t.Run("DifferentValues", func(t *testing.T) {
+		var diffs []Diff
+		diffStrSlice(&diffs, "f", []string{"a", "b"}, []string{"a", "c"})
+		assert.Len(t, diffs, 1)
+	})
+
+	t.Run("CommaEdgeCase", func(t *testing.T) {
+		// ["a,b"] and ["a", "b"] must be treated as different
+		var diffs []Diff
+		diffStrSlice(&diffs, "f", []string{"a,b"}, []string{"a", "b"})
+		assert.Len(t, diffs, 1)
+	})
+
+	t.Run("BothNil", func(t *testing.T) {
+		var diffs []Diff
+		diffStrSlice(&diffs, "f", nil, nil)
+		assert.Empty(t, diffs)
+	})
+}
+
+func TestDiffInt64Slice(t *testing.T) {
+	t.Run("Equal", func(t *testing.T) {
+		var diffs []Diff
+		diffInt64Slice(&diffs, "f", []int64{1, 2}, []int64{1, 2})
+		assert.Empty(t, diffs)
+	})
+
+	t.Run("DifferentLength", func(t *testing.T) {
+		var diffs []Diff
+		diffInt64Slice(&diffs, "f", []int64{1}, []int64{1, 2})
+		assert.Len(t, diffs, 1)
+	})
+
+	t.Run("DifferentValues", func(t *testing.T) {
+		var diffs []Diff
+		diffInt64Slice(&diffs, "f", []int64{1, 2}, []int64{1, 3})
+		assert.Len(t, diffs, 1)
+	})
+
+	t.Run("BothNil", func(t *testing.T) {
+		var diffs []Diff
+		diffInt64Slice(&diffs, "f", nil, nil)
+		assert.Empty(t, diffs)
+	})
+}
+
+func TestCollectIDs(t *testing.T) {
+	t.Run("MergedAndSorted", func(t *testing.T) {
+		ids := collectIDs(map[int64]string{3: "c", 1: "a"}, map[int64]string{2: "b", 1: "a"})
+		assert.Equal(t, []int64{1, 2, 3}, ids)
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		ids := collectIDs(map[int64]string{}, map[int64]string{})
+		assert.Empty(t, ids)
+	})
+}
+
+func toDiffMap(diffs []Diff) map[string]Diff {
+	m := make(map[string]Diff, len(diffs))
+	for _, d := range diffs {
+		m[d.Path] = d
+	}
+	return m
+}

--- a/cmd/etcd-schema-verify/dump.go
+++ b/cmd/etcd-schema-verify/dump.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+)
+
+// kvGetter abstracts etcd Get for testability.
+type kvGetter interface {
+	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+}
+
+type reader struct {
+	cli      kvGetter
+	rootPath string
+}
+
+func (r *reader) prefix(parts ...string) string {
+	elems := append([]string{r.rootPath}, parts...)
+	return path.Join(elems...)
+}
+
+// findCollection scans etcd for a collection by name, returns the full dump.
+func (r *reader) findCollection(ctx context.Context, dbName, collName string) (*CollectionDump, error) {
+	dbs, err := r.listDatabases(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list databases: %w", err)
+	}
+
+	type match struct {
+		info   *etcdpb.CollectionInfo
+		dbName string
+	}
+	var matches []match
+
+	for _, db := range dbs {
+		if dbName != "" && db.GetName() != dbName {
+			continue
+		}
+
+		colls, err := r.listCollections(ctx, db.GetId())
+		if err != nil {
+			return nil, fmt.Errorf("list collections for db %d (%s): %w", db.GetId(), db.GetName(), err)
+		}
+
+		for _, c := range colls {
+			if c.GetSchema().GetName() == collName {
+				matches = append(matches, match{info: c, dbName: db.GetName()})
+			}
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("collection %q not found in etcd (root_path=%s)", collName, r.rootPath)
+	case 1:
+		return r.loadCollectionDetail(ctx, matches[0].info)
+	default:
+		var dbNames []string
+		for _, m := range matches {
+			dbNames = append(dbNames, m.dbName)
+		}
+		return nil, fmt.Errorf("collection %q found in multiple databases %v, specify --db", collName, dbNames)
+	}
+}
+
+func (r *reader) listDatabases(ctx context.Context) ([]*etcdpb.DatabaseInfo, error) {
+	prefix := r.prefix("meta", "root-coord", "database", "db-info") + "/"
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var dbs []*etcdpb.DatabaseInfo
+	for _, kv := range resp.Kvs {
+		db := &etcdpb.DatabaseInfo{}
+		if err := proto.Unmarshal(kv.Value, db); err != nil {
+			continue
+		}
+		dbs = append(dbs, db)
+	}
+
+	if len(dbs) == 0 {
+		dbs = append(dbs, &etcdpb.DatabaseInfo{
+			Id:    0,
+			Name:  "default",
+			State: etcdpb.DatabaseState_DatabaseCreated,
+		})
+	}
+
+	return dbs, nil
+}
+
+func (r *reader) listCollections(ctx context.Context, dbID int64) ([]*etcdpb.CollectionInfo, error) {
+	prefix := r.prefix("meta", "root-coord", "database", "collection-info", strconv.FormatInt(dbID, 10)) + "/"
+	colls, err := r.getCollections(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(colls) == 0 && dbID == 0 {
+		prefix = r.prefix("meta", "root-coord", "collection") + "/"
+		colls, err = r.getCollections(ctx, prefix)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return colls, nil
+}
+
+func (r *reader) getCollections(ctx context.Context, prefix string) ([]*etcdpb.CollectionInfo, error) {
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var colls []*etcdpb.CollectionInfo
+	for _, kv := range resp.Kvs {
+		c := &etcdpb.CollectionInfo{}
+		if err := proto.Unmarshal(kv.Value, c); err != nil {
+			continue
+		}
+		colls = append(colls, c)
+	}
+	return colls, nil
+}
+
+func (r *reader) loadCollectionDetail(ctx context.Context, coll *etcdpb.CollectionInfo) (*CollectionDump, error) {
+	collID := coll.GetID()
+
+	d := &CollectionDump{
+		ID:                   collID,
+		DBID:                 coll.GetDbId(),
+		Name:                 coll.GetSchema().GetName(),
+		Description:          coll.GetSchema().GetDescription(),
+		State:                coll.GetState().String(),
+		ShardsNum:            coll.GetShardsNum(),
+		ConsistencyLevel:     coll.GetConsistencyLevel().String(),
+		Properties:           kvPairsToMap(coll.GetProperties()),
+		CreateTime:           coll.GetCreateTime(),
+		UpdateTimestamp:      coll.GetUpdateTimestamp(),
+		VirtualChannelNames:  coll.GetVirtualChannelNames(),
+		PhysicalChannelNames: coll.GetPhysicalChannelNames(),
+	}
+
+	// inline schema fields
+	for _, f := range coll.GetSchema().GetFields() {
+		d.Fields = append(d.Fields, buildFieldDump(f))
+	}
+
+	// separately stored fields
+	sepFields, err := r.listFields(ctx, collID)
+	if err != nil {
+		return nil, fmt.Errorf("list fields for collection %d: %w", collID, err)
+	}
+	mergeFields(d, sepFields)
+
+	// partitions
+	d.Partitions, err = r.listPartitions(ctx, collID)
+	if err != nil {
+		return nil, fmt.Errorf("list partitions for collection %d: %w", collID, err)
+	}
+
+	// indexes
+	d.Indexes, err = r.listIndexes(ctx, collID)
+	if err != nil {
+		return nil, fmt.Errorf("list indexes for collection %d: %w", collID, err)
+	}
+
+	// functions
+	d.Functions, err = r.listFunctions(ctx, collID)
+	if err != nil {
+		return nil, fmt.Errorf("list functions for collection %d: %w", collID, err)
+	}
+
+	// sort for deterministic comparison
+	sort.Slice(d.Fields, func(i, j int) bool { return d.Fields[i].FieldID < d.Fields[j].FieldID })
+	sort.Slice(d.Partitions, func(i, j int) bool { return d.Partitions[i].PartitionID < d.Partitions[j].PartitionID })
+	sort.Slice(d.Indexes, func(i, j int) bool { return d.Indexes[i].IndexID < d.Indexes[j].IndexID })
+	sort.Slice(d.Functions, func(i, j int) bool { return d.Functions[i].ID < d.Functions[j].ID })
+
+	return d, nil
+}
+
+func (r *reader) listFields(ctx context.Context, collID int64) ([]*schemapb.FieldSchema, error) {
+	prefix := r.prefix("meta", "root-coord", "fields", strconv.FormatInt(collID, 10)) + "/"
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var fields []*schemapb.FieldSchema
+	for _, kv := range resp.Kvs {
+		f := &schemapb.FieldSchema{}
+		if err := proto.Unmarshal(kv.Value, f); err != nil {
+			continue
+		}
+		fields = append(fields, f)
+	}
+	return fields, nil
+}
+
+func mergeFields(d *CollectionDump, sepFields []*schemapb.FieldSchema) {
+	existing := make(map[int64]int, len(d.Fields))
+	for i, f := range d.Fields {
+		existing[f.FieldID] = i
+	}
+
+	for _, sf := range sepFields {
+		if idx, ok := existing[sf.GetFieldID()]; ok {
+			// update state from separately stored field
+			d.Fields[idx].State = sf.GetState().String()
+			continue
+		}
+		d.Fields = append(d.Fields, buildFieldDump(sf))
+	}
+}
+
+func (r *reader) listPartitions(ctx context.Context, collID int64) ([]PartitionDump, error) {
+	prefix := r.prefix("meta", "root-coord", "partitions", strconv.FormatInt(collID, 10)) + "/"
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var partitions []PartitionDump
+	for _, kv := range resp.Kvs {
+		p := &etcdpb.PartitionInfo{}
+		if err := proto.Unmarshal(kv.Value, p); err != nil {
+			continue
+		}
+		partitions = append(partitions, PartitionDump{
+			PartitionID:      p.GetPartitionID(),
+			PartitionName:    p.GetPartitionName(),
+			State:            p.GetState().String(),
+			CreatedTimestamp: p.GetPartitionCreatedTimestamp(),
+		})
+	}
+	return partitions, nil
+}
+
+func (r *reader) listIndexes(ctx context.Context, collID int64) ([]IndexDump, error) {
+	prefix := r.prefix("meta", "field-index", strconv.FormatInt(collID, 10)) + "/"
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var indexes []IndexDump
+	for _, kv := range resp.Kvs {
+		fi := &indexpb.FieldIndex{}
+		if err := proto.Unmarshal(kv.Value, fi); err != nil {
+			continue
+		}
+		info := fi.GetIndexInfo()
+		indexes = append(indexes, IndexDump{
+			IndexID:         info.GetIndexID(),
+			IndexName:       info.GetIndexName(),
+			FieldID:         info.GetFieldID(),
+			TypeParams:      kvPairsToMap(info.GetTypeParams()),
+			IndexParams:     kvPairsToMap(info.GetIndexParams()),
+			UserIndexParams: kvPairsToMap(info.GetUserIndexParams()),
+			IsAutoIndex:     info.GetIsAutoIndex(),
+			State:           info.GetState().String(),
+			Deleted:         fi.GetDeleted(),
+		})
+	}
+	return indexes, nil
+}
+
+func (r *reader) listFunctions(ctx context.Context, collID int64) ([]FunctionDump, error) {
+	prefix := r.prefix("meta", "root-coord", "functions", strconv.FormatInt(collID, 10)) + "/"
+	resp, err := r.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	var funcs []FunctionDump
+	for _, kv := range resp.Kvs {
+		f := &schemapb.FunctionSchema{}
+		if err := proto.Unmarshal(kv.Value, f); err != nil {
+			continue
+		}
+		funcs = append(funcs, FunctionDump{
+			ID:               f.GetId(),
+			Name:             f.GetName(),
+			Description:      f.GetDescription(),
+			Type:             f.GetType().String(),
+			InputFieldIDs:    f.GetInputFieldIds(),
+			InputFieldNames:  f.GetInputFieldNames(),
+			OutputFieldIDs:   f.GetOutputFieldIds(),
+			OutputFieldNames: f.GetOutputFieldNames(),
+			Params:           kvPairsToMap(f.GetParams()),
+		})
+	}
+	return funcs, nil
+}
+
+// helpers
+
+func buildFieldDump(f *schemapb.FieldSchema) FieldDump {
+	fd := FieldDump{
+		FieldID:          f.GetFieldID(),
+		Name:             f.GetName(),
+		Description:      f.GetDescription(),
+		DataType:         f.GetDataType().String(),
+		TypeParams:       kvPairsToMap(f.GetTypeParams()),
+		IndexParams:      kvPairsToMap(f.GetIndexParams()),
+		IsPrimaryKey:     f.GetIsPrimaryKey(),
+		AutoID:           f.GetAutoID(),
+		IsPartitionKey:   f.GetIsPartitionKey(),
+		IsClusteringKey:  f.GetIsClusteringKey(),
+		IsFunctionOutput: f.GetIsFunctionOutput(),
+		Nullable:         f.GetNullable(),
+		State:            f.GetState().String(),
+	}
+
+	if f.GetElementType() != schemapb.DataType_None {
+		fd.ElementType = f.GetElementType().String()
+	}
+
+	if f.GetDefaultValue() != nil {
+		fd.DefaultValue = fmt.Sprintf("%v", f.GetDefaultValue())
+	}
+
+	return fd
+}
+
+func kvPairsToMap(pairs []*commonpb.KeyValuePair) map[string]string {
+	if len(pairs) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(pairs))
+	for _, kv := range pairs {
+		m[kv.GetKey()] = kv.GetValue()
+	}
+	return m
+}

--- a/cmd/etcd-schema-verify/dump_test.go
+++ b/cmd/etcd-schema-verify/dump_test.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/stretchr/testify/assert"
+	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/protobuf/proto"
+)
+
+// mockKV returns pre-configured responses keyed by prefix match.
+type mockKV struct {
+	data map[string][]*mvccpb.KeyValue
+}
+
+func newMockKV() *mockKV {
+	return &mockKV{data: make(map[string][]*mvccpb.KeyValue)}
+}
+
+func (m *mockKV) put(key string, msg proto.Message) {
+	val, _ := proto.Marshal(msg)
+	m.data[key] = append(m.data[key], &mvccpb.KeyValue{Key: []byte(key), Value: val})
+}
+
+func (m *mockKV) Get(_ context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	op := clientv3.OpGet(key, opts...)
+	var kvs []*mvccpb.KeyValue
+	if op.IsOptsWithPrefix() {
+		for k, vs := range m.data {
+			if len(k) >= len(key) && k[:len(key)] == key {
+				kvs = append(kvs, vs...)
+			}
+		}
+	} else {
+		kvs = m.data[key]
+	}
+	return &clientv3.GetResponse{Kvs: kvs}, nil
+}
+
+// setupTestEtcd populates a mockKV with a full collection's metadata.
+func setupTestEtcd() (*mockKV, *reader) {
+	kv := newMockKV()
+
+	kv.put("test-root/meta/root-coord/database/db-info/1", &etcdpb.DatabaseInfo{
+		Id: 1, Name: "default", State: etcdpb.DatabaseState_DatabaseCreated,
+	})
+
+	kv.put("test-root/meta/root-coord/database/collection-info/1/100", &etcdpb.CollectionInfo{
+		ID: 100, DbId: 1, ShardsNum: 2,
+		Schema: &schemapb.CollectionSchema{
+			Name: "test_coll",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 2, Name: "vec", DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}}},
+			},
+		},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+
+	kv.put("test-root/meta/root-coord/fields/100/1", &schemapb.FieldSchema{
+		FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64,
+		IsPrimaryKey: true, State: schemapb.FieldState_FieldCreated,
+	})
+	kv.put("test-root/meta/root-coord/fields/100/2", &schemapb.FieldSchema{
+		FieldID: 2, Name: "vec", DataType: schemapb.DataType_FloatVector,
+		State: schemapb.FieldState_FieldCreated,
+	})
+
+	kv.put("test-root/meta/root-coord/partitions/100/10", &etcdpb.PartitionInfo{
+		PartitionID: 10, PartitionName: "_default",
+		State: etcdpb.PartitionState_PartitionCreated, CollectionId: 100,
+	})
+	kv.put("test-root/meta/root-coord/partitions/100/11", &etcdpb.PartitionInfo{
+		PartitionID: 11, PartitionName: "part_a",
+		State: etcdpb.PartitionState_PartitionCreated, CollectionId: 100,
+	})
+
+	kv.put("test-root/meta/field-index/100/1", &indexpb.FieldIndex{
+		IndexInfo: &indexpb.IndexInfo{
+			CollectionID: 100, FieldID: 2, IndexID: 1, IndexName: "idx_vec",
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: "index_type", Value: "IVF_FLAT"}, {Key: "nlist", Value: "128"},
+			},
+			State: commonpb.IndexState_Finished,
+		},
+	})
+
+	kv.put("test-root/meta/root-coord/functions/100/1", &schemapb.FunctionSchema{
+		Id: 1, Name: "bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{3}, InputFieldNames: []string{"text"},
+		OutputFieldIds: []int64{4}, OutputFieldNames: []string{"sparse"},
+	})
+
+	return kv, &reader{cli: kv, rootPath: "test-root"}
+}
+
+func TestKvPairsToMap(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		assert.Nil(t, kvPairsToMap(nil))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		assert.Nil(t, kvPairsToMap([]*commonpb.KeyValuePair{}))
+	})
+
+	t.Run("MultipleEntries", func(t *testing.T) {
+		pairs := []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}, {Key: "metric", Value: "L2"}}
+		m := kvPairsToMap(pairs)
+		assert.Equal(t, "128", m["dim"])
+		assert.Equal(t, "L2", m["metric"])
+	})
+}
+
+func TestBuildFieldDump(t *testing.T) {
+	t.Run("BasicField", func(t *testing.T) {
+		fd := buildFieldDump(&schemapb.FieldSchema{
+			FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64,
+			IsPrimaryKey: true, AutoID: true, State: schemapb.FieldState_FieldCreated,
+		})
+		assert.Equal(t, int64(100), fd.FieldID)
+		assert.Equal(t, "Int64", fd.DataType)
+		assert.True(t, fd.IsPrimaryKey)
+		assert.True(t, fd.AutoID)
+		assert.Equal(t, "FieldCreated", fd.State)
+		assert.Empty(t, fd.ElementType)
+	})
+
+	t.Run("ArrayWithElementType", func(t *testing.T) {
+		fd := buildFieldDump(&schemapb.FieldSchema{
+			FieldID: 102, Name: "tags",
+			DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_VarChar,
+		})
+		assert.Equal(t, "VarChar", fd.ElementType)
+	})
+
+	t.Run("WithDefaultValue", func(t *testing.T) {
+		fd := buildFieldDump(&schemapb.FieldSchema{
+			FieldID: 106, Name: "status", DataType: schemapb.DataType_Int64,
+			DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 0}},
+		})
+		assert.NotEmpty(t, fd.DefaultValue)
+	})
+
+	t.Run("AllBoolFlags", func(t *testing.T) {
+		fd := buildFieldDump(&schemapb.FieldSchema{
+			FieldID: 107, Name: "f", DataType: schemapb.DataType_VarChar,
+			IsPartitionKey: true, IsClusteringKey: true, IsFunctionOutput: true, Nullable: true,
+		})
+		assert.True(t, fd.IsPartitionKey)
+		assert.True(t, fd.IsClusteringKey)
+		assert.True(t, fd.IsFunctionOutput)
+		assert.True(t, fd.Nullable)
+	})
+}
+
+func TestMergeFields(t *testing.T) {
+	t.Run("UpdateState", func(t *testing.T) {
+		d := &CollectionDump{Fields: []FieldDump{{FieldID: 1, Name: "pk", State: ""}}}
+		mergeFields(d, []*schemapb.FieldSchema{{FieldID: 1, State: schemapb.FieldState_FieldCreated}})
+		assert.Equal(t, "FieldCreated", d.Fields[0].State)
+	})
+
+	t.Run("AddNewField", func(t *testing.T) {
+		d := &CollectionDump{Fields: []FieldDump{{FieldID: 1, Name: "pk"}}}
+		mergeFields(d, []*schemapb.FieldSchema{{FieldID: 2, Name: "vec", DataType: schemapb.DataType_FloatVector}})
+		assert.Len(t, d.Fields, 2)
+		assert.Equal(t, "vec", d.Fields[1].Name)
+	})
+
+	t.Run("EmptyBoth", func(t *testing.T) {
+		d := &CollectionDump{}
+		mergeFields(d, nil)
+		assert.Empty(t, d.Fields)
+	})
+}
+
+func TestReaderPrefix(t *testing.T) {
+	r := &reader{rootPath: "by-dev"}
+
+	t.Run("RootcoordPath", func(t *testing.T) {
+		assert.Equal(t, "by-dev/meta/root-coord/database/db-info", r.prefix("meta", "root-coord", "database", "db-info"))
+	})
+
+	t.Run("IndexPath", func(t *testing.T) {
+		assert.Equal(t, "by-dev/meta/field-index/100", r.prefix("meta", "field-index", "100"))
+	})
+}
+
+func TestListDatabases(t *testing.T) {
+	t.Run("Found", func(t *testing.T) {
+		_, r := setupTestEtcd()
+		dbs, err := r.listDatabases(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, dbs, 1)
+		assert.Equal(t, "default", dbs[0].GetName())
+	})
+
+	t.Run("FallbackDefault", func(t *testing.T) {
+		r := &reader{cli: newMockKV(), rootPath: "empty"}
+		dbs, err := r.listDatabases(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, dbs, 1)
+		assert.Equal(t, int64(0), dbs[0].GetId())
+		assert.Equal(t, "default", dbs[0].GetName())
+	})
+}
+
+func TestListCollections(t *testing.T) {
+	t.Run("V25Path", func(t *testing.T) {
+		_, r := setupTestEtcd()
+		colls, err := r.listCollections(context.Background(), 1)
+		assert.NoError(t, err)
+		assert.Len(t, colls, 1)
+		assert.Equal(t, "test_coll", colls[0].GetSchema().GetName())
+	})
+
+	t.Run("LegacyFallback", func(t *testing.T) {
+		kv := newMockKV()
+		kv.put("r/meta/root-coord/collection/100", &etcdpb.CollectionInfo{
+			ID: 100, Schema: &schemapb.CollectionSchema{Name: "legacy_coll"},
+		})
+		r := &reader{cli: kv, rootPath: "r"}
+		colls, err := r.listCollections(context.Background(), 0)
+		assert.NoError(t, err)
+		assert.Len(t, colls, 1)
+		assert.Equal(t, "legacy_coll", colls[0].GetSchema().GetName())
+	})
+
+	t.Run("NoFallbackForNonZeroDB", func(t *testing.T) {
+		r := &reader{cli: newMockKV(), rootPath: "empty"}
+		colls, err := r.listCollections(context.Background(), 99)
+		assert.NoError(t, err)
+		assert.Empty(t, colls)
+	})
+}
+
+func TestListFields(t *testing.T) {
+	_, r := setupTestEtcd()
+	fields, err := r.listFields(context.Background(), 100)
+	assert.NoError(t, err)
+	assert.Len(t, fields, 2)
+}
+
+func TestListPartitions(t *testing.T) {
+	_, r := setupTestEtcd()
+	parts, err := r.listPartitions(context.Background(), 100)
+	assert.NoError(t, err)
+	assert.Len(t, parts, 2)
+}
+
+func TestListIndexes(t *testing.T) {
+	_, r := setupTestEtcd()
+	indexes, err := r.listIndexes(context.Background(), 100)
+	assert.NoError(t, err)
+	assert.Len(t, indexes, 1)
+	assert.Equal(t, "idx_vec", indexes[0].IndexName)
+	assert.Equal(t, "IVF_FLAT", indexes[0].IndexParams["index_type"])
+}
+
+func TestListFunctions(t *testing.T) {
+	_, r := setupTestEtcd()
+	funcs, err := r.listFunctions(context.Background(), 100)
+	assert.NoError(t, err)
+	assert.Len(t, funcs, 1)
+	assert.Equal(t, "bm25", funcs[0].Name)
+	assert.Equal(t, []int64{3}, funcs[0].InputFieldIDs)
+}
+
+func TestLoadCollectionDetail(t *testing.T) {
+	_, r := setupTestEtcd()
+	coll := &etcdpb.CollectionInfo{
+		ID: 100, DbId: 1, ShardsNum: 2,
+		Schema: &schemapb.CollectionSchema{
+			Name: "test_coll",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 2, Name: "vec", DataType: schemapb.DataType_FloatVector},
+			},
+		},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	}
+
+	t.Run("FullDump", func(t *testing.T) {
+		dump, err := r.loadCollectionDetail(context.Background(), coll)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(100), dump.ID)
+		assert.Equal(t, "test_coll", dump.Name)
+		assert.Equal(t, int32(2), dump.ShardsNum)
+		assert.Len(t, dump.Fields, 2)
+		assert.Equal(t, "FieldCreated", dump.Fields[0].State)
+		assert.Len(t, dump.Partitions, 2)
+		assert.Len(t, dump.Indexes, 1)
+		assert.Len(t, dump.Functions, 1)
+	})
+
+	t.Run("SortedByID", func(t *testing.T) {
+		dump, err := r.loadCollectionDetail(context.Background(), coll)
+		assert.NoError(t, err)
+		assert.True(t, dump.Fields[0].FieldID < dump.Fields[1].FieldID)
+		assert.True(t, dump.Partitions[0].PartitionID < dump.Partitions[1].PartitionID)
+	})
+}
+
+func TestFindCollection(t *testing.T) {
+	_, r := setupTestEtcd()
+
+	t.Run("Found", func(t *testing.T) {
+		dump, err := r.findCollection(context.Background(), "", "test_coll")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(100), dump.ID)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := r.findCollection(context.Background(), "", "nonexistent")
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("FilterByDBNoMatch", func(t *testing.T) {
+		_, err := r.findCollection(context.Background(), "other_db", "test_coll")
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("FilterByDBMatch", func(t *testing.T) {
+		dump, err := r.findCollection(context.Background(), "default", "test_coll")
+		assert.NoError(t, err)
+		assert.Equal(t, "test_coll", dump.Name)
+	})
+
+	t.Run("MultipleDBsAmbiguous", func(t *testing.T) {
+		kv := newMockKV()
+		kv.put("r/meta/root-coord/database/db-info/1", &etcdpb.DatabaseInfo{Id: 1, Name: "db1", State: etcdpb.DatabaseState_DatabaseCreated})
+		kv.put("r/meta/root-coord/database/db-info/2", &etcdpb.DatabaseInfo{Id: 2, Name: "db2", State: etcdpb.DatabaseState_DatabaseCreated})
+		kv.put("r/meta/root-coord/database/collection-info/1/100", &etcdpb.CollectionInfo{
+			ID: 100, DbId: 1, Schema: &schemapb.CollectionSchema{Name: "dup"},
+		})
+		kv.put("r/meta/root-coord/database/collection-info/2/200", &etcdpb.CollectionInfo{
+			ID: 200, DbId: 2, Schema: &schemapb.CollectionSchema{Name: "dup"},
+		})
+		r := &reader{cli: kv, rootPath: "r"}
+
+		_, err := r.findCollection(context.Background(), "", "dup")
+		assert.ErrorContains(t, err, "multiple databases")
+	})
+
+	t.Run("MultipleDBsResolved", func(t *testing.T) {
+		kv := newMockKV()
+		kv.put("r/meta/root-coord/database/db-info/1", &etcdpb.DatabaseInfo{Id: 1, Name: "db1", State: etcdpb.DatabaseState_DatabaseCreated})
+		kv.put("r/meta/root-coord/database/db-info/2", &etcdpb.DatabaseInfo{Id: 2, Name: "db2", State: etcdpb.DatabaseState_DatabaseCreated})
+		kv.put("r/meta/root-coord/database/collection-info/1/100", &etcdpb.CollectionInfo{
+			ID: 100, DbId: 1, Schema: &schemapb.CollectionSchema{Name: "dup"},
+		})
+		kv.put("r/meta/root-coord/database/collection-info/2/200", &etcdpb.CollectionInfo{
+			ID: 200, DbId: 2, Schema: &schemapb.CollectionSchema{Name: "dup"},
+		})
+		r := &reader{cli: kv, rootPath: "r"}
+
+		dump, err := r.findCollection(context.Background(), "db2", "dup")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(200), dump.ID)
+	})
+}

--- a/cmd/etcd-schema-verify/main.go
+++ b/cmd/etcd-schema-verify/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	srcEndpoints := flag.String("src-endpoints", "", "source etcd endpoints (comma-separated, required)")
+	dstEndpoints := flag.String("dst-endpoints", "", "destination etcd endpoints (comma-separated, required)")
+	srcRootPath := flag.String("src-root-path", "by-dev", "source Milvus etcd rootPath")
+	dstRootPath := flag.String("dst-root-path", "by-dev", "destination Milvus etcd rootPath")
+	collection := flag.String("collection", "", "collection name to verify (required)")
+	dbName := flag.String("db", "", "database name (optional, scans all databases if empty)")
+	timeout := flag.Duration("timeout", 30*time.Second, "etcd operation timeout")
+	flag.Parse()
+
+	if *collection == "" || *srcEndpoints == "" || *dstEndpoints == "" {
+		fmt.Fprintf(os.Stderr, "Usage: etcd-schema-verify --src-endpoints=HOST:PORT --dst-endpoints=HOST:PORT --collection=NAME\n\n")
+		flag.PrintDefaults()
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	srcCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(*srcEndpoints, ","),
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: connect source etcd: %v\n", err)
+		return 1
+	}
+	defer srcCli.Close() //nolint:errcheck // best-effort cleanup
+
+	dstCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(*dstEndpoints, ","),
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: connect destination etcd: %v\n", err)
+		return 1
+	}
+	defer dstCli.Close() //nolint:errcheck // best-effort cleanup
+
+	srcReader := &reader{cli: srcCli, rootPath: *srcRootPath}
+	srcDump, err := srcReader.findCollection(ctx, *dbName, *collection)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: source: %v\n", err)
+		return 1
+	}
+
+	dstReader := &reader{cli: dstCli, rootPath: *dstRootPath}
+	dstDump, err := dstReader.findCollection(ctx, *dbName, *collection)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: target: %v\n", err)
+		return 1
+	}
+
+	diffs := diffCollections(srcDump, dstDump)
+
+	result := &VerifyResult{
+		Collection: *collection,
+		Database:   *dbName,
+		Aligned:    len(diffs) == 0,
+		Source:     srcDump,
+		Target:     dstDump,
+		Diffs:      diffs,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "error: encode JSON: %v\n", err)
+		return 1
+	}
+
+	if !result.Aligned {
+		return 1
+	}
+	return 0
+}

--- a/cmd/etcd-schema-verify/types.go
+++ b/cmd/etcd-schema-verify/types.go
@@ -1,0 +1,94 @@
+package main
+
+// VerifyResult is the top-level JSON output.
+type VerifyResult struct {
+	Collection string          `json:"collection"`
+	Database   string          `json:"database,omitempty"`
+	Aligned    bool            `json:"aligned"`
+	Source     *CollectionDump `json:"source"`
+	Target     *CollectionDump `json:"target"`
+	Diffs      []Diff          `json:"diffs"`
+}
+
+// Diff represents a single difference between source and target.
+type Diff struct {
+	Path string `json:"path"`
+	Src  string `json:"src"`
+	Dst  string `json:"dst"`
+}
+
+// CollectionDump is the full schema snapshot read from one etcd.
+type CollectionDump struct {
+	ID               int64             `json:"id"`
+	DBID             int64             `json:"db_id"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	State            string            `json:"state"`
+	ShardsNum        int32             `json:"shards_num"`
+	ConsistencyLevel string            `json:"consistency_level"`
+	Properties       map[string]string `json:"properties,omitempty"`
+
+	Fields     []FieldDump     `json:"fields"`
+	Partitions []PartitionDump `json:"partitions"`
+	Indexes    []IndexDump     `json:"indexes,omitempty"`
+	Functions  []FunctionDump  `json:"functions,omitempty"`
+
+	// Display-only, skipped in comparison
+	CreateTime           uint64   `json:"create_timestamp"`
+	UpdateTimestamp      uint64   `json:"update_timestamp"`
+	VirtualChannelNames  []string `json:"virtual_channel_names"`
+	PhysicalChannelNames []string `json:"physical_channel_names"`
+}
+
+// FieldDump holds one field's metadata.
+type FieldDump struct {
+	FieldID          int64             `json:"field_id"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	DataType         string            `json:"data_type"`
+	ElementType      string            `json:"element_type,omitempty"`
+	TypeParams       map[string]string `json:"type_params,omitempty"`
+	IndexParams      map[string]string `json:"index_params,omitempty"`
+	IsPrimaryKey     bool              `json:"is_primary_key"`
+	AutoID           bool              `json:"auto_id"`
+	IsPartitionKey   bool              `json:"is_partition_key"`
+	IsClusteringKey  bool              `json:"is_clustering_key"`
+	IsFunctionOutput bool              `json:"is_function_output"`
+	Nullable         bool              `json:"nullable"`
+	DefaultValue     string            `json:"default_value,omitempty"`
+	State            string            `json:"state,omitempty"`
+}
+
+// PartitionDump holds one partition's metadata.
+type PartitionDump struct {
+	PartitionID      int64  `json:"partition_id"`
+	PartitionName    string `json:"partition_name"`
+	State            string `json:"state"`
+	CreatedTimestamp uint64 `json:"created_timestamp"`
+}
+
+// IndexDump holds one index's metadata.
+type IndexDump struct {
+	IndexID         int64             `json:"index_id"`
+	IndexName       string            `json:"index_name"`
+	FieldID         int64             `json:"field_id"`
+	TypeParams      map[string]string `json:"type_params,omitempty"`
+	IndexParams     map[string]string `json:"index_params,omitempty"`
+	UserIndexParams map[string]string `json:"user_index_params,omitempty"`
+	IsAutoIndex     bool              `json:"is_auto_index"`
+	State           string            `json:"state"`
+	Deleted         bool              `json:"deleted"`
+}
+
+// FunctionDump holds one function's metadata.
+type FunctionDump struct {
+	ID               int64             `json:"id"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	Type             string            `json:"type"`
+	InputFieldIDs    []int64           `json:"input_field_ids"`
+	InputFieldNames  []string          `json:"input_field_names"`
+	OutputFieldIDs   []int64           `json:"output_field_ids"`
+	OutputFieldNames []string          `json:"output_field_names"`
+	Params           map[string]string `json:"params,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add standalone tool `cmd/etcd-schema-verify` that reads collection metadata directly from etcd and compares source vs target schemas at the etcd level
- Covers fields invisible to DescribeCollection: internal field IDs, field states, index params, partition states, function schemas
- CDC scenario aware: compares all IDs (collection/field/partition/index) since they are preserved across clusters
- Integrate into secondary restore CI to verify schema alignment after restore

## Changes
- `cmd/etcd-schema-verify/` — standalone Go binary with flag-based CLI
  - Reads databases, collections, fields, partitions, indexes, functions from etcd via protobuf deserialization
  - Diff logic matches by ID, outputs JSON with `aligned` flag and detailed diffs
  - Exit code 1 when not aligned (CI friendly)
- `.github/workflows/main.yaml` — build the tool and run it after secondary restore for `hello_milvus` and `hello_milvus2`

/kind improvement