### PR TITLE
backup: capture dynamic field schema from etcd for secondary restore

### DIFF
--- a/core/backup/coll_dyn_field_task.go
+++ b/core/backup/coll_dyn_field_task.go
@@ -1,0 +1,115 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/zilliztech/milvus-backup/internal/log"
+)
+
+// collDynFieldTask reads the dynamic field ($meta) schema for each collection
+// directly from etcd. The Milvus DescribeCollection API filters out fields
+// with IsDynamic == true (see milvus internal/proxy/task.go), so the backup
+// metadata gathered via gRPC never contains the actual $meta field attributes
+// (Nullable, DefaultValue, ...). This causes secondary restore to misalign
+// the $meta field schema. See zilliztech/milvus-backup#1013.
+type collDynFieldTask struct {
+	taskID string
+
+	kv clientv3.KV
+
+	etcdRootPath string
+
+	metaBuilder *metaBuilder
+
+	logger *zap.Logger
+}
+
+func newCollDynFieldTask(taskID string, kv clientv3.KV, etcdRootPath string, metaBuilder *metaBuilder) *collDynFieldTask {
+	return &collDynFieldTask{
+		taskID:       taskID,
+		kv:           kv,
+		etcdRootPath: etcdRootPath,
+		metaBuilder:  metaBuilder,
+		logger:       log.With(zap.String("task_id", taskID)),
+	}
+}
+
+func (cdft *collDynFieldTask) Execute(ctx context.Context) error {
+	// Milvus stores collection field schemas under
+	//   {MetaRootPath}/root-coord/fields/{collectionID}/{fieldID}
+	// where MetaRootPath is "{etcdRootPath}/meta" in milvus-backup config terms.
+	prefix := fmt.Sprintf("%s/meta/root-coord/fields/", cdft.etcdRootPath)
+	cdft.logger.Info("start to get field schemas from etcd", zap.String("prefix", prefix))
+	resp, err := cdft.kv.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("backup: get field schemas from etcd %w", err)
+	}
+	cdft.logger.Info("get field schemas from etcd done", zap.Int("count", len(resp.Kvs)))
+
+	dynFields := make(map[int64]*schemapb.FieldSchema)
+	for _, kv := range resp.Kvs {
+		collID, ok := parseCollIDFromFieldKey(string(kv.Key), prefix)
+		if !ok {
+			cdft.logger.Warn("skip field with unparsable key", zap.String("key", string(kv.Key)))
+			continue
+		}
+		field := &schemapb.FieldSchema{}
+		if err := proto.Unmarshal(kv.Value, field); err != nil {
+			// The key may be a tombstone or a non-FieldSchema payload, skip
+			// rather than fail the whole backup.
+			cdft.logger.Warn("skip field that cannot be unmarshalled",
+				zap.String("key", string(kv.Key)), zap.Error(err))
+			continue
+		}
+		if !field.GetIsDynamic() {
+			continue
+		}
+		if existing, ok := dynFields[collID]; ok {
+			cdft.logger.Warn("multiple dynamic fields found for one collection, keeping the first",
+				zap.Int64("collection_id", collID),
+				zap.Int64("existing_field_id", existing.GetFieldID()),
+				zap.Int64("duplicate_field_id", field.GetFieldID()))
+			continue
+		}
+		cdft.logger.Info("found dynamic field",
+			zap.String("key", string(kv.Key)),
+			zap.Int64("collection_id", collID),
+			zap.Int64("field_id", field.GetFieldID()),
+			zap.String("name", field.GetName()),
+			zap.Bool("nullable", field.GetNullable()))
+		dynFields[collID] = field
+	}
+
+	if err := cdft.metaBuilder.addDynamicFields(dynFields); err != nil {
+		return err
+	}
+
+	cdft.logger.Info("backup dynamic field info done", zap.Int("dynamic_field_count", len(dynFields)))
+	return nil
+}
+
+// parseCollIDFromFieldKey parses the collection id from an etcd field key like
+// "{prefix}{collectionID}/{fieldID}".
+func parseCollIDFromFieldKey(key, prefix string) (int64, bool) {
+	if !strings.HasPrefix(key, prefix) {
+		return 0, false
+	}
+	rest := strings.TrimPrefix(key, prefix)
+	idx := strings.Index(rest, "/")
+	if idx <= 0 {
+		return 0, false
+	}
+	collID, err := strconv.ParseInt(rest[:idx], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return collID, true
+}

--- a/core/backup/coll_dyn_field_task_test.go
+++ b/core/backup/coll_dyn_field_task_test.go
@@ -1,0 +1,37 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCollIDFromFieldKey(t *testing.T) {
+	prefix := "by-dev/meta/root-coord/fields/"
+
+	t.Run("ValidKey", func(t *testing.T) {
+		collID, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/12345/678", prefix)
+		assert.True(t, ok)
+		assert.Equal(t, int64(12345), collID)
+	})
+
+	t.Run("PrefixMismatch", func(t *testing.T) {
+		_, ok := parseCollIDFromFieldKey("by-dev/meta/other/12345/678", prefix)
+		assert.False(t, ok)
+	})
+
+	t.Run("MissingFieldIDSegment", func(t *testing.T) {
+		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/12345", prefix)
+		assert.False(t, ok)
+	})
+
+	t.Run("EmptyCollectionID", func(t *testing.T) {
+		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields//678", prefix)
+		assert.False(t, ok)
+	})
+
+	t.Run("NonNumericCollectionID", func(t *testing.T) {
+		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/abc/678", prefix)
+		assert.False(t, ok)
+	})
+}

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -1,12 +1,15 @@
 package backup
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sync"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/log"
@@ -155,6 +158,72 @@ func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) {
 		indexInfo.MinIndexVersion = info.GetMinIndexVersion()
 		indexInfo.MaxIndexVersion = info.GetMaxIndexVersion()
 	}
