### PR TITLE
stream: add per-pchannel replay buffer for replicate stream

### DIFF
--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -58,7 +58,9 @@ func (s *recordingStream) Forward(_ context.Context, msg *commonpb.ImmutableMess
 	return nil
 }
 
-func (s *recordingStream) WaitConfirm() {}
+func (s *recordingStream) WaitConfirm(_ context.Context) error { return nil }
+
+func (s *recordingStream) Close() {}
 
 // timestampsByPch returns the time-ticks grouped by physical channel, in send
 // order.

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -89,6 +89,9 @@ func (t *Task) initClients() error {
 }
 
 func (t *Task) closeClients() {
+	if t.streamCli != nil {
+		t.streamCli.Close()
+	}
 	if t.grpc != nil {
 		if err := t.grpc.Close(); err != nil {
 			t.logger.Warn("close grpc client", zap.Error(err))
@@ -125,7 +128,10 @@ func (t *Task) Execute(ctx context.Context) error {
 	}
 
 	t.logger.Info("wait confirm")
-	t.streamCli.WaitConfirm()
+	if err := t.streamCli.WaitConfirm(ctx); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return fmt.Errorf("secondary: wait confirm: %w", err)
+	}
 
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreSuccess())
 	t.logger.Info("restore done")

--- a/internal/client/milvus/msg_queue.go
+++ b/internal/client/milvus/msg_queue.go
@@ -1,0 +1,185 @@
+package milvus
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+)
+
+var errQueueClosed = errors.New("stream: msg queue closed")
+
+// msgQueue is a bounded in-memory replay buffer for replicate messages.
+//
+// It separates two cursors:
+//   - the storage head, which is advanced only when the broker confirms a
+//     message via CleanupConfirmedMessages
+//   - the read cursor, which sendLoop advances as it ships messages on the
+//     current gRPC stream
+//
+// On reconnect, callers invoke SeekToHead to rewind the read cursor so that
+// every still-buffered (i.e. unconfirmed) message is replayed in time-tick
+// order on the new connection. The storage head only advances on confirms,
+// so as long as the broker eventually checkpoints the messages, the buffer
+// drains.
+//
+// Enqueue blocks when the buffer is full so that producers experience
+// backpressure rather than unbounded memory growth.
+type msgQueue struct {
+	mu       sync.Mutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+
+	buf     []*commonpb.ImmutableMessage
+	readIdx int
+	cap     int
+	closed  bool
+}
+
+func newMsgQueue(capacity int) *msgQueue {
+	if capacity <= 0 {
+		panic("msgQueue: capacity must be > 0")
+	}
+	q := &msgQueue{cap: capacity}
+	q.notEmpty = sync.NewCond(&q.mu)
+	q.notFull = sync.NewCond(&q.mu)
+	return q
+}
+
+func (q *msgQueue) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.buf)
+}
+
+// Enqueue appends msg to the buffer. Blocks until capacity is available or ctx
+// is canceled. Once enqueued, the message is owned by the queue and will be
+// shipped on the current connection (and replayed on reconnect) until the
+// broker confirms its time-tick.
+func (q *msgQueue) Enqueue(ctx context.Context, msg *commonpb.ImmutableMessage) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for len(q.buf) >= q.cap && !q.closed {
+		if err := q.waitWithCtx(ctx, q.notFull); err != nil {
+			return err
+		}
+	}
+	if q.closed {
+		return errQueueClosed
+	}
+
+	q.buf = append(q.buf, msg)
+	q.notEmpty.Signal()
+	return nil
+}
+
+// ReadNext returns the message at the read cursor and advances it by one. The
+// message stays in the buffer until CleanupConfirmedMessages drops it. Blocks
+// when the cursor has caught up with the tail.
+func (q *msgQueue) ReadNext(ctx context.Context) (*commonpb.ImmutableMessage, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for q.readIdx >= len(q.buf) && !q.closed {
+		if err := q.waitWithCtx(ctx, q.notEmpty); err != nil {
+			return nil, err
+		}
+	}
+	if q.closed && q.readIdx >= len(q.buf) {
+		return nil, errQueueClosed
+	}
+
+	m := q.buf[q.readIdx]
+	q.readIdx++
+	return m, nil
+}
+
+// SeekToHead rewinds the read cursor to the head of the storage so that the
+// next ReadNext returns the oldest unconfirmed message. Called from the
+// reconnect path before a new sendLoop starts on a fresh connection.
+func (q *msgQueue) SeekToHead() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.readIdx = 0
+	if len(q.buf) > 0 {
+		q.notEmpty.Broadcast()
+	}
+}
+
+// CleanupConfirmedMessages drops every message whose time-tick is <=
+// confirmedTT and returns the number of messages removed. The read cursor is
+// adjusted by the same amount, clamped at 0.
+func (q *msgQueue) CleanupConfirmedMessages(confirmedTT uint64) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.buf) == 0 {
+		return 0
+	}
+
+	cut := 0
+	for cut < len(q.buf) {
+		tt, err := GetTT(q.buf[cut])
+		if err != nil || tt > confirmedTT {
+			break
+		}
+		cut++
+	}
+	if cut == 0 {
+		return 0
+	}
+
+	for i := 0; i < cut; i++ {
+		q.buf[i] = nil
+	}
+	q.buf = q.buf[cut:]
+	q.readIdx -= cut
+	if q.readIdx < 0 {
+		q.readIdx = 0
+	}
+
+	q.notFull.Broadcast()
+	return cut
+}
+
+// Close marks the queue as closed and wakes every waiter. Subsequent Enqueue
+// calls fail; ReadNext drains the remaining messages and then fails.
+func (q *msgQueue) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	q.closed = true
+	q.notEmpty.Broadcast()
+	q.notFull.Broadcast()
+}
+
+// waitWithCtx blocks on cond until either ctx is canceled or another goroutine
+// signals. The mutex must be held by the caller; it is released for the
+// duration of the wait and reacquired before return.
+func (q *msgQueue) waitWithCtx(ctx context.Context, cond *sync.Cond) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// Spawn a watcher that broadcasts the cond when ctx fires so that any
+	// goroutine parked on Wait wakes up and observes the cancellation.
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			q.mu.Lock()
+			cond.Broadcast()
+			q.mu.Unlock()
+		case <-stop:
+		}
+	}()
+
+	cond.Wait()
+	close(stop)
+
+	return ctx.Err()
+}

