### PR TITLE
milvus: use strict semver to parse server version for feature check

### DIFF
--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -57,9 +57,10 @@ type featureTuple struct {
 	Flag        FeatureFlag
 }
 
-// _latestDevVersion is used as a fallback when the server returns a non-semver version
-// string (e.g. "master-20260226-abcdef" from dev builds). It ensures lower-bound
-// constraints (>= X) pass while upper-bound constraints (< Y) correctly fail.
+// _latestDevVersion is used as a fallback when the server returns a version string
+// that is not a strict MAJOR.MINOR.PATCH semver (e.g. "master-20260226-abcdef" or
+// "2.6-20260404-31fb3fc" from dev builds). It ensures lower-bound constraints (>= X)
+// pass while upper-bound constraints (< Y) correctly fail.
 var _latestDevVersion = semver.MustParse("99.0.0")
 
 var _featureTuples = []featureTuple{
@@ -444,13 +445,7 @@ func (g *GrpcClient) checkFeature(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("client: get version: %w", err)
 	}
-	sem, err := semver.NewVersion(ver)
-	if err != nil {
-		// Dev/master builds may return non-semver strings like "master-20260226-abcdef".
-		g.logger.Warn("cannot parse server version as semver, treat as latest dev build",
-			zap.String("version", ver), zap.Error(err))
-		sem = _latestDevVersion
-	}
+	sem := g.parseVersionForFeature(ver)
 
 	for _, tuple := range _featureTuples {
 		if tuple.Constraints.Check(sem) {
@@ -462,6 +457,26 @@ func (g *GrpcClient) checkFeature(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// parseVersionForFeature parses a server version for feature constraint checking.
+//
+// It strips an optional leading "v" (Milvus releases report build tags like "v2.2.16")
+// and then uses StrictNewVersion, which requires MAJOR.MINOR.PATCH. This deliberately
+// rejects dev build tags like "2.6-20260404-31fb3fc" or "master-20260226-abcdef" so
+// they fall through to _latestDevVersion.
+//
+// The lenient semver.NewVersion cannot be used here because it parses
+// "2.6-20260404-31fb3fc" as "2.6.0-20260404-31fb3fc" — a prerelease of 2.6.0 — which
+// compares LESS than 2.6.x and silently disables features on dev builds.
+func (g *GrpcClient) parseVersionForFeature(ver string) *semver.Version {
+	sem, err := semver.StrictNewVersion(strings.TrimPrefix(ver, "v"))
+	if err != nil {
+		g.logger.Warn("cannot parse server version as strict semver, treat as latest dev build",
+			zap.String("version", ver), zap.Error(err))
+		return _latestDevVersion
+	}
+	return sem
 }
 
 func (g *GrpcClient) CreateDatabase(ctx context.Context, dbName string) error {

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -179,6 +180,55 @@ func TestReplicateMessageConstraint(t *testing.T) {
 				}
 			}
 			t.Fatal("ReplicateMessage not found in _featureTuples")
+		})
+	}
+}
+
+func TestGrpcClient_parseVersionForFeature(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		wantConstraint string
+		wantPass       bool
+	}{
+		// Strict semver: real release versions match constraints based on actual values.
+		{"Release2.6.0_NoMultiL0", "2.6.0", ">= 2.6.5-0", false},
+		{"Release2.6.5_HasMultiL0", "2.6.5", ">= 2.6.5-0", true},
+		{"Release2.6.11_HasFlushAll", "2.6.11", ">= 2.6.11-0", true},
+		{"Release2.6.10_NoFlushAll", "2.6.10", ">= 2.6.11-0", false},
+
+		// Milvus releases report build tags with a leading "v" (e.g. "v2.2.16").
+		// Without v-prefix stripping these would fall back to _latestDevVersion and
+		// incorrectly enable features the old release does not implement (e.g.
+		// DescribeDatabase on v2.2.16, which then crashes with Unimplemented).
+		{"VPrefixV2.2.16_NoDescribeDatabase", "v2.2.16", ">= 2.4.3-0", false},
+		{"VPrefixV2.3.22_NoDescribeDatabase", "v2.3.22", ">= 2.4.3-0", false},
+		{"VPrefixV2.4.23_HasDescribeDatabase", "v2.4.23", ">= 2.4.3-0", true},
+		{"VPrefixV2.5.20_NoMultiL0", "v2.5.20", ">= 2.6.5-0", false},
+		{"VPrefixV2.6.5_HasMultiL0", "v2.6.5", ">= 2.6.5-0", true},
+		{"VPrefixV2.5.20_HasReplicateMessage", "v2.5.20", ">= 2.5.0-0, < 2.6.0-0", true},
+
+		// Dev RC tag: must be treated as latest dev (and pass all >= constraints).
+		// Without StrictNewVersion this regresses: lenient parser turns it into
+		// 2.6.0-20260404-31fb3fc, which is LESS than 2.6.5-0 and disables features.
+		{"DevTag2.6_HasMultiL0", "2.6-20260404-31fb3fc", ">= 2.6.5-0", true},
+		{"DevTag2.6_HasFlushAll", "2.6-20260404-31fb3fc", ">= 2.6.11-0", true},
+		{"DevTag2.6_HasGC", "2.6-20260404-31fb3fc", ">= 2.6.8-0", true},
+
+		// Master tag: also treated as latest dev.
+		{"MasterTag_HasFlushAll", "master-20260226-abcdef", ">= 2.6.11-0", true},
+
+		// Empty string: also falls back to dev.
+		{"Empty_HasFlushAll", "", ">= 2.6.11-0", true},
+	}
+
+	cli := &GrpcClient{logger: zap.NewNop()}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sem := cli.parseVersionForFeature(tt.version)
+			constraint, err := semver.NewConstraint(tt.wantConstraint)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPass, constraint.Check(sem))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
The lenient `semver.NewVersion` parses Milvus dev RC build tags like `2.6-20260404-31fb3fc` as `2.6.0-20260404-31fb3fc`, a prerelease of `2.6.0`. By semver precedence rules, a version with a prerelease suffix compares **less** than the same `MAJOR.MINOR.PATCH` without one, so this dev tag ends up below `2.6.5-0`, `2.6.8-0` and `2.6.11-0`. As a result, `MultiL0InOneJob`, `FlushAll`, `CollectionLevelGCControl` and `FuncRuntimeCheck` are silently disabled when running against a tip-of-2.6 dev build.

Switch `checkFeature` to `semver.StrictNewVersion`, which requires `MAJOR.MINOR.PATCH`. Non-strict tags (`2.6-20260404-31fb3fc`, `master-20260226-abcdef`, `""`) now fall through to `_latestDevVersion` and pass all `>= X` constraints, restoring the intended behavior.

The early-return in `GetVersion` keeps the lenient parser on purpose: it is only a "skip extra RPC" sanity check, not a constraint comparison, so widening it to strict would just cost an extra RPC round-trip with no behavioral benefit.

## Changes
- Extract `parseServerVersionForFeature` helper that uses `semver.StrictNewVersion` and falls back to `_latestDevVersion` on failure
- Use the helper from `checkFeature`
- Add `TestParseServerVersionForFeature` covering release versions (`2.6.0` / `2.6.5` / `2.6.10` / `2.6.11`), the `2.6-20260404-31fb3fc` dev tag, master tags, and the empty string
- Update the `_latestDevVersion` doc comment to mention the `2.6-…` tag form

/kind improvement