+}
+
+// addDynamicFields injects the dynamic field schema (read directly from etcd)
+// into each collection backup that has dynamic schema enabled. The Milvus
+// DescribeCollection API filters out IsDynamic fields, so without this the
+// backup metadata is missing the actual $meta field attributes (Nullable,
+// DefaultValue) and secondary restore would have to reconstruct it blindly.
+// See zilliztech/milvus-backup#1013.
+//
+// Returns an error if any collection has EnableDynamicField=true but the
+// caller did not supply a matching dynamic field. We treat this as a hard
+// failure rather than silently producing an incomplete backup, since the
+// resulting file would break secondary restore.
+func (builder *metaBuilder) addDynamicFields(dynFields map[int64]*schemapb.FieldSchema) error {
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	for _, coll := range builder.data.GetCollectionBackups() {
+		if !coll.GetSchema().GetEnableDynamicField() {
+			continue
+		}
+
+		dynField, ok := dynFields[coll.GetCollectionId()]
+		if !ok {
+			return fmt.Errorf("backup: %q missing dynamic field in etcd", coll.GetCollectionName())
+		}
+
+		bakField, err := convDynField(dynField)
+		if err != nil {
+			return fmt.Errorf("backup: convert dynamic field of %q: %w", coll.GetCollectionName(), err)
+		}
+		coll.Schema.Fields = append(coll.Schema.Fields, bakField)
+	}
+
+	return nil
+}
+
+// convDynField converts a milvus schemapb.FieldSchema (read from etcd) into
+// the backup proto FieldSchema. It only fills the subset of attributes that
+// matter for the dynamic field ($meta).
+func convDynField(field *schemapb.FieldSchema) (*backuppb.FieldSchema, error) {
+	var defaultValueBase64 string
+	if field.GetDefaultValue() != nil {
+		bytes, err := proto.Marshal(field.GetDefaultValue())
+		if err != nil {
+			return nil, fmt.Errorf("backup: marshal dynamic field default value: %w", err)
+		}
+		defaultValueBase64 = base64.StdEncoding.EncodeToString(bytes)
+	}
+
+	return &backuppb.FieldSchema{
+		FieldID:            field.GetFieldID(),
+		Name:               field.GetName(),
+		IsPrimaryKey:       field.GetIsPrimaryKey(),
+		Description:        field.GetDescription(),
+		AutoID:             field.GetAutoID(),
+		DataType:           backuppb.DataType(field.GetDataType()),
+		TypeParams:         pbconv.MilvusKVToBakKV(field.GetTypeParams()),
+		IndexParams:        pbconv.MilvusKVToBakKV(field.GetIndexParams()),
+		IsDynamic:          field.GetIsDynamic(),
+		IsPartitionKey:     field.GetIsPartitionKey(),
+		Nullable:           field.GetNullable(),
+		ElementType:        backuppb.DataType(field.GetElementType()),
+		IsFunctionOutput:   field.GetIsFunctionOutput(),
+		DefaultValueBase64: defaultValueBase64,
+	}, nil
 }
 
 func (builder *metaBuilder) setRBACMeta(rbacMeta *backuppb.RBACMeta) {

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -1,10 +1,13 @@
 package backup
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -174,6 +177,96 @@ func TestBuildFullMetaContainsEverything(t *testing.T) {
 		totalSegs += len(part.GetSegmentBackups())
 	}
 	assert.Equal(t, 2, totalSegs)
+}
+
+func TestAddDynamicFields(t *testing.T) {
+	t.Run("InjectsDynamicFieldFromEtcd", func(t *testing.T) {
+		builder := newMetaBuilder("task1", "backup1")
+
+		ns := namespace.New("db1", "coll1")
+		coll := &backuppb.CollectionBackupInfo{
+			CollectionId:   1,
+			DbName:         "db1",
+			CollectionName: "coll1",
+			Schema: &backuppb.CollectionSchema{
+				Name:               "coll1",
+				EnableDynamicField: true,
+				Fields: []*backuppb.FieldSchema{
+					{FieldID: 100, Name: "pk", IsPrimaryKey: true, DataType: backuppb.DataType_Int64},
+					{FieldID: 101, Name: "vec", DataType: backuppb.DataType_FloatVector},
+				},
+			},
+		}
+		builder.addCollection(ns, coll)
+
+		defaultValue := &schemapb.ValueField{Data: &schemapb.ValueField_BytesData{BytesData: []byte("{}")}}
+		dynField := &schemapb.FieldSchema{
+			FieldID:      102,
+			Name:         "$meta",
+			DataType:     schemapb.DataType_JSON,
+			IsDynamic:    true,
+			Nullable:     true,
+			DefaultValue: defaultValue,
+			Description:  "dynamic schema",
+		}
+		assert.NoError(t, builder.addDynamicFields(map[int64]*schemapb.FieldSchema{1: dynField}))
+
+		fields := builder.collectionBackups[1].GetSchema().GetFields()
+		assert.Len(t, fields, 3)
+		dyn := fields[2]
+		assert.Equal(t, int64(102), dyn.GetFieldID())
+		assert.Equal(t, "$meta", dyn.GetName())
+		assert.True(t, dyn.GetIsDynamic())
+		assert.True(t, dyn.GetNullable())
+		assert.Equal(t, backuppb.DataType_JSON, dyn.GetDataType())
+
+		// Default value round-trips through base64+proto.
+		bytes, err := base64.StdEncoding.DecodeString(dyn.GetDefaultValueBase64())
+		assert.NoError(t, err)
+		var got schemapb.ValueField
+		assert.NoError(t, proto.Unmarshal(bytes, &got))
+		assert.Equal(t, []byte("{}"), got.GetBytesData())
+	})
+
+	t.Run("SkipsCollectionWithoutDynamicField", func(t *testing.T) {
+		builder := newMetaBuilder("task1", "backup1")
+		ns := namespace.New("db1", "coll1")
+		coll := &backuppb.CollectionBackupInfo{
+			CollectionId: 1,
+			Schema: &backuppb.CollectionSchema{
+				EnableDynamicField: false,
+				Fields:             []*backuppb.FieldSchema{{FieldID: 100, Name: "pk"}},
+			},
+		}
+		builder.addCollection(ns, coll)
+
+		dynField := &schemapb.FieldSchema{FieldID: 101, Name: "$meta", IsDynamic: true}
+		assert.NoError(t, builder.addDynamicFields(map[int64]*schemapb.FieldSchema{1: dynField}))
+
+		// Schema must be untouched when EnableDynamicField is false.
+		assert.Len(t, builder.collectionBackups[1].GetSchema().GetFields(), 1)
+	})
+
+	t.Run("ErrorsOnMissingEntryForCollection", func(t *testing.T) {
+		builder := newMetaBuilder("task1", "backup1")
+		ns := namespace.New("db1", "coll1")
+		coll := &backuppb.CollectionBackupInfo{
+			CollectionId:   1,
+			CollectionName: "coll1",
+			Schema: &backuppb.CollectionSchema{
+				EnableDynamicField: true,
+				Fields:             []*backuppb.FieldSchema{{FieldID: 100, Name: "pk"}},
+			},
+		}
+		builder.addCollection(ns, coll)
+
+		// etcd has no record for collection 1.
+		err := builder.addDynamicFields(map[int64]*schemapb.FieldSchema{2: {FieldID: 101, IsDynamic: true}})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"coll1"`)
+		// Schema must remain untouched on error.
+		assert.Len(t, builder.collectionBackups[1].GetSchema().GetFields(), 1)
+	})
 }
 
 func TestSequentialBuildDoesNotCorruptData(t *testing.T) {

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -254,6 +254,10 @@ func (t *Task) privateExecute(ctx context.Context) error {
 		return fmt.Errorf("backup: run index extra info task: %w", err)
 	}
 
+	if err := t.backupCollDynField(ctx); err != nil {
+		return fmt.Errorf("backup: run coll dyn field task: %w", err)
+	}
+
 	if err := t.writeMeta(ctx); err != nil {
 		return fmt.Errorf("backup: write meta: %w", err)
 	}
@@ -495,6 +499,32 @@ func (t *Task) backupIndexExtraInfo(ctx context.Context) error {
 	indexExtraTask := newCollIndexExtraTask(t.taskID, t.etcdCli, t.etcdRootPath, t.metaBuilder)
 	if err := indexExtraTask.Execute(ctx); err != nil {
 		return fmt.Errorf("backup: execute index extra task: %w", err)
+	}
+
+	return nil
+}
+
+// backupCollDynField reads each collection's dynamic field ($meta) schema
+// directly from etcd and stores it in the backup metadata. This is necessary
+// because the Milvus DescribeCollection API filters out IsDynamic fields, so
+// the gRPC-based backup path never sees the actual $meta attributes
+// (Nullable, DefaultValue, ...). Without this info, secondary restore would
+// reconstruct the field with hardcoded defaults that may not match the source
+// collection. See zilliztech/milvus-backup#1013.
+//
+// Reuses the etcd client created for BackupIndexExtra; if etcd is not
+// configured (BackupIndexExtra disabled) the task is skipped.
+func (t *Task) backupCollDynField(ctx context.Context) error {
+	if t.etcdCli == nil {
+		t.logger.Info("skip backup collection dynamic field, etcd client is not initialized")
+		return nil
+	}
+
+	t.logger.Info("start backup collection dynamic field")
+
+	dynFieldTask := newCollDynFieldTask(t.taskID, t.etcdCli, t.etcdRootPath, t.metaBuilder)
+	if err := dynFieldTask.Execute(ctx); err != nil {
+		return fmt.Errorf("backup: execute coll dyn field task: %w", err)
 	}
 
 	return nil

--- a/core/restore/coll_ddl_task.go
+++ b/core/restore/coll_ddl_task.go
@@ -106,10 +106,25 @@ func (ddlt *collDDLTask) dropExistedColl(ctx context.Context) error {
 // This discrepancy in field order between the new collection and the backup file can cause restore errors.
 // Therefore, we stop processing fields if the field IDs are not continuous.
 // The remaining fields will be imported via addField.
+//
+// The dynamic field ($meta) is never returned in either slice: when
+// EnableDynamicField is true, Milvus auto-creates $meta inside CreateCollection,
+// and the AddField API rejects dynamic fields. Newer backups carry the actual
+// $meta schema in the backup metadata (see zilliztech/milvus-backup#1013) but
+// for the regular restore path it is purely informational.
 func (ddlt *collDDLTask) fields() ([]*schemapb.FieldSchema, []*schemapb.FieldSchema, error) {
-	fields, err := ddlt.convFields(ddlt.collBackup.GetSchema().GetFields())
+	allFields, err := ddlt.convFields(ddlt.collBackup.GetSchema().GetFields())
 	if err != nil {
 		return nil, nil, fmt.Errorf("collection: get fields: %w", err)
+	}
+
+	// Drop the dynamic field if present; CreateCollection / Milvus owns it.
+	fields := make([]*schemapb.FieldSchema, 0, len(allFields))
+	for _, f := range allFields {
+		if f.GetIsDynamic() {
+			continue
+		}
+		fields = append(fields, f)
 	}
 
 	if !ddlt.collBackup.GetSchema().GetEnableDynamicField() {

--- a/core/restore/secondary/coll_ddl_task.go
+++ b/core/restore/secondary/coll_ddl_task.go
@@ -161,12 +161,14 @@ func (ddlt *collDDLTask) createColl(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("secondary: convert schema: %w", err)
 	}
+	if err := checkDynamicField(schema); err != nil {
+		return err
+	}
 	schema.Properties = append(schema.Properties, &commonpb.KeyValuePair{
 		Key:   common.ConsistencyLevel,
 		Value: ddlt.collBackup.GetConsistencyLevel().String(),
 	})
 	appendSysFields(schema)
-	appendDynamicField(schema)
 
 	ddlt.logger.Info("collection schema", zap.Any("schema", schema))
 

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -402,8 +402,10 @@ func (dmlt *collDMLTask) sendImportMsg(ctx context.Context, partitionID int64, b
 	if err != nil {
 		return 0, fmt.Errorf("secondary: convert schema: %w", err)
 	}
+	if err := checkDynamicField(schema); err != nil {
+		return 0, err
+	}
 	appendSysFields(schema)
-	appendDynamicField(schema)
 
 	dmlt.sendMu.Lock()
 	defer dmlt.sendMu.Unlock()

--- a/core/restore/secondary/funcs.go
+++ b/core/restore/secondary/funcs.go
@@ -1,11 +1,26 @@
 package secondary
 
 import (
+	"fmt"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
-
-	"github.com/zilliztech/milvus-backup/core/restore/funcs"
 )
+
+// checkDynamicField fails the restore if the source collection had dynamic
+// schema enabled but the backup metadata does not carry the actual $meta
+// field. See zilliztech/milvus-backup#1013.
+func checkDynamicField(schema *schemapb.CollectionSchema) error {
+	if !schema.GetEnableDynamicField() {
+		return nil
+	}
+	for _, f := range schema.GetFields() {
+		if f.GetIsDynamic() {
+			return nil
+		}
+	}
+	return fmt.Errorf("secondary: %q missing dynamic field in backup", schema.GetName())
+}
 
 func appendSysFields(schema *schemapb.CollectionSchema) {
 	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
@@ -23,22 +38,4 @@ func appendSysFields(schema *schemapb.CollectionSchema) {
 		Description:  "time stamp",
 		DataType:     schemapb.DataType_Int64,
 	})
-}
-
-func appendDynamicField(schema *schemapb.CollectionSchema) {
-	if schema.GetEnableDynamicField() {
-		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
-			FieldID:     funcs.GuessDynFieldID(schema.Fields),
-			Name:        common.MetaFieldName,
-			Description: "dynamic schema",
-			DataType:    schemapb.DataType_JSON,
-			IsDynamic:   true,
-			Nullable:    true,
-			DefaultValue: &schemapb.ValueField{
-				Data: &schemapb.ValueField_BytesData{
-					BytesData: []byte("{}"),
-				},
-			},
-		})
-	}
 }

--- a/core/restore/secondary/funcs_test.go
+++ b/core/restore/secondary/funcs_test.go
@@ -1,0 +1,46 @@
+package secondary
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckDynamicField(t *testing.T) {
+	t.Run("DynamicDisabled", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "coll",
+			EnableDynamicField: false,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk"},
+			},
+		}
+		assert.NoError(t, checkDynamicField(schema))
+	})
+
+	t.Run("DynamicEnabledAndPresent", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "coll",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk"},
+				{FieldID: 101, Name: "$meta", IsDynamic: true},
+			},
+		}
+		assert.NoError(t, checkDynamicField(schema))
+	})
+
+	t.Run("DynamicEnabledButMissing", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "coll",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk"},
+			},
+		}
+		err := checkDynamicField(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"coll"`)
+	})
+}