--- a/internal/client/milvus/msg_queue_test.go
+++ b/internal/client/milvus/msg_queue_test.go
@@ -1,0 +1,190 @@
+package milvus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// newImmutableForTest builds a minimal ImmutableMessage carrying the given
+// time-tick in the same property the production code reads from.
+func newImmutableForTest(tt uint64) *commonpb.ImmutableMessage {
+	return &commonpb.ImmutableMessage{
+		Properties: map[string]string{
+			"_tt": message.EncodeUint64(tt),
+		},
+	}
+}
+
+func TestMsgQueue_EnqueueAndReadInOrder(t *testing.T) {
+	q := newMsgQueue(8)
+
+	for i := uint64(1); i <= 4; i++ {
+		assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(i)))
+	}
+	assert.Equal(t, 4, q.Len())
+
+	for i := uint64(1); i <= 4; i++ {
+		got, err := q.ReadNext(context.Background())
+		assert.NoError(t, err)
+		tt, _ := GetTT(got)
+		assert.Equal(t, i, tt)
+	}
+}
+
+func TestMsgQueue_CleanupConfirmedDropsPrefix(t *testing.T) {
+	q := newMsgQueue(8)
+
+	for i := uint64(1); i <= 5; i++ {
+		assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(i)))
+	}
+
+	dropped := q.CleanupConfirmedMessages(3)
+	assert.Equal(t, 3, dropped)
+	assert.Equal(t, 2, q.Len())
+
+	got, err := q.ReadNext(context.Background())
+	assert.NoError(t, err)
+	tt, _ := GetTT(got)
+	assert.Equal(t, uint64(4), tt)
+}
+
+func TestMsgQueue_SeekToHeadReplays(t *testing.T) {
+	q := newMsgQueue(8)
+
+	for i := uint64(1); i <= 3; i++ {
+		assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(i)))
+	}
+
+	// Drain via the read cursor; storage stays intact.
+	for i := 0; i < 3; i++ {
+		_, err := q.ReadNext(context.Background())
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, 3, q.Len())
+
+	q.SeekToHead()
+
+	// All three messages should be readable again from the head.
+	for i := uint64(1); i <= 3; i++ {
+		got, err := q.ReadNext(context.Background())
+		assert.NoError(t, err)
+		tt, _ := GetTT(got)
+		assert.Equal(t, i, tt)
+	}
+}
+
+func TestMsgQueue_CleanupAdjustsReadCursor(t *testing.T) {
+	q := newMsgQueue(8)
+
+	for i := uint64(1); i <= 5; i++ {
+		assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(i)))
+	}
+	// Advance read cursor past msgs 1, 2, 3.
+	for i := 0; i < 3; i++ {
+		_, _ = q.ReadNext(context.Background())
+	}
+
+	// Cleanup confirms tt<=2; cursor should now point at the new index of msg 3.
+	q.CleanupConfirmedMessages(2)
+	assert.Equal(t, 3, q.Len())
+
+	got, err := q.ReadNext(context.Background())
+	assert.NoError(t, err)
+	tt, _ := GetTT(got)
+	assert.Equal(t, uint64(4), tt, "cursor should resume after the dropped prefix")
+}
+
+func TestMsgQueue_EnqueueBlocksWhenFull(t *testing.T) {
+	q := newMsgQueue(2)
+
+	assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(1)))
+	assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(2)))
+
+	// Third Enqueue must block until cleanup frees a slot.
+	enqueued := make(chan error, 1)
+	go func() {
+		enqueued <- q.Enqueue(context.Background(), newImmutableForTest(3))
+	}()
+
+	select {
+	case <-enqueued:
+		t.Fatal("Enqueue should have blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	q.CleanupConfirmedMessages(1)
+
+	select {
+	case err := <-enqueued:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Enqueue did not unblock after cleanup")
+	}
+}
+
+func TestMsgQueue_EnqueueRespectsContextCancel(t *testing.T) {
+	q := newMsgQueue(1)
+	assert.NoError(t, q.Enqueue(context.Background(), newImmutableForTest(1)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- q.Enqueue(ctx, newImmutableForTest(2))
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Enqueue did not return after ctx cancel")
+	}
+}
+
+func TestMsgQueue_ReadNextRespectsContextCancel(t *testing.T) {
+	q := newMsgQueue(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := q.ReadNext(ctx)
+		done <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("ReadNext did not return after ctx cancel")
+	}
+}
+
+func TestMsgQueue_CloseUnblocksWaiters(t *testing.T) {
+	q := newMsgQueue(1)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := q.ReadNext(context.Background())
+		done <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	q.Close()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, errQueueClosed)
+	case <-time.After(time.Second):
+		t.Fatal("ReadNext did not return after Close")
+	}
+}

