### PR TITLE
Fix restore import paths to avoid empty S3 prefix listing

### DIFF
--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -391,6 +391,17 @@ func (ct *collTask) restoreNotL0SegV1(ctx context.Context, part *backuppb.Partit
 }
 
 func toPaths(dir partitionDir) []string {
+	paths := make([]string, 0, 2)
+	if dir.insertLogDir != "" {
+		paths = append(paths, dir.insertLogDir)
+	}
+	if dir.deltaLogDir != "" {
+		paths = append(paths, dir.deltaLogDir)
+	}
+	return paths
+}
+
+func toGrpcPaths(dir partitionDir) []string {
 	if len(dir.insertLogDir) == 0 {
 		return []string{dir.deltaLogDir}
 	}
@@ -741,13 +752,13 @@ func (ct *collTask) bulkInsertViaGrpc(ctx context.Context, partitionName string,
 		g.Go(func() error {
 			defer ct.bulkInsertSem.Release(1)
 
-			paths := toPaths(dir)
+			paths := toGrpcPaths(dir)
 			ct.logger.Info("start bulk insert via grpc", zap.Strings("paths", paths), zap.String("partition", partitionName))
 			in := milvus.GrpcBulkInsertInput{
 				DB:             ct.targetNS.DBName(),
 				CollectionName: ct.targetNS.CollName(),
 				PartitionName:  partitionName,
-				Paths:          toPaths(dir),
+				Paths:          paths,
 				BackupTS:       b.timestamp,
 				IsL0:           b.isL0,
 				StorageVersion: b.storageVersion,

--- a/core/restore/coll_task_test.go
+++ b/core/restore/coll_task_test.go
@@ -83,11 +83,33 @@ func TestToPaths(t *testing.T) {
 	// without delta
 	dir = partitionDir{insertLogDir: "insert"}
 	paths = toPaths(dir)
-	assert.Equal(t, []string{"insert", ""}, paths)
+	assert.Equal(t, []string{"insert"}, paths)
 
 	// without insert
 	dir = partitionDir{deltaLogDir: "delta"}
 	paths = toPaths(dir)
+	assert.Equal(t, []string{"delta"}, paths)
+
+	// empty
+	dir = partitionDir{}
+	paths = toPaths(dir)
+	assert.Empty(t, paths)
+}
+
+func TestToGrpcPaths(t *testing.T) {
+	// normal
+	dir := partitionDir{insertLogDir: "insert", deltaLogDir: "delta"}
+	paths := toGrpcPaths(dir)
+	assert.Equal(t, []string{"insert", "delta"}, paths)
+
+	// without delta
+	dir = partitionDir{insertLogDir: "insert"}
+	paths = toGrpcPaths(dir)
+	assert.Equal(t, []string{"insert", ""}, paths)
+
+	// without insert
+	dir = partitionDir{deltaLogDir: "delta"}
+	paths = toGrpcPaths(dir)
 	assert.Equal(t, []string{"delta"}, paths)
 }
 

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -41,10 +41,14 @@ type partitionDir struct {
 }
 
 func (dir *partitionDir) toPaths() []string {
-	if len(dir.insertLogDir) == 0 {
-		return []string{dir.deltaLogDir}
+	paths := make([]string, 0, 2)
+	if dir.insertLogDir != "" {
+		paths = append(paths, dir.insertLogDir)
 	}
-	return []string{dir.insertLogDir, dir.deltaLogDir}
+	if dir.deltaLogDir != "" {
+		paths = append(paths, dir.deltaLogDir)
+	}
+	return paths
 }
 
 type batch struct {

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -141,6 +141,41 @@ func newTestCollBackup(vchannels []string, partitions []*backuppb.PartitionBacku
 	}
 }
 
+func TestPartitionDirToPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  partitionDir
+		want []string
+	}{
+		{
+			name: "insert and delta",
+			dir:  partitionDir{insertLogDir: "insert", deltaLogDir: "delta"},
+			want: []string{"insert", "delta"},
+		},
+		{
+			name: "insert only",
+			dir:  partitionDir{insertLogDir: "insert"},
+			want: []string{"insert"},
+		},
+		{
+			name: "delta only",
+			dir:  partitionDir{deltaLogDir: "delta"},
+			want: []string{"delta"},
+		},
+		{
+			name: "empty",
+			dir:  partitionDir{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.dir.toPaths())
+		})
+	}
+}
+
 func newTestDMLTask(t *testing.T, collBackup *backuppb.CollectionBackupInfo, stream *recordingStream) *collDMLTask {
 	vchannels := collBackup.GetVirtualChannelNames()
 


### PR DESCRIPTION
This is triggered by insert-only restore data: the backup has insert logs, but no delta logs, so `insertLogDir` is set and `deltaLogDir` is empty.

The affected paths are regular RESTful restore import and secondary restore import-file construction. Both now filter empty  paths so Milvus will not receive `""` and list S3 with `prefix=`.

gRPC bulk insert is intentionally kept unchanged via `toGrpcPaths`. The old gRPC import API expects paths in positional `[insert, delta]` form, so for insert-only data `["<insert_log_dir>", ""]` is the compatibility format meaning “insert logs exist, delta logs do not”.