### PR DESCRIPTION
## Summary
Capture the `$meta` dynamic field schema directly from etcd at backup time, since the Milvus `DescribeCollection` API filters out `IsDynamic` fields and leaves the gRPC-based backup path with no way to see the actual attributes (`Nullable`, `DefaultValue`, ...). Without this, secondary restore had to reconstruct the field with hardcoded defaults that did not match the source collection and broke its strict alignment requirement.

## Changes
- Add `core/backup/coll_dyn_field_task.go` that reads field schemas from etcd at `{rootPath}/meta/root-coord/fields/{collectionID}/{fieldID}`, filters for `IsDynamic == true`, and groups them by collection, mirroring the existing `coll_index_extra_task.go` pattern.
- Wire `backupCollDynField` into `Task.privateExecute`, reusing the etcd client created for `BackupIndexExtra`.
- Add `metaBuilder.addDynamicFields` to inject the dynamic field into each `CollectionBackupInfo.Schema.Fields`, plus a `convDynField` helper for the schemapb→backuppb conversion.
- Drop any dynamic field from the regular restore's `fields()` split, because `CreateCollection` auto-creates `$meta` and `AddField` rejects dynamic fields.
- Remove the legacy `appendDynamicField` from secondary restore (which synthesized hardcoded `Nullable=true` / `DefaultValue={}`) and trust the backup file. Add `checkDynamicField` to fail fast when `EnableDynamicField=true` but the backup metadata does not contain `$meta` (i.e. an old backup taken before this fix); the error message points users to re-run backup with `BackupIndexExtra` enabled.
- Unit tests for `parseCollIDFromFieldKey`, `metaBuilder.addDynamicFields`, and `checkDynamicField`.

Fixes #1013