### PR TITLE
ci: skip workflow runs for non-code path changes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - '.github/mergify.yml'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - '.github/mergify.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Summary
Skip the full CI matrix for PRs that only touch documentation, scripts, or the mergify config — mergify already auto-labels these as `ci-passed` via file-pattern rules, so running the jobs is pure waste.

## Changes
- Add `paths-ignore` to both `pull_request` and `push` triggers of `.github/workflows/main.yaml`
- Mirror the non-code allowlist already encoded in `.github/mergify.yml`: `**/*.md`, `docs/**`, `scripts/**`, `.github/mergify.yml`

/kind improvement