### PR TITLE
ci: add cross-version matrix to repro $meta misalignment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -572,12 +572,28 @@ jobs:
 
   test-backup-restore-secondary:
     needs: unit-test-go
-    name: Backup and restore secondary
+    name: Backup and restore secondary (${{ matrix.scenario }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        image_tag: [master-latest]
+        # Two scenarios:
+        #   - same-version:          source and target are both the latest master.
+        #   - cross-version-upgrade: source data is created on a pre-#46419 Milvus
+        #     (v2.6.7, where the auto-appended $meta field has no Nullable nor
+        #     DefaultValue), then the cluster is upgraded to a CDC-capable image
+        #     (2.6-latest, since CDC support landed in v2.6.11+) before backup
+        #     and secondary restore. This reproduces the schema misalignment from
+        #     zilliztech/milvus-backup#1013 — etcd-schema-verify is expected to
+        #     fail on the $meta field's nullable/default_value until the bug is
+        #     fixed.
+        include:
+          - scenario: same-version
+            prepare_image_tag: master-latest
+            run_image_tag: master-latest
+          - scenario: cross-version-upgrade
+            prepare_image_tag: v2.6.7
+            run_image_tag: 2.6-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -610,15 +626,15 @@ jobs:
         run: |
           pip install -r requirements.txt --trusted-host https://test.pypi.org
 
-      - name: Deploy dual Milvus
+      - name: Deploy dual Milvus (prepare image)
         timeout-minutes: 15
         shell: bash
         working-directory: deployment/secondary
         run: |
-          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.prepare_image_tag }}) && echo $tag
           yq -i ".services.upstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           yq -i ".services.downstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
-          if [ "${{ matrix.image_tag }}" == "master-latest" ]; then
+          if [ "${{ matrix.prepare_image_tag }}" == "master-latest" ]; then
             yq -i '.common.storage.useLoonFFI = false' upstream.yaml
             yq -i '.common.storage.useLoonFFI = false' downstream.yaml
           fi
@@ -658,6 +674,26 @@ jobs:
         run: |
           python example/prepare_data.py --uri http://127.0.0.1:19530
 
+      - name: Upgrade dual Milvus to run image
+        if: ${{ matrix.prepare_image_tag != matrix.run_image_tag }}
+        timeout-minutes: 15
+        shell: bash
+        working-directory: deployment/secondary
+        run: |
+          # Stop containers but keep bind-mounted volumes (./volumes/*) so the
+          # collection schema written by the prepare image — including its
+          # version-specific $meta attributes — survives the upgrade.
+          sudo docker compose -f docker-compose.yml down
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.run_image_tag }}) && echo $tag
+          yq -i ".services.upstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          yq -i ".services.downstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          if [ "${{ matrix.run_image_tag }}" == "master-latest" ]; then
+            yq -i '.common.storage.useLoonFFI = false' upstream.yaml
+            yq -i '.common.storage.useLoonFFI = false' downstream.yaml
+          fi
+          sudo docker compose -f docker-compose.yml up -d --wait
+          sudo docker compose -f docker-compose.yml ps -a
+
       - name: Create index and load on upstream
         timeout-minutes: 3
         shell: bash
@@ -666,7 +702,7 @@ jobs:
           from pymilvus import connections, Collection
           connections.connect('default', uri='http://127.0.0.1:19530')
           index = {'index_type': 'IVF_FLAT', 'metric_type': 'L2', 'params': {'nlist': 128}}
-          for name in ['hello_milvus', 'hello_milvus2']:
+          for name in ['hello_milvus', 'hello_milvus2', 'hello_milvus_dynamic']:
               c = Collection(name)
               c.create_index('embeddings', index)
               c.load()
@@ -718,7 +754,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          for coll in hello_milvus hello_milvus2; do
+          for coll in hello_milvus hello_milvus2 hello_milvus_dynamic; do
             echo "=== Verifying schema: ${coll} ==="
             ./etcd-schema-verify \
               -src-endpoints localhost:2379 \
@@ -766,7 +802,7 @@ jobs:
         if: ${{ ! success() }}
         uses: actions/upload-artifact@v7
         with:
-          name: secondary-restore-logs-${{ matrix.image_tag }}
+          name: secondary-restore-logs-${{ matrix.scenario }}
           path: |
             /tmp/ci_logs
             /tmp/schema_verify_*.json

