### PR TITLE
migrate: skip copy verification on cloud staging storage

### DIFF
--- a/core/migrate/task.go
+++ b/core/migrate/task.go
@@ -255,7 +255,8 @@ func (t *Task) copyToCloud(ctx context.Context) error {
 			t.taskMgr.UpdateMigrateTask(t.taskID, taskmgr.IncMigrateCopiedSize(size, cost))
 		},
 
-		CopyByServer: true,
+		CopyByServer:      true,
+		DisableVerifyCopy: true,
 	}
 
 	copyTask := storage.NewCopyPrefixTask(opt)

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -18,7 +18,8 @@ type CopyAttr struct {
 }
 
 type copierOpt struct {
-	traceFn TraceFn
+	traceFn           TraceFn
+	disableVerifyCopy bool
 }
 
 type TraceFn func(size int64, cost time.Duration)
@@ -68,12 +69,14 @@ func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 			return fmt.Errorf("storage: remote copier copy object %w", err)
 		}
 
-		attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
-		if err != nil {
-			return fmt.Errorf("storage: remote copier verify copy: %w", err)
-		}
-		if attr.Length != copyAttr.Src.Length {
-			return fmt.Errorf("storage: remote copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
+		if !rp.opt.disableVerifyCopy {
+			attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
+			if err != nil {
+				return fmt.Errorf("storage: remote copier verify copy: %w", err)
+			}
+			if attr.Length != copyAttr.Src.Length {
+				return fmt.Errorf("storage: remote copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
+			}
 		}
 
 		return nil
@@ -116,12 +119,14 @@ func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 			return fmt.Errorf("storage: server copier upload object %w", err)
 		}
 
-		attr, err := sc.dest.HeadObject(ctx, copyAttr.DestKey)
-		if err != nil {
-			return fmt.Errorf("storage: server copier verify copy: %w", err)
-		}
-		if attr.Length != copyAttr.Src.Length {
-			return fmt.Errorf("storage: server copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
+		if !sc.opt.disableVerifyCopy {
+			attr, err := sc.dest.HeadObject(ctx, copyAttr.DestKey)
+			if err != nil {
+				return fmt.Errorf("storage: server copier verify copy: %w", err)
+			}
+			if attr.Length != copyAttr.Src.Length {
+				return fmt.Errorf("storage: server copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
+			}
 		}
 
 		return nil

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -25,6 +25,8 @@ type CopyPrefixOpt struct {
 	TraceFn TraceFn
 
 	CopyByServer bool
+
+	DisableVerifyCopy bool
 }
 
 type CopyPrefixTask struct {
@@ -39,7 +41,10 @@ func NewCopyPrefixTask(opt CopyPrefixOpt) *CopyPrefixTask {
 	return &CopyPrefixTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{
+			traceFn:           opt.TraceFn,
+			disableVerifyCopy: opt.DisableVerifyCopy,
+		}),
 
 		logger: log.L().With(zap.String("src", opt.SrcPrefix), zap.String("dest", opt.DestPrefix)),
 	}
@@ -105,6 +110,8 @@ type CopyObjectsOpt struct {
 	TraceFn TraceFn
 
 	CopyByServer bool
+
+	DisableVerifyCopy bool
 }
 
 type CopyObjectsTask struct {
@@ -117,7 +124,10 @@ func NewCopyObjectsTask(opt CopyObjectsOpt) *CopyObjectsTask {
 	return &CopyObjectsTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{
+			traceFn:           opt.TraceFn,
+			disableVerifyCopy: opt.DisableVerifyCopy,
+		}),
 	}
 }
 


### PR DESCRIPTION
## Summary
Skip the HeadObject copy verification during migrate, since cloud staging storage doesn't grant HeadObject permission. Added a `DisableVerifyCopy` option to the copier so the verification can be toggled per call site.

Related to #1050

## Changes
- Add `disableVerifyCopy` flag to `copierOpt`, skip HeadObject verification when set
- Add `DisableVerifyCopy` field to `CopyPrefixOpt` and `CopyObjectsOpt`, thread to copier
- Set `DisableVerifyCopy: true` in migrate's `copyToCloud` to skip verification on cloud staging storage

/kind improvement