### PR TITLE
docs: add FAQ for 'has no insert logs' backup error

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -53,3 +53,27 @@ During restore, milvus-backup copies backup data into the bucket specified by `m
 Run `./milvus-backup check config` to print the resolved configuration, and make sure `minio.bucketName` matches the bucket that the **target Milvus** is actually using. Run `./milvus-backup check` to verify connectivity.
 
 **Related issues:** [#1026](https://github.com/zilliztech/milvus-backup/issues/1026), [#1006](https://github.com/zilliztech/milvus-backup/issues/1006), [#923](https://github.com/zilliztech/milvus-backup/issues/923), [#895](https://github.com/zilliztech/milvus-backup/issues/895)
+
+---
+
+### Backup fails with `segment xxx has no insert logs`
+
+This error means milvus-backup cannot list any binlog files for the segment under the configured object storage path. It almost always indicates that the `minio` section in `backup.yaml` does not match the storage the source Milvus is actually using.
+
+**How to fix it?**
+
+Run:
+
+```bash
+./milvus-backup check
+```
+
+If the output contains:
+
+```
+!!! Milvus root path is empty !!!
+```
+
+then at least one of `minio.address` / `minio.bucketName` / `minio.rootPath` in `backup.yaml` disagrees with the source Milvus configuration. `rootPath` is the most frequent culprit — an empty string, `files`, and `/files` all behave differently. Align each field with the source Milvus config and retry.
+
+**Related issues:** [#1033](https://github.com/zilliztech/milvus-backup/issues/1033), [#441](https://github.com/zilliztech/milvus-backup/issues/441), [#183](https://github.com/zilliztech/milvus-backup/issues/183), [#176](https://github.com/zilliztech/milvus-backup/issues/176)


### PR DESCRIPTION
## Summary
Add a FAQ entry for the `segment xxx has no insert logs` error that surfaces during `milvus-backup create` when `backup.yaml`'s `minio` section does not match the source Milvus storage.

## Changes
- Add new FAQ section in `docs/FAQ.md` covering the error, the `./milvus-backup check` diagnosis (empty root path warning), and the fix (align `minio.address` / `minio.bucketName` / `minio.rootPath`).
- Link related historical issues (#1033, #441, #183, #176).

/kind improvement