--- a/internal/client/milvus/stream.go
+++ b/internal/client/milvus/stream.go
@@ -2,8 +2,10 @@ package milvus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -11,7 +13,20 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/retry"
+)
+
+const (
+	// pchQueueCapacity bounds the number of unconfirmed replicate messages
+	// buffered per pchannel. Producers block (backpressure) once the buffer is
+	// full. The bound exists primarily as a safety net against a stalled
+	// broker; in normal operation the broker confirms quickly and the buffer
+	// stays small.
+	pchQueueCapacity = 4096
+
+	// pchReconnectInitialBackoff and pchReconnectMaxBackoff control the delay
+	// between reconnect attempts when the gRPC stream fails.
+	pchReconnectInitialBackoff = 100 * time.Millisecond
+	pchReconnectMaxBackoff     = 10 * time.Second
 )
 
 // Stream is the replicate stream client used by the secondary restore path.
@@ -21,26 +36,35 @@ import (
 // with the dispatch to the matching pchannel. Pre-built immutable messages
 // (e.g. flush-all messages whose time-ticks come from the source cluster) are
 // passed through Forward without re-stamping.
+//
+// Each pchannel owns an in-memory replay buffer of unconfirmed messages.
+// Send/Forward enqueue into that buffer; a per-pchannel goroutine drains it
+// onto the current gRPC stream and replays from the head on every reconnect,
+// so an in-flight gRPC failure no longer drops data.
 type Stream interface {
 	// Alloc returns the next monotonic timestamp from the stream client's
 	// internal allocator. Use it for message body timestamps such as
 	// MsgBase.Timestamp so that body and wire time-ticks share one axis.
 	Alloc() uint64
 
-	// Send stamps a wire time-tick on the mutable message and dispatches it to
-	// the pchannel matching the message's vchannel. The (alloc, dispatch) pair
-	// is performed atomically with respect to other Send/Forward calls so that
-	// per-pchannel time-tick monotonicity is preserved.
+	// Send stamps a wire time-tick on the mutable message and enqueues it on
+	// the pchannel matching the message's vchannel. Returns once the message
+	// is in the replay buffer (not when the broker has confirmed it).
 	Send(ctx context.Context, msg message.MutableMessage) error
 
-	// Forward dispatches a pre-built immutable message to its pchannel without
+	// Forward enqueues a pre-built immutable message on its pchannel without
 	// re-stamping its time-tick. Used to replay messages whose time-ticks were
 	// assigned by the source cluster.
 	Forward(ctx context.Context, msg *commonpb.ImmutableMessage) error
 
-	// WaitConfirm blocks until every pchannel has received a confirmation
-	// covering the highest time-tick that was sent on it.
-	WaitConfirm()
+	// WaitConfirm blocks until every pchannel has either drained its replay
+	// buffer (i.e. all messages have been confirmed by the broker) or
+	// encountered a permanent error. Returns the first error observed.
+	WaitConfirm(ctx context.Context) error
+
+	// Close cancels every pchannel's reconnect loop and releases its
+	// resources. Safe to call multiple times.
+	Close()
 }
 
 type StreamClient struct {
@@ -48,18 +72,17 @@ type StreamClient struct {
 
 	tsAlloc *tsAlloc
 
-	// dispatchMu serializes (alloc tt + dispatch to pchClient) so that the
-	// per-pchannel time-tick stays monotonic across concurrent callers.
+	// dispatchMu serializes (alloc tt + enqueue) so that the per-pchannel
+	// time-tick stays monotonic across concurrent callers.
 	dispatchMu sync.Mutex
+
+	closeOnce sync.Once
 }
 
 func NewStreamClient(srcClusterID, taskID string, pch []string, grpc Grpc) (*StreamClient, error) {
 	pchClients := make(map[string]*pchClient, len(pch))
 	for _, p := range pch {
-		pchCli, err := newPchClient(srcClusterID, taskID, p, grpc)
-		if err != nil {
-			return nil, fmt.Errorf("stream: new pch client: %w", err)
-		}
+		pchCli := newPchClient(srcClusterID, taskID, p, grpc)
 		pchClients[p] = pchCli
 	}
 
@@ -98,10 +121,9 @@ func (s *StreamClient) Send(ctx context.Context, msg message.MutableMessage) err
 		return fmt.Errorf("stream: no pch client for %s", pch)
 	}
 
-	if err := cli.send(ctx, immutable); err != nil {
+	if err := cli.enqueue(ctx, immutable); err != nil {
 		return fmt.Errorf("stream: send message: %w", err)
 	}
-
 	return nil
 }
 
@@ -120,74 +142,263 @@ func (s *StreamClient) Forward(ctx context.Context, immutable *commonpb.Immutabl
 		return fmt.Errorf("stream: no pch client for %s", pch)
 	}
 
-	if err := cli.send(ctx, immutable); err != nil {
+	if err := cli.enqueue(ctx, immutable); err != nil {
 		return fmt.Errorf("stream: forward message: %w", err)
 	}
-
 	return nil
 }
 
-func (s *StreamClient) WaitConfirm() {
+func (s *StreamClient) WaitConfirm(ctx context.Context) error {
 	for _, cli := range s.pchClient {
-		cli.waitConfirm()
+		if err := cli.waitConfirm(ctx); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
+func (s *StreamClient) Close() {
+	s.closeOnce.Do(func() {
+		for _, cli := range s.pchClient {
+			cli.close()
+		}
+	})
+}
+
+// pchClient owns one replicate stream to a single pchannel. It is structured
+// as three cooperating goroutines:
+//
+//   - runForever: the outer reconnect loop. Opens a new gRPC stream, rewinds
+//     the queue read cursor, spawns sendLoop+recvLoop, waits for either to
+//     fail, and starts the next iteration with exponential backoff.
+//
+//   - sendLoop: drains the queue and writes messages to the current stream.
+//     On gRPC error it returns and the outer loop reconnects.
+//
+//   - recvLoop: reads ConfirmedTimeTick acks from the current stream and
+//     drops the matching prefix from the queue. On gRPC error it returns and
+//     the outer loop reconnects.
+//
+// Producers (Send/Forward) only touch the queue via enqueue and never block on
+// the network.
 type pchClient struct {
 	sourceClusterID string
+	pch             string
 	grpc            Grpc
 
-	cli            milvuspb.MilvusService_CreateReplicateStreamClient
-	connCancelFunc context.CancelFunc
+	queue *msgQueue
 
-	cond        *sync.Cond
-	mu          sync.Mutex
-	sentTT      uint64
-	confirmedTT uint64
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	finishedCh chan struct{}
+
+	// statusMu protects permErr and broadcasts via statusCond when state
+	// transitions that waitConfirm cares about happen (cleanup, perm failure,
+	// shutdown).
+	statusMu   sync.Mutex
+	statusCond *sync.Cond
+	permErr    error
 
 	logger *zap.Logger
 }
 
-func newPchClient(sourceClusterID, taskID, pch string, grpc Grpc) (*pchClient, error) {
+func newPchClient(sourceClusterID, taskID, pch string, grpc Grpc) *pchClient {
+	ctx, cancel := context.WithCancel(context.Background())
 	p := &pchClient{
-		grpc:            grpc,
 		sourceClusterID: sourceClusterID,
+		pch:             pch,
+		grpc:            grpc,
+
+		queue: newMsgQueue(pchQueueCapacity),
+
+		ctx:        ctx,
+		cancelFunc: cancel,
+		finishedCh: make(chan struct{}),
 
 		logger: log.With(zap.String("task_id", taskID), zap.String("pch", pch)),
 	}
-	p.cond = sync.NewCond(&p.mu)
-
-	if err := p.newStreamClient(); err != nil {
-		return nil, fmt.Errorf("stream: new stream client: %w", err)
-	}
-
-	return p, nil
+	p.statusCond = sync.NewCond(&p.statusMu)
+	go p.runForever()
+	return p
 }
 
-func (p *pchClient) newStreamClient() error {
-	if p.connCancelFunc != nil {
-		p.connCancelFunc()
+func (p *pchClient) enqueue(ctx context.Context, msg *commonpb.ImmutableMessage) error {
+	p.statusMu.Lock()
+	if p.permErr != nil {
+		err := p.permErr
+		p.statusMu.Unlock()
+		return err
 	}
+	p.statusMu.Unlock()
 
-	p.logger.Info("create stream client")
-	if p.cli != nil {
-		if err := p.cli.CloseSend(); err != nil {
-			p.logger.Warn("close stream error", zap.Error(err))
+	return p.queue.Enqueue(ctx, msg)
+}
+
+func (p *pchClient) waitConfirm(ctx context.Context) error {
+	// A watchdog that wakes the cond on ctx cancellation, so the loop below
+	// observes ctx.Err() promptly instead of parking forever.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.statusMu.Lock()
+			p.statusCond.Broadcast()
+			p.statusMu.Unlock()
+		case <-stop:
+		}
+	}()
+
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+
+	for {
+		if p.permErr != nil {
+			return p.permErr
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if p.queue.Len() == 0 {
+			return nil
+		}
+		p.statusCond.Wait()
+	}
+}
+
+func (p *pchClient) close() {
+	p.cancelFunc()
+	p.queue.Close()
+	<-p.finishedCh
+}
+
+func (p *pchClient) runForever() {
+	defer close(p.finishedCh)
+
+	backoff := pchReconnectInitialBackoff
+	for {
+		if p.ctx.Err() != nil {
+			return
+		}
+
+		ok := p.runOneConnection()
+
+		if p.ctx.Err() != nil {
+			return
+		}
+
+		if ok {
+			backoff = pchReconnectInitialBackoff
+		} else {
+			p.logger.Warn("replicate stream connection failed, retrying", zap.Duration("backoff", backoff))
+			select {
+			case <-time.After(backoff):
+			case <-p.ctx.Done():
+				return
+			}
+			backoff *= 2
+			if backoff > pchReconnectMaxBackoff {
+				backoff = pchReconnectMaxBackoff
+			}
 		}
 	}
+}
 
-	connCtx, cancel := context.WithCancel(context.Background())
-	p.connCancelFunc = cancel
+// runOneConnection opens one gRPC stream, runs sendLoop+recvLoop until either
+// fails, then tears down. Returns true if the connection actually established
+// (so the outer loop resets backoff), false otherwise.
+func (p *pchClient) runOneConnection() (established bool) {
+	connCtx, connCancel := context.WithCancel(p.ctx)
+	defer connCancel()
 
 	cli, err := p.grpc.CreateReplicateStream(connCtx, p.sourceClusterID)
 	if err != nil {
-		return fmt.Errorf("create replicate stream: %w", err)
+		p.logger.Warn("create replicate stream failed", zap.Error(err))
+		return false
+	}
+	defer func() {
+		if err := cli.CloseSend(); err != nil {
+			p.logger.Debug("close stream send", zap.Error(err))
+		}
+	}()
+
+	p.logger.Info("replicate stream connected")
+
+	// Rewind the read cursor so that any unconfirmed messages from the previous
+	// connection are replayed on this fresh stream in time-tick order.
+	p.queue.SeekToHead()
+
+	sendErrCh := make(chan error, 1)
+	recvErrCh := make(chan error, 1)
+	go func() {
+		sendErrCh <- p.sendLoop(connCtx, cli)
+		close(sendErrCh)
+	}()
+	go func() {
+		recvErrCh <- p.recvLoop(connCtx, cli)
+		close(recvErrCh)
+	}()
+
+	var loopErr error
+	select {
+	case <-p.ctx.Done():
+	case loopErr = <-sendErrCh:
+	case loopErr = <-recvErrCh:
 	}
 
-	p.cli = cli
-	go p.recvLoop(cli)
+	connCancel()
+	// Drain both channels so that two loops never race over the same gRPC
+	// client across reconnects. Each channel is closed by its goroutine after
+	// the single send, so the receives below return immediately once the
+	// loops have exited (zero value if already consumed by the case above).
+	<-sendErrCh
+	<-recvErrCh
 
-	return nil
+	if loopErr != nil && !errors.Is(loopErr, context.Canceled) {
+		p.logger.Warn("replicate stream loop failed", zap.Error(loopErr))
+	}
+	return true
+}
+
+func (p *pchClient) sendLoop(ctx context.Context, cli milvuspb.MilvusService_CreateReplicateStreamClient) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		msg, err := p.queue.ReadNext(ctx)
+		if err != nil {
+			return err
+		}
+		if err := cli.Send(p.newReq(msg)); err != nil {
+			return fmt.Errorf("stream: send: %w", err)
+		}
+	}
+}
+
+func (p *pchClient) recvLoop(ctx context.Context, cli milvuspb.MilvusService_CreateReplicateStreamClient) error {
+	for {
+		resp, err := cli.Recv()
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return fmt.Errorf("stream: recv: %w", err)
+		}
+		confirmedTT := resp.GetReplicateConfirmedMessageInfo().GetConfirmedTimeTick()
+		if confirmedTT == 0 {
+			continue
+		}
+		dropped := p.queue.CleanupConfirmedMessages(confirmedTT)
+		if dropped > 0 {
+			p.logger.Debug("recv confirm",
+				zap.Uint64("confirmed_tt", confirmedTT),
+				zap.Int("dropped", dropped),
+				zap.Int("remaining", p.queue.Len()))
+			p.statusMu.Lock()
+			p.statusCond.Broadcast()
+			p.statusMu.Unlock()
+		}
+	}
 }
 
 func (p *pchClient) newReq(msg *commonpb.ImmutableMessage) *milvuspb.ReplicateRequest {
@@ -199,64 +410,4 @@ func (p *pchClient) newReq(msg *commonpb.ImmutableMessage) *milvuspb.ReplicateRe
 			},
 		},
 	}
-}
-
-func (p *pchClient) send(ctx context.Context, msg *commonpb.ImmutableMessage) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	tt, err := GetTT(msg)
-	if err != nil {
-		return fmt.Errorf("stream: get tt: %w", err)
-	}
-
-	err = retry.Do(ctx, func() error {
-		if err := p.cli.Send(p.newReq(msg)); err != nil {
-			p.logger.Warn("send to stream error, try to reconnect", zap.Error(err))
-
-			if err := p.newStreamClient(); err != nil {
-				return fmt.Errorf("stream: new stream client: %w", err)
-			}
-
-			return fmt.Errorf("stream: send message: %w", err)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("stream: send message: %w", err)
-	}
-
-	p.sentTT = tt
-
-	return nil
-}
-
-func (p *pchClient) recvLoop(cli milvuspb.MilvusService_CreateReplicateStreamClient) {
-	for {
-		resp, err := cli.Recv()
-		if err != nil {
-			p.logger.Warn("recv from stream error", zap.Error(err))
-			return
-		}
-
-		confirmTT := resp.GetReplicateConfirmedMessageInfo().GetConfirmedTimeTick()
-		p.logger.Info("recv confirm", zap.Uint64("confirmed_tt", confirmTT), zap.Uint64("sent_tt", p.sentTT))
-		p.mu.Lock()
-		p.confirmedTT = confirmTT
-		p.mu.Unlock()
-		p.cond.Signal()
-	}
-}
-
-func (p *pchClient) waitConfirm() {
-	p.mu.Lock()
-
-	for p.confirmedTT < p.sentTT {
-		p.logger.Info("wait confirm", zap.Uint64("confirmed_tt", p.confirmedTT), zap.Uint64("sent_tt", p.sentTT))
-		p.cond.Wait()
-	}
-
-	p.mu.Unlock()
 }

--- a/internal/client/milvus/stream_test.go
+++ b/internal/client/milvus/stream_test.go
@@ -1,0 +1,313 @@
+package milvus
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// fakeReplicateStream is a hand-rolled
+// milvuspb.MilvusService_CreateReplicateStreamClient implementation that the
+// pchClient tests drive directly. Each instance models one underlying gRPC
+// stream; reconnect spins up a fresh fakeReplicateStream.
+type fakeReplicateStream struct {
+	// sentCh receives every successfully Sent request.
+	sentCh chan *milvuspb.ReplicateRequest
+
+	// recvCh feeds responses into Recv. Tests push confirms by sending on it.
+	recvCh chan *milvuspb.ReplicateResponse
+
+	// stopCh is closed when the stream is "torn down" (either by the test
+	// calling closeRecv to simulate a network drop, or by the production code
+	// invoking CloseSend on connection teardown). Recv returns recvErr (or
+	// io.EOF) once stopCh is closed; Send returns recvErr.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
+	// recvErr is the error returned by Recv (and Send) after stopCh closes.
+	recvErr atomic.Value // error
+}
+
+func newFakeReplicateStream() *fakeReplicateStream {
+	return &fakeReplicateStream{
+		sentCh: make(chan *milvuspb.ReplicateRequest, 256),
+		recvCh: make(chan *milvuspb.ReplicateResponse, 64),
+		stopCh: make(chan struct{}),
+	}
+}
+
+func (f *fakeReplicateStream) Send(req *milvuspb.ReplicateRequest) error {
+	select {
+	case <-f.stopCh:
+		if v := f.recvErr.Load(); v != nil {
+			return v.(error)
+		}
+		return io.EOF
+	default:
+	}
+	f.sentCh <- req
+	return nil
+}
+
+func (f *fakeReplicateStream) Recv() (*milvuspb.ReplicateResponse, error) {
+	select {
+	case resp := <-f.recvCh:
+		return resp, nil
+	case <-f.stopCh:
+		if v := f.recvErr.Load(); v != nil {
+			return nil, v.(error)
+		}
+		return nil, io.EOF
+	}
+}
+
+// closeRecv simulates a network drop. Subsequent Send/Recv calls return err.
+func (f *fakeReplicateStream) closeRecv(err error) {
+	if err != nil {
+		f.recvErr.Store(err)
+	}
+	f.stopOnce.Do(func() { close(f.stopCh) })
+}
+
+// pushConfirm enqueues a ConfirmedTimeTick response to be returned by the next
+// Recv call.
+func (f *fakeReplicateStream) pushConfirm(tt uint64) {
+	f.recvCh <- &milvuspb.ReplicateResponse{
+		Response: &milvuspb.ReplicateResponse_ReplicateConfirmedMessageInfo{
+			ReplicateConfirmedMessageInfo: &milvuspb.ReplicateConfirmedMessageInfo{
+				ConfirmedTimeTick: tt,
+			},
+		},
+	}
+}
+
+// grpc.ClientStream method stubs — pchClient never calls these other than
+// CloseSend, but the interface forces us to provide them.
+
+func (f *fakeReplicateStream) Header() (metadata.MD, error) { return nil, nil }
+func (f *fakeReplicateStream) Trailer() metadata.MD         { return nil }
+func (f *fakeReplicateStream) CloseSend() error {
+	f.closeRecv(nil)
+	return nil
+}
+func (f *fakeReplicateStream) Context() context.Context { return context.Background() }
+func (f *fakeReplicateStream) SendMsg(m any) error      { return nil }
+func (f *fakeReplicateStream) RecvMsg(m any) error      { return nil }
+
+var _ milvuspb.MilvusService_CreateReplicateStreamClient = (*fakeReplicateStream)(nil)
+
+// fakeGrpc returns a sequence of pre-built fake streams; each call to
+// CreateReplicateStream consumes the next one. Tests push streams to model
+// reconnects.
+type fakeGrpc struct {
+	mu      sync.Mutex
+	streams []*fakeReplicateStream
+	openErr error
+}
+
+func newFakeGrpc(streams ...*fakeReplicateStream) *fakeGrpc {
+	return &fakeGrpc{streams: streams}
+}
+
+func (g *fakeGrpc) CreateReplicateStream(ctx context.Context, sourceClusterID string) (milvuspb.MilvusService_CreateReplicateStreamClient, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.openErr != nil {
+		return nil, g.openErr
+	}
+	if len(g.streams) == 0 {
+		return nil, errors.New("fakeGrpc: no more streams")
+	}
+	s := g.streams[0]
+	g.streams = g.streams[1:]
+
+	// A real gRPC bidi stream is bound to the context: when ctx fires, the
+	// transport tears down and Recv/Send return errors. Mirror that here so
+	// runOneConnection's connCancel reliably unblocks the fake stream.
+	go func() {
+		<-ctx.Done()
+		s.closeRecv(ctx.Err())
+	}()
+
+	return s, nil
+}
+
+func newPchClientForTest(grpc Grpc) *pchClient {
+	return newPchClient("src-cluster", "task-1", "rootcoord-dml_0", grpc)
+}
+
+// waitFor polls cond until it returns true or the deadline elapses.
+func waitFor(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+func TestPchClient_SendThenConfirmDrainsBuffer(t *testing.T) {
+	stream := newFakeReplicateStream()
+	g := newFakeGrpc(stream)
+
+	p := newPchClientForTest(&pchTestGrpc{fake: g})
+	defer p.close()
+
+	for i := uint64(1); i <= 3; i++ {
+		assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(i)))
+	}
+
+	// All three requests should land on the fake stream.
+	for i := 0; i < 3; i++ {
+		select {
+		case req := <-stream.sentCh:
+			assert.NotNil(t, req.GetReplicateMessage())
+		case <-time.After(time.Second):
+			t.Fatal("expected request on fake stream")
+		}
+	}
+
+	// Confirm everything.
+	stream.pushConfirm(3)
+
+	waitFor(t, time.Second, "queue drained after confirm", func() bool {
+		return p.queue.Len() == 0
+	})
+
+	// WaitConfirm should now return immediately.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.NoError(t, p.waitConfirm(ctx))
+}
+
+func TestPchClient_PartialConfirmDropsPrefixOnly(t *testing.T) {
+	stream := newFakeReplicateStream()
+	g := newFakeGrpc(stream)
+
+	p := newPchClientForTest(&pchTestGrpc{fake: g})
+	defer p.close()
+
+	for i := uint64(1); i <= 5; i++ {
+		assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(i)))
+	}
+	for i := 0; i < 5; i++ {
+		<-stream.sentCh
+	}
+
+	stream.pushConfirm(3)
+	waitFor(t, time.Second, "prefix dropped", func() bool { return p.queue.Len() == 2 })
+}
+
+func TestPchClient_ReconnectReplaysUnconfirmed(t *testing.T) {
+	stream1 := newFakeReplicateStream()
+	stream2 := newFakeReplicateStream()
+	g := newFakeGrpc(stream1, stream2)
+
+	p := newPchClientForTest(&pchTestGrpc{fake: g})
+	defer p.close()
+
+	// Enqueue 5 messages on stream1.
+	for i := uint64(1); i <= 5; i++ {
+		assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(i)))
+	}
+	// Drain stream1 sent channel.
+	for i := 0; i < 5; i++ {
+		<-stream1.sentCh
+	}
+
+	// Confirm tt<=2, then kill stream1 to force a reconnect.
+	stream1.pushConfirm(2)
+	waitFor(t, time.Second, "prefix dropped", func() bool { return p.queue.Len() == 3 })
+	stream1.closeRecv(errors.New("connection reset"))
+
+	// pchClient should reconnect onto stream2 and replay msgs 3, 4, 5 in
+	// time-tick order.
+	for i := uint64(3); i <= 5; i++ {
+		select {
+		case req := <-stream2.sentCh:
+			tt, err := GetTT(req.GetReplicateMessage().GetMessage())
+			assert.NoError(t, err)
+			assert.Equal(t, i, tt, "replay must follow time-tick order")
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected replay of msg %d on stream2", i)
+		}
+	}
+}
+
+func TestPchClient_NewSendsAfterReconnectFlowToNewStream(t *testing.T) {
+	stream1 := newFakeReplicateStream()
+	stream2 := newFakeReplicateStream()
+	g := newFakeGrpc(stream1, stream2)
+
+	p := newPchClientForTest(&pchTestGrpc{fake: g})
+	defer p.close()
+
+	assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(1)))
+	<-stream1.sentCh
+	stream1.pushConfirm(1)
+	waitFor(t, time.Second, "msg 1 confirmed", func() bool { return p.queue.Len() == 0 })
+
+	stream1.closeRecv(errors.New("reset"))
+
+	// After reconnect, new sends should land on stream2.
+	assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(2)))
+	select {
+	case req := <-stream2.sentCh:
+		tt, _ := GetTT(req.GetReplicateMessage().GetMessage())
+		assert.Equal(t, uint64(2), tt)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected new send on stream2")
+	}
+}
+
+func TestPchClient_WaitConfirmRespectsContextCancel(t *testing.T) {
+	stream := newFakeReplicateStream()
+	g := newFakeGrpc(stream)
+
+	p := newPchClientForTest(&pchTestGrpc{fake: g})
+	defer p.close()
+
+	assert.NoError(t, p.enqueue(context.Background(), newImmutableForTest(1)))
+	<-stream.sentCh
+
+	// Buffer holds 1 unconfirmed message; cancel ctx should unblock waitConfirm.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.waitConfirm(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("waitConfirm did not return on ctx cancel")
+	}
+}
+
+// pchTestGrpc adapts a fakeGrpc into the Grpc interface. Only
+// CreateReplicateStream is exercised; everything else panics if called.
+type pchTestGrpc struct {
+	Grpc
+	fake *fakeGrpc
+}
+
+func (g *pchTestGrpc) CreateReplicateStream(ctx context.Context, sourceClusterID string) (milvuspb.MilvusService_CreateReplicateStreamClient, error) {
+	return g.fake.CreateReplicateStream(ctx, sourceClusterID)
+}
+
+// silence unused linter on the helper alias
+var _ grpc.ClientStream = (*fakeReplicateStream)(nil)


