### PR TITLE
docs: suggest milvus-backup check output in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -31,6 +31,20 @@ body:
     required: true
 - type: textarea
   attributes:
+    label: Output of `milvus-backup check`
+    description: |
+      Optional but strongly recommended: paste the full output of `milvus-backup check`.
+      It verifies connectivity to Milvus and the object storage, and saves a lot of back-and-forth
+      when the root cause is a misconfiguration on either side.
+    placeholder: |
+      ```
+      <paste output here>
+      ```
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
     label: Current Behavior
     description: A concise description of what you're experiencing.
     placeholder: |


### PR DESCRIPTION
## Summary
Add an optional `Output of milvus-backup check` field to the bug report template. The intent is to save everyone's time: when the root cause is a misconfiguration in Milvus or object storage connectivity, `milvus-backup check` surfaces it immediately, avoiding several rounds of back-and-forth on the issue.

Kept optional so it does not turn away reporters who can't easily run the command.

## Changes
- Add an optional textarea asking for the output of `milvus-backup check`, with a description explaining why it helps.

/kind improvement