--- a/example/prepare_data.py
+++ b/example/prepare_data.py
@@ -164,6 +164,55 @@ def main(uri="http://127.0.0.1:19530", token="root:Milvus", stage=None, total_en
         print(fmt.format(f"Stage {stage} completed for hello_milvus2"))
         print(f"Stage {stage} inserted {num_entities2} entities starting from offset {entity_offset2}")
 
+    # hello_milvus_dynamic exercises the dynamic schema path. The $meta field
+    # attributes are version-dependent (Milvus #46419 added Nullable=true and
+    # DefaultValue={} starting from v2.6.8 / master), so creating this collection
+    # on a pre-#46419 Milvus and then doing secondary restore reproduces the
+    # schema misalignment described in zilliztech/milvus-backup#1013.
+    fields_dynamic = [
+        FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=False),
+        FieldSchema(name="random", dtype=DataType.DOUBLE),
+        FieldSchema(name="var", dtype=DataType.VARCHAR, max_length=65535),
+        FieldSchema(name="embeddings", dtype=DataType.FLOAT_VECTOR, dim=dim),
+    ]
+    schema_dynamic = CollectionSchema(
+        fields_dynamic, "hello_milvus_dynamic", enable_dynamic_field=True
+    )
+
+    print(fmt.format("Create collection `hello_milvus_dynamic`"))
+    hello_milvus_dynamic = Collection(
+        "hello_milvus_dynamic", schema_dynamic, consistency_level="Strong"
+    )
+
+    if stage != 2:
+        print(fmt.format("Start inserting entities to hello_milvus_dynamic"))
+        num_entities_d = total_entities
+        rng_d = np.random.default_rng(seed=19531)
+        rows = []
+        for i in range(num_entities_d):
+            row = {
+                "pk": i,
+                "random": float(rng_d.random()),
+                "var": str(i),
+                "embeddings": rng_d.random(dim).tolist(),
+                # Populate dynamic fields on every row so the collection has
+                # real dynamic schema usage, not just a declared $meta field.
+                "extra_int": i,
+                "extra_str": f"dyn_{i}",
+            }
+            rows.append(row)
+
+        batch_size = max(1, num_entities_d // 10)
+        for j in range(0, num_entities_d, batch_size):
+            hello_milvus_dynamic.insert(rows[j : j + batch_size])
+            time.sleep(1)
+        hello_milvus_dynamic.flush()
+        print(
+            f"Number of entities in hello_milvus_dynamic: {hello_milvus_dynamic.num_entities}"
+        )
+    else:
+        print("Stage 2: Skipping data insertion to hello_milvus_dynamic")
+
 
 if __name__ == "__main__":
     args = argparse.ArgumentParser(description="prepare data for backup/restore testing")

--- a/example/secondary/verify_data.py
+++ b/example/secondary/verify_data.py
@@ -23,8 +23,10 @@ def main(uri, token):
     print(fmt.format(f"Milvus uri: {uri}"))
     connections.connect("default", uri=uri, token=token)
 
-    # Secondary restore uses original collection names (no _recover suffix)
-    collections = ["hello_milvus", "hello_milvus2"]
+    # Secondary restore uses original collection names (no _recover suffix).
+    # hello_milvus_dynamic exercises the dynamic-schema path; see
+    # zilliztech/milvus-backup#1013 for the $meta misalignment it covers.
+    collections = ["hello_milvus", "hello_milvus2", "hello_milvus_dynamic"]
 
     for collection_name in collections:
         has = utility.has_collection(collection_name)


### PR DESCRIPTION
## Summary

Reproduce the `$meta` field schema misalignment from #1013 in CI by adding a dynamic-schema collection and a new matrix scenario that prepares data on a pre-#46419 Milvus before upgrading to a CDC-capable image for backup/restore.

This is a TDD red test — the new `cross-version-upgrade` matrix entry is expected to fail on `etcd-schema-verify` until the underlying bug is fixed.

## Changes

- `example/prepare_data.py`: add `hello_milvus_dynamic` collection (`enable_dynamic_field=True`, 3000 rows, dynamic fields populated on every row)
- `example/secondary/verify_data.py`: include the new collection in the post-restore verification list
- `.github/workflows/main.yaml` (`test-backup-restore-secondary`):
  - Replace single `image_tag` matrix with `prepare_image_tag` / `run_image_tag` / `scenario` `include` matrix
  - Add `cross-version-upgrade` scenario: prepare on `v2.6.7`, upgrade to `2.6-latest` before backup/restore (CDC support landed in v2.6.11+; volumes are bind-mounted so the pre-#46419 `$meta` schema survives the upgrade)
  - Add new `Upgrade dual Milvus to run image` step, conditional on `prepare != run`
  - Wire `hello_milvus_dynamic` into the index/load step and the `etcd-schema-verify` loop

## Expected CI behavior

| scenario | bug not fixed | bug fixed |
|---|---|---|
| `same-version` (master → master) | pass — both sides have `Nullable=true, DefaultValue={}`, matches the hardcoded restore values | pass |
| `cross-version-upgrade` (v2.6.7 → 2.6-latest) | **fail** — source `$meta` (created on v2.6.7) has no `Nullable` / `DefaultValue`; secondary restore reconstructs it with the hardcoded values, etcd-schema-verify reports a diff | pass |

Related to #1013

/kind improvement