### PR TITLE
test: wait for schema version before adding fields

### DIFF
--- a/example/prepare_data.py
+++ b/example/prepare_data.py
@@ -15,7 +15,84 @@ from pymilvus import (
     Collection,
     MilvusClient,
 )
+from pymilvus.exceptions import MilvusException
 import argparse
+
+
+SCHEMA_VERSION_CONSISTENT_KEY = "schema_version_consistent_segments"
+SCHEMA_VERSION_TOTAL_KEY = "schema_version_total_segments"
+
+
+def is_schema_version_not_ready(exc):
+    message = str(exc)
+    return (
+        "schema version" in message
+        and (
+            "not ready" in message
+            or "consistency check failed" in message
+        )
+    )
+
+
+def wait_schema_version_consistent(client, collection_name, timeout=60, poll_interval=0.2):
+    deadline = time.time() + timeout
+    last_consistent = None
+    last_total = None
+
+    while time.time() < deadline:
+        stats = client.get_collection_stats(collection_name=collection_name)
+        consistent = stats.get(SCHEMA_VERSION_CONSISTENT_KEY)
+        total = stats.get(SCHEMA_VERSION_TOTAL_KEY)
+
+        if consistent is None and total is None:
+            return
+        if consistent is not None and total is not None and int(consistent) == int(total):
+            return
+
+        last_consistent = consistent
+        last_total = total
+        time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"schema version is not consistent for {collection_name}: "
+        f"{last_consistent}/{last_total} segments are consistent"
+    )
+
+
+def add_collection_field_with_schema_retry(
+    client,
+    collection_name,
+    field_name,
+    data_type,
+    timeout=120,
+    **kwargs,
+):
+    deadline = time.time() + timeout
+    last_error = None
+
+    while time.time() < deadline:
+        wait_schema_version_consistent(
+            client,
+            collection_name,
+            timeout=max(1, min(30, deadline - time.time())),
+        )
+        try:
+            return client.add_collection_field(
+                collection_name=collection_name,
+                field_name=field_name,
+                data_type=data_type,
+                **kwargs,
+            )
+        except MilvusException as exc:
+            if not is_schema_version_not_ready(exc):
+                raise
+            last_error = exc
+            print(f"schema version not ready after adding fields, retrying: {exc}")
+            time.sleep(1)
+
+    raise TimeoutError(
+        f"timed out adding field {field_name} to {collection_name}"
+    ) from last_error
 
 
 
@@ -279,10 +356,11 @@ def main_added(uri="http://127.0.0.1:19530", token="root:Milvus", total_entities
         ("added_json", DataType.JSON, {"nullable": True}),
     ]
     for field_name, data_type, kwargs in added_fields:
-        client.add_collection_field(
-            collection_name="hello_milvus_added",
-            field_name=field_name,
-            data_type=data_type,
+        add_collection_field_with_schema_retry(
+            client,
+            "hello_milvus_added",
+            field_name,
+            data_type,
             **kwargs,
         )
         print(f"added field {field_name} ({data_type.name}) {kwargs}")

--- a/tests/testcases/test_restore_backup.py
+++ b/tests/testcases/test_restore_backup.py
@@ -7,6 +7,7 @@ import pandas as pd
 import random
 from collections import defaultdict
 from pymilvus import db, list_collections, Collection, DataType, Function, FunctionType
+from pymilvus.exceptions import MilvusException
 from base.client_base import TestcaseBase
 from common import common_func as cf
 from common import common_type as ct
@@ -21,6 +22,80 @@ fake_en = Faker("en_US")
 prefix = "restore_backup"
 backup_prefix = "backup"
 suffix = "_bak"
+SCHEMA_VERSION_CONSISTENT_KEY = "schema_version_consistent_segments"
+SCHEMA_VERSION_TOTAL_KEY = "schema_version_total_segments"
+
+
+def is_schema_version_not_ready(exc):
+    message = str(exc)
+    return (
+        "schema version" in message
+        and (
+            "not ready" in message
+            or "consistency check failed" in message
+        )
+    )
+
+
+def wait_schema_version_consistent(client, collection_name, timeout=60, poll_interval=0.2):
+    deadline = time.time() + timeout
+    last_consistent = None
+    last_total = None
+
+    while time.time() < deadline:
+        stats = client.get_collection_stats(collection_name=collection_name)
+        consistent = stats.get(SCHEMA_VERSION_CONSISTENT_KEY)
+        total = stats.get(SCHEMA_VERSION_TOTAL_KEY)
+
+        if consistent is None and total is None:
+            return
+        if consistent is not None and total is not None and int(consistent) == int(total):
+            return
+
+        last_consistent = consistent
+        last_total = total
+        time.sleep(poll_interval)
+
+    raise AssertionError(
+        f"schema version is not consistent for {collection_name}: "
+        f"{last_consistent}/{last_total} segments are consistent"
+    )
+
+
+def add_collection_field_with_schema_retry(
+    client,
+    collection_name,
+    field_name,
+    data_type,
+    timeout=120,
+    **kwargs,
+):
+    deadline = time.time() + timeout
+    last_error = None
+
+    while time.time() < deadline:
+        wait_schema_version_consistent(
+            client,
+            collection_name,
+            timeout=max(1, min(30, deadline - time.time())),
+        )
+        try:
+            return client.add_collection_field(
+                collection_name=collection_name,
+                field_name=field_name,
+                data_type=data_type,
+                **kwargs
+            )
+        except MilvusException as exc:
+            if not is_schema_version_not_ready(exc):
+                raise
+            last_error = exc
+            log.info(f"schema version not ready after adding fields, retrying: {exc}")
+            time.sleep(1)
+
+    raise AssertionError(
+        f"timed out adding field {field_name} to {collection_name}"
+    ) from last_error
 
 
 class TestRestoreBackup(TestcaseBase):
@@ -2032,10 +2107,11 @@ class TestRestoreBackup(TestcaseBase):
 
         added_field_names = []
         for field_name, data_type, kwargs in fields_to_add:
-            self.milvus_client.add_collection_field(
-                collection_name=name_origin,
-                field_name=field_name,
-                data_type=data_type,
+            add_collection_field_with_schema_retry(
+                self.milvus_client,
+                name_origin,
+                field_name,
+                data_type,
                 **kwargs
             )
             added_field_names.append(field_name)


### PR DESCRIPTION
## Summary
- wait for Milvus schema-version consistency before issuing back-to-back add_collection_field calls in prepare_data.py
- retry transient schema-version-not-ready add field failures in the RELEASE restore test
- cover both current code=110 and older code=1100 message forms seen in Milvus master-latest

## Background
Milvus master-latest now gates schema changes on segment schema-version consistency after add-field backfill. The same transient condition is tracked upstream in:
- https://github.com/milvus-io/milvus/issues/49350
- https://github.com/milvus-io/milvus/issues/49475

## Test
- python3 -m py_compile example/prepare_data.py tests/testcases/test_restore_backup.py