### PR TITLE
ci: skip missing-issue block for dependabot PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -73,6 +73,7 @@ pull_request_rules:
         - -body~=https://github.com/zilliztech/milvus-backup/issues/[0-9]{1,6}(\s+|$)
       - -label=kind/improvement
       - -title~=\[automated\]
+      - author!=dependabot[bot]
     actions:
       label:
         add:


### PR DESCRIPTION
## Summary
Prevent mergify from commenting `Please associate the related issue...` on dependabot PRs.

## Changes
- Add `author!=dependabot[bot]` to the "Blocking PR if missing a related issue" rule in `.github/mergify.yml`, so the rule no longer fires for dependabot. Previously it raced with the "Add kind/improvement tag for dependabot's PR" rule on PR open and left a spurious comment before the label was applied.

/kind improvement