### PR DESCRIPTION
## Summary
Add a bounded in-memory replay buffer per pchannel inside the replicate stream client. The previous implementation wrote each message directly onto the gRPC bidi stream and exited \`recvLoop\` on the first error, silently losing in-flight messages on any connection drop and deadlocking \`WaitConfirm\` once recv had quit. The new implementation matches the pattern Milvus' own CDC client uses internally (\`internal/cdc/replication/replicatestream\`).

This is the second part of the secondary-restore reliability work that started in #1020.

## Changes
- Add a bounded \`msgQueue\` (capacity 4096, blocks producers on backpressure) with two cursors: a read cursor that \`sendLoop\` advances as it ships messages, and a storage head that only moves on broker confirms via \`CleanupConfirmedMessages\`. \`SeekToHead\` rewinds the read cursor on reconnect so unconfirmed messages are replayed in time-tick order on the new gRPC stream.
- Restructure \`pchClient\` as three cooperating goroutines:
  - \`runForever\` — outer reconnect loop with exponential backoff (100ms → 10s)
  - \`sendLoop\` — drains the queue onto the current stream
  - \`recvLoop\` — reads \`ConfirmedTimeTick\` and drops the matching prefix
- \`Send\`/\`Forward\` enqueue into the queue and return as soon as the message is buffered, decoupling producers from network latency and reconnects.
- \`WaitConfirm\` now takes a \`context.Context\` and returns an \`error\` so callers can bail on cancellation. \`secondary.Task.Execute\` propagates the context and surfaces the error; \`Task.closeClients\` calls the new \`Stream.Close\` so per-pch goroutines are bounded by the restore task.
- The \`recordingStream\` test fake in \`core/restore/secondary\` is updated for the new interface.
- Unit tests cover the queue (enqueue/cleanup/seek/cursor adjustment/backpressure/ctx cancellation/close) and the pchClient (confirm drains buffer, partial confirm drops prefix, reconnect replays unconfirmed in tt order, new sends after reconnect flow to the new stream, WaitConfirm respects ctx cancel) using a hand-rolled \`fakeReplicateStream\` that mirrors how a real gRPC bidi stream tears down on context cancellation.

## Notes on duplicate-on-replay
The Milvus replicate interceptor dedupes per checkpoint, not per message: messages with \`tt > checkpoint\` are reprocessed if replayed (\`internal/streamingnode/server/wal/interceptors/replicate/replicates/impl.go\`). Milvus' own CDC client makes the same trade-off — accepts the rare double-execution risk in exchange for not losing data on every reconnect — and we follow suit.

/kind improvement