### PR TITLE
storage: replace per-file copy verification with batched prefix verify

### DIFF
--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -367,7 +367,59 @@ func (dmlt *collDMLTask) Execute(ctx context.Context) error {
 		return fmt.Errorf("backup: backup segments %w", err)
 	}
 
+	if err := dmlt.verifySegmentsData(ctx, describe.CollectionID, segments); err != nil {
+		return fmt.Errorf("backup: verify segments %w", err)
+	}
+
 	dmlt.taskMgr.UpdateBackupTask(dmlt.taskID, taskmgr.SetBackupCollDMLDone(dmlt.ns))
+
+	return nil
+}
+
+// verifySegmentsData verifies that every copied binlog exists in the backup
+// storage with a matching size. The destination keys all live under the
+// collection-level insert_log and delta_log dirs, so two recursive lists cover
+// the whole collection instead of issuing a HeadObject per binlog.
+func (dmlt *collDMLTask) verifySegmentsData(ctx context.Context, collID int64, segments []*backuppb.SegmentBackupInfo) error {
+	insertExpected := make(map[string]int64)
+	deltaExpected := make(map[string]int64)
+	for _, seg := range segments {
+		insertAttrs, err := dmlt.insertLogsAttrs(seg)
+		if err != nil {
+			return fmt.Errorf("backup: build insert log expected %w", err)
+		}
+		for _, attr := range insertAttrs {
+			insertExpected[attr.DestKey] = attr.Src.Length
+		}
+
+		deltaAttrs, err := dmlt.deltaLogAttrs(seg)
+		if err != nil {
+			return fmt.Errorf("backup: build delta log expected %w", err)
+		}
+		for _, attr := range deltaAttrs {
+			deltaExpected[attr.DestKey] = attr.Src.Length
+		}
+	}
+
+	insertDir := mpath.BackupInsertLogDir(dmlt.backupDir, mpath.CollectionID(collID))
+	insertVerify := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{
+		Cli:      dmlt.backupStorage,
+		Prefix:   insertDir,
+		Expected: insertExpected,
+	})
+	if err := insertVerify.Execute(ctx); err != nil {
+		return fmt.Errorf("backup: verify insert logs %w", err)
+	}
+
+	deltaDir := mpath.BackupDeltaLogDir(dmlt.backupDir, mpath.CollectionID(collID))
+	deltaVerify := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{
+		Cli:      dmlt.backupStorage,
+		Prefix:   deltaDir,
+		Expected: deltaExpected,
+	})
+	if err := deltaVerify.Execute(ctx); err != nil {
+		return fmt.Errorf("backup: verify delta logs %w", err)
+	}
 
 	return nil
 }

--- a/core/backup/coll_dml_task_test.go
+++ b/core/backup/coll_dml_task_test.go
@@ -176,3 +176,70 @@ func TestCollDMLTask_listDeltaLogByAPI(t *testing.T) {
 		{LogId: 2, LogPath: objs[1].Key, LogSize: 2},
 	})
 }
+
+func TestCollDMLTask_verifySegmentsData(t *testing.T) {
+	const (
+		backupDir = "bak"
+		collID    = int64(1)
+		partID    = int64(2)
+		segID     = int64(3)
+		groupID   = int64(3)
+		fieldID   = int64(100)
+	)
+
+	seg := &backuppb.SegmentBackupInfo{
+		CollectionId: collID,
+		PartitionId:  partID,
+		SegmentId:    segID,
+		GroupId:      groupID,
+		Binlogs: []*backuppb.FieldBinlog{
+			{FieldID: fieldID, Binlogs: []*backuppb.Binlog{
+				{LogId: 10, LogPath: "milvus/insert_log/1/2/3/100/10", LogSize: 5},
+			}},
+		},
+		Deltalogs: []*backuppb.FieldBinlog{
+			{Binlogs: []*backuppb.Binlog{
+				{LogId: 20, LogPath: "milvus/delta_log/1/2/3/20", LogSize: 7},
+			}},
+		},
+	}
+
+	insertKey := mpath.Join(
+		mpath.BackupInsertLogDir(backupDir, mpath.CollectionID(collID), mpath.PartitionID(partID), mpath.SegmentID(segID), mpath.GroupID(groupID)),
+		mpath.FieldID(fieldID), mpath.LogID(10))
+	deltaKey := mpath.Join(
+		mpath.BackupDeltaLogDir(backupDir, mpath.CollectionID(collID), mpath.PartitionID(partID), mpath.SegmentID(segID), mpath.GroupID(groupID)),
+		mpath.LogID(20))
+
+	insertColl := mpath.BackupInsertLogDir(backupDir, mpath.CollectionID(collID))
+	deltaColl := mpath.BackupDeltaLogDir(backupDir, mpath.CollectionID(collID))
+
+	t.Run("AllPresent", func(t *testing.T) {
+		st := storage.NewMockClient(t)
+		st.EXPECT().ListPrefix(mock.Anything, insertColl, true).
+			Return(storage.NewMockObjectIterator([]storage.ObjectAttr{{Key: insertKey, Length: 5}}), nil).Once()
+		st.EXPECT().ListPrefix(mock.Anything, deltaColl, true).
+			Return(storage.NewMockObjectIterator([]storage.ObjectAttr{{Key: deltaKey, Length: 7}}), nil).Once()
+
+		dmlt := newTestCollDMLTask()
+		dmlt.backupStorage = st
+		dmlt.backupDir = backupDir
+
+		err := dmlt.verifySegmentsData(context.Background(), collID, []*backuppb.SegmentBackupInfo{seg})
+		assert.NoError(t, err)
+	})
+
+	t.Run("InsertMissing", func(t *testing.T) {
+		st := storage.NewMockClient(t)
+		st.EXPECT().ListPrefix(mock.Anything, insertColl, true).
+			Return(storage.NewMockObjectIterator(nil), nil).Once()
+
+		dmlt := newTestCollDMLTask()
+		dmlt.backupStorage = st
+		dmlt.backupDir = backupDir
+
+		err := dmlt.verifySegmentsData(context.Background(), collID, []*backuppb.SegmentBackupInfo{seg})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "verify insert logs")
+	})
+}

--- a/core/check/task.go
+++ b/core/check/task.go
@@ -160,8 +160,18 @@ func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 			t.logger.Error("failed to delete check file", zap.String("path", destKey), zap.Error(err))
 		}
 	}()
-
 	t.logger.Info("copy from milvus storage to backup storage success")
+
+	expected, err := storage.ExpectedDestObjects(ctx, t.milvusStorage, srcKey, destKey)
+	if err != nil {
+		return fmt.Errorf("check: build expected for copy verify %w", err)
+	}
+	verifyTask := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{Cli: t.backupStorage, Prefix: destKey, Expected: expected})
+	if err := verifyTask.Execute(ctx); err != nil {
+		return fmt.Errorf("check: verify copy to backup storage %w", err)
+	}
+	t.logger.Info("verify copy to backup storage success")
+
 	return nil
 }
 

--- a/core/migrate/task.go
+++ b/core/migrate/task.go
@@ -244,19 +244,20 @@ func (t *Task) copyToCloud(ctx context.Context) error {
 		return fmt.Errorf("migrate: new volume storage %w", err)
 	}
 
+	srcPrefix := t.backupDir
+	destPrefix := t.volume.currentResp.resp.UploadPath
 	opt := storage.CopyPrefixOpt{
 		Src:        t.backupStorage,
 		Dest:       destCli,
-		SrcPrefix:  t.backupDir,
-		DestPrefix: t.volume.currentResp.resp.UploadPath,
+		SrcPrefix:  srcPrefix,
+		DestPrefix: destPrefix,
 		Sem:        t.copySem,
 
 		TraceFn: func(size int64, cost time.Duration) {
 			t.taskMgr.UpdateMigrateTask(t.taskID, taskmgr.IncMigrateCopiedSize(size, cost))
 		},
 
-		CopyByServer:      true,
-		DisableVerifyCopy: true,
+		CopyByServer: true,
 	}
 
 	copyTask := storage.NewCopyPrefixTask(opt)
@@ -265,7 +266,28 @@ func (t *Task) copyToCloud(ctx context.Context) error {
 	}
 	t.logger.Info("copy backup to cloud done")
 
+	// The cloud staging volume only grants ListObject (no HeadObject/GetObject),
+	// so verify the copy with a single recursive list instead of per-object head.
+	if err := t.verifyCopyToCloud(ctx, destCli, srcPrefix, destPrefix); err != nil {
+		return fmt.Errorf("migrate: verify copy to cloud %w", err)
+	}
+	t.logger.Info("verify copy to cloud done")
+
 	return nil
+}
+
+func (t *Task) verifyCopyToCloud(ctx context.Context, destCli storage.Client, srcPrefix, destPrefix string) error {
+	expected, err := storage.ExpectedDestObjects(ctx, t.backupStorage, srcPrefix, destPrefix)
+	if err != nil {
+		return fmt.Errorf("migrate: build expected %w", err)
+	}
+
+	verifyTask := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{
+		Cli:      destCli,
+		Prefix:   destPrefix,
+		Expected: expected,
+	})
+	return verifyTask.Execute(ctx)
 }
 
 func (t *Task) startMigrate(ctx context.Context) error {

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -328,6 +328,15 @@ func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix s
 	if err := task.Execute(ctx); err != nil {
 		return "", fmt.Errorf("restore_collection: copy temporary restore file: %w", err)
 	}
+
+	expected, err := storage.ExpectedDestObjects(ctx, ct.backupStorage, srcPrefix, dest)
+	if err != nil {
+		return "", fmt.Errorf("restore_collection: build expected for copy verify: %w", err)
+	}
+	verifyTask := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{Cli: ct.milvusStorage, Prefix: dest, Expected: expected})
+	if err := verifyTask.Execute(ctx); err != nil {
+		return "", fmt.Errorf("restore_collection: verify temporary restore file: %w", err)
+	}
 	ct.logger.Info("copy temporary restore file success", zap.String("src", srcPrefix), zap.String("dest", dest))
 
 	return dest, nil

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -18,8 +18,7 @@ type CopyAttr struct {
 }
 
 type copierOpt struct {
-	traceFn           TraceFn
-	disableVerifyCopy bool
+	traceFn TraceFn
 }
 
 type TraceFn func(size int64, cost time.Duration)
@@ -69,16 +68,6 @@ func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 			return fmt.Errorf("storage: remote copier copy object %w", err)
 		}
 
-		if !rp.opt.disableVerifyCopy {
-			attr, err := rp.dest.HeadObject(ctx, copyAttr.DestKey)
-			if err != nil {
-				return fmt.Errorf("storage: remote copier verify copy: %w", err)
-			}
-			if attr.Length != copyAttr.Src.Length {
-				return fmt.Errorf("storage: remote copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
-			}
-		}
-
 		return nil
 	})
 
@@ -117,16 +106,6 @@ func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 		i := UploadObjectInput{Body: body, Key: copyAttr.DestKey, Size: copyAttr.Src.Length}
 		if err := sc.dest.UploadObject(ctx, i); err != nil {
 			return fmt.Errorf("storage: server copier upload object %w", err)
-		}
-
-		if !sc.opt.disableVerifyCopy {
-			attr, err := sc.dest.HeadObject(ctx, copyAttr.DestKey)
-			if err != nil {
-				return fmt.Errorf("storage: server copier verify copy: %w", err)
-			}
-			if attr.Length != copyAttr.Src.Length {
-				return fmt.Errorf("storage: server copier size mismatch, src=%d dest=%d", copyAttr.Src.Length, attr.Length)
-			}
 		}
 
 		return nil

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -45,7 +45,6 @@ func TestRemoteCopier_Copy(t *testing.T) {
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
 
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		err := rp.copy(context.Background(), attr)
@@ -77,7 +76,6 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
 
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		err := rp.copy(context.Background(), attr)
@@ -98,7 +96,6 @@ func TestRemoteCopier_Copy(t *testing.T) {
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
 
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		err := rp.copy(context.Background(), attr)
@@ -128,42 +125,6 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, traced)
 	})
-
-	t.Run("HeadObjectError", func(t *testing.T) {
-		dest := NewMockClient(t)
-		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
-
-		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{}, assert.AnError).Once()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := rp.copy(ctx, attr)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "verify copy")
-	})
-
-	t.Run("SizeMismatch", func(t *testing.T) {
-		dest := NewMockClient(t)
-		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
-
-		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 3}, nil).Once()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := rp.copy(ctx, attr)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "size mismatch")
-	})
 }
 
 func TestServerCopier_Copy(t *testing.T) {
@@ -178,54 +139,9 @@ func TestServerCopier_Copy(t *testing.T) {
 
 		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
 		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 5}, nil).Once()
 
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		err := sp.copy(context.Background(), attr)
 		assert.NoError(t, err)
-	})
-
-	t.Run("HeadObjectError", func(t *testing.T) {
-		dest := NewMockClient(t)
-		src := NewMockClient(t)
-		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
-
-		body := io.NopCloser(bytes.NewReader([]byte("hello")))
-		obj := &Object{Body: body, Length: 5}
-		src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
-
-		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
-		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{}, assert.AnError).Once()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := sp.copy(ctx, attr)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "verify copy")
-	})
-
-	t.Run("SizeMismatch", func(t *testing.T) {
-		dest := NewMockClient(t)
-		src := NewMockClient(t)
-		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
-
-		body := io.NopCloser(bytes.NewReader([]byte("hello")))
-		obj := &Object{Body: body, Length: 5}
-		src.EXPECT().GetObject(mock.Anything, "a/b").Return(obj, nil).Once()
-
-		i := UploadObjectInput{Body: body, Key: "c/d", Size: 5}
-		dest.EXPECT().UploadObject(mock.Anything, i).Return(nil).Once()
-		dest.EXPECT().HeadObject(mock.Anything, "c/d").Return(ObjectAttr{Key: "c/d", Length: 3}, nil).Once()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
-		err := sp.copy(ctx, attr)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "size mismatch")
 	})
 }

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -25,8 +25,6 @@ type CopyPrefixOpt struct {
 	TraceFn TraceFn
 
 	CopyByServer bool
-
-	DisableVerifyCopy bool
 }
 
 type CopyPrefixTask struct {
@@ -41,10 +39,7 @@ func NewCopyPrefixTask(opt CopyPrefixOpt) *CopyPrefixTask {
 	return &CopyPrefixTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{
-			traceFn:           opt.TraceFn,
-			disableVerifyCopy: opt.DisableVerifyCopy,
-		}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
 
 		logger: log.L().With(zap.String("src", opt.SrcPrefix), zap.String("dest", opt.DestPrefix)),
 	}
@@ -110,8 +105,6 @@ type CopyObjectsOpt struct {
 	TraceFn TraceFn
 
 	CopyByServer bool
-
-	DisableVerifyCopy bool
 }
 
 type CopyObjectsTask struct {
@@ -124,10 +117,7 @@ func NewCopyObjectsTask(opt CopyObjectsOpt) *CopyObjectsTask {
 	return &CopyObjectsTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{
-			traceFn:           opt.TraceFn,
-			disableVerifyCopy: opt.DisableVerifyCopy,
-		}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
 	}
 }
 

--- a/internal/storage/copy_task_test.go
+++ b/internal/storage/copy_task_test.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/zilliztech/milvus-backup/internal/retry"
+)
+
+// errorIterator reports a next item but always fails when read.
+type errorIterator struct{}
+
+func (errorIterator) HasNext() bool             { return true }
+func (errorIterator) Next() (ObjectAttr, error) { return ObjectAttr{}, assert.AnError }
+
+func TestCopyPrefixTask_Execute(t *testing.T) {
+	t.Run("CopiesAllAndRemapsKeys", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+
+		objs := []ObjectAttr{
+			{Key: "src/a", Length: 1},
+			{Key: "src/b/c", Length: 2},
+			{Key: "src/dir/", Length: 0}, // directory marker, must be skipped
+		}
+		src.EXPECT().ListPrefix(mock.Anything, "src/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "src/a", Length: 1}, DestKey: "dest/a"}).Return(nil).Once()
+		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "src/b/c", Length: 2}, DestKey: "dest/b/c"}).Return(nil).Once()
+
+		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(2)})
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("ListError", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+		src.EXPECT().ListPrefix(mock.Anything, "src/", true).Return(nil, assert.AnError).Once()
+
+		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(2)})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "walk prefix")
+	})
+
+	t.Run("CopyError", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+		objs := []ObjectAttr{{Key: "src/a", Length: 1}}
+		src.EXPECT().ListPrefix(mock.Anything, "src/", true).Return(&mockObjectIterator{objs: objs}, nil).Once()
+		dest.EXPECT().CopyObject(mock.Anything, mock.Anything).Return(retry.Unrecoverable(assert.AnError)).Once()
+
+		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(1)})
+		assert.Error(t, task.Execute(context.Background()))
+	})
+}
+
+func TestCopyObjectsTask_Execute(t *testing.T) {
+	t.Run("CopiesAllObjects", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+
+		attrs := []CopyAttr{
+			{Src: ObjectAttr{Key: "a", Length: 1}, DestKey: "x"},
+			{Src: ObjectAttr{Key: "b", Length: 2}, DestKey: "y"},
+		}
+		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a", Length: 1}, DestKey: "x"}).Return(nil).Once()
+		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "b", Length: 2}, DestKey: "y"}).Return(nil).Once()
+
+		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(2)})
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("CopyByServerUploadsAll", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+
+		body := io.NopCloser(bytes.NewReader([]byte("hi")))
+		src.EXPECT().GetObject(mock.Anything, "a").Return(&Object{Body: body, Length: 2}, nil).Once()
+		dest.EXPECT().UploadObject(mock.Anything, UploadObjectInput{Body: body, Key: "x", Size: 2}).Return(nil).Once()
+
+		attrs := []CopyAttr{{Src: ObjectAttr{Key: "a", Length: 2}, DestKey: "x"}}
+		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1), CopyByServer: true})
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("CopyError", func(t *testing.T) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+
+		attrs := []CopyAttr{{Src: ObjectAttr{Key: "a", Length: 1}, DestKey: "x"}}
+		dest.EXPECT().CopyObject(mock.Anything, mock.Anything).Return(retry.Unrecoverable(assert.AnError)).Once()
+
+		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1)})
+		assert.Error(t, task.Execute(context.Background()))
+	})
+}

--- a/internal/storage/funcs.go
+++ b/internal/storage/funcs.go
@@ -45,6 +45,29 @@ func ListPrefixFlat(ctx context.Context, cli Client, prefix string, recursive bo
 	return keys, sizes, nil
 }
 
+// ExpectedDestObjects lists srcPrefix on src and returns the destination keys
+// (mapped by replacing srcPrefix with destPrefix, matching CopyPrefixTask) to
+// their sizes. The result feeds VerifyPrefixTask to verify a prefix copy.
+// Directory markers (empty objects whose key ends with "/") are skipped,
+// consistent with what CopyPrefixTask copies.
+func ExpectedDestObjects(ctx context.Context, src Client, srcPrefix, destPrefix string) (map[string]int64, error) {
+	keys, sizes, err := ListPrefixFlat(ctx, src, srcPrefix, true)
+	if err != nil {
+		return nil, fmt.Errorf("storage: expected dest objects list prefix %w", err)
+	}
+
+	expected := make(map[string]int64, len(keys))
+	for idx, key := range keys {
+		if sizes[idx] == 0 && strings.HasSuffix(key, "/") {
+			continue
+		}
+		destKey := strings.Replace(key, srcPrefix, destPrefix, 1)
+		expected[destKey] = sizes[idx]
+	}
+
+	return expected, nil
+}
+
 func DeletePrefix(ctx context.Context, cli Client, prefix string) error {
 	if prefix == "" {
 		return fmt.Errorf("storage: delete prefix empty prefix")

--- a/internal/storage/verify_task.go
+++ b/internal/storage/verify_task.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/internal/log"
+)
+
+// _missingSampleSize bounds how many missing keys are listed in the error so a
+// large failure does not produce an unreadable message.
+const _missingSampleSize = 5
+
+type VerifyPrefixOpt struct {
+	// Cli is the storage client used to list the objects under Prefix.
+	Cli Client
+	// Prefix is the destination prefix to list recursively.
+	Prefix string
+	// Expected maps every object key that must exist under Prefix to its
+	// expected size.
+	Expected map[string]int64
+}
+
+// VerifyPrefixTask verifies that every object in Expected exists under Prefix
+// with a matching size. It lists the prefix once instead of issuing a HeadObject
+// per object, so the request count drops from O(N) to O(N/1000) (ListObjects
+// returns up to 1000 keys per request) and it only needs ListObjects permission.
+type VerifyPrefixTask struct {
+	opt VerifyPrefixOpt
+
+	logger *zap.Logger
+}
+
+func NewVerifyPrefixTask(opt VerifyPrefixOpt) *VerifyPrefixTask {
+	return &VerifyPrefixTask{
+		opt:    opt,
+		logger: log.L().With(zap.String("prefix", opt.Prefix)),
+	}
+}
+
+func (t *VerifyPrefixTask) Execute(ctx context.Context) error {
+	if len(t.opt.Expected) == 0 {
+		return nil
+	}
+	t.logger.Info("start verify prefix", zap.Int("expected_num", len(t.opt.Expected)))
+
+	iter, err := t.opt.Cli.ListPrefix(ctx, t.opt.Prefix, true)
+	if err != nil {
+		return fmt.Errorf("storage: verify prefix list prefix %w", err)
+	}
+
+	// Track keys not yet seen in the listing; drop each as it is found.
+	missing := make(map[string]int64, len(t.opt.Expected))
+	for key, size := range t.opt.Expected {
+		missing[key] = size
+	}
+
+	for iter.HasNext() {
+		attr, err := iter.Next()
+		if err != nil {
+			return fmt.Errorf("storage: verify prefix iter object %w", err)
+		}
+
+		want, ok := t.opt.Expected[attr.Key]
+		if !ok {
+			continue
+		}
+		if attr.Length != want {
+			return fmt.Errorf("storage: verify prefix size mismatch, key=%s want=%d got=%d", attr.Key, want, attr.Length)
+		}
+		delete(missing, attr.Key)
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("storage: verify prefix %d objects missing under %s, e.g. [%s]",
+			len(missing), t.opt.Prefix, sampleKeys(missing))
+	}
+
+	t.logger.Info("verify prefix success", zap.Int("verified_num", len(t.opt.Expected)))
+	return nil
+}
+
+// sampleKeys returns up to _missingSampleSize keys joined by ", " for error
+// messages.
+func sampleKeys(keys map[string]int64) string {
+	sample := make([]string, 0, _missingSampleSize)
+	for key := range keys {
+		sample = append(sample, key)
+		if len(sample) == _missingSampleSize {
+			break
+		}
+	}
+	return strings.Join(sample, ", ")
+}

--- a/internal/storage/verify_task_test.go
+++ b/internal/storage/verify_task_test.go
@@ -1,0 +1,171 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestVerifyPrefixTask_Execute(t *testing.T) {
+	t.Run("AllPresent", func(t *testing.T) {
+		cli := NewMockClient(t)
+		objs := []ObjectAttr{
+			{Key: "dest/a", Length: 1},
+			{Key: "dest/b", Length: 2},
+		}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1, "dest/b": 2},
+		})
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("ExtraObjectsIgnored", func(t *testing.T) {
+		cli := NewMockClient(t)
+		objs := []ObjectAttr{
+			{Key: "dest/a", Length: 1},
+			{Key: "dest/extra", Length: 9},
+		}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1},
+		})
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("SizeMismatch", func(t *testing.T) {
+		cli := NewMockClient(t)
+		objs := []ObjectAttr{{Key: "dest/a", Length: 3}}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1},
+		})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "size mismatch")
+	})
+
+	t.Run("Missing", func(t *testing.T) {
+		cli := NewMockClient(t)
+		objs := []ObjectAttr{{Key: "dest/a", Length: 1}}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1, "dest/b": 2},
+		})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing")
+		assert.Contains(t, err.Error(), "dest/b")
+	})
+
+	t.Run("ManyMissingSampleCapped", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(&mockObjectIterator{}, nil).Once()
+
+		expected := make(map[string]int64, _missingSampleSize+3)
+		for i := 0; i < _missingSampleSize+3; i++ {
+			expected[fmt.Sprintf("dest/%d", i)] = 1
+		}
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{Cli: cli, Prefix: "dest/", Expected: expected})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing")
+	})
+
+	t.Run("EmptyExpectedSkipsList", func(t *testing.T) {
+		cli := NewMockClient(t)
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{},
+		})
+		// No ListPrefix expectation: an empty expected set must not call the API.
+		assert.NoError(t, task.Execute(context.Background()))
+	})
+
+	t.Run("ListError", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(nil, assert.AnError).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1},
+		})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "list prefix")
+	})
+
+	t.Run("IterError", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "dest/", true).
+			Return(errorIterator{}, nil).Once()
+
+		task := NewVerifyPrefixTask(VerifyPrefixOpt{
+			Cli:      cli,
+			Prefix:   "dest/",
+			Expected: map[string]int64{"dest/a": 1},
+		})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "iter object")
+	})
+}
+
+func TestExpectedDestObjects(t *testing.T) {
+	t.Run("MapsKeysAndSkipsDirMarkers", func(t *testing.T) {
+		cli := NewMockClient(t)
+		objs := []ObjectAttr{
+			{Key: "src/a", Length: 1},
+			{Key: "src/sub/b", Length: 2},
+			{Key: "src/dir/", Length: 0}, // directory marker, must be skipped
+		}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "src/", true).
+			Return(&mockObjectIterator{objs: objs}, nil).Once()
+
+		expected, err := ExpectedDestObjects(context.Background(), cli, "src/", "dest/")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]int64{"dest/a": 1, "dest/sub/b": 2}, expected)
+	})
+
+	t.Run("ListError", func(t *testing.T) {
+		cli := NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "src/", true).
+			Return(nil, assert.AnError).Once()
+
+		_, err := ExpectedDestObjects(context.Background(), cli, "src/", "dest/")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "list prefix")
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1050

Per-object `HeadObject` verification after each copy cost one API request per file and required `HeadObject`/`GetObject` permission — which is exactly why `migrate` failed against a Zilliz Cloud Stage whose credentials grant `PutObject`/`ListObject` but deny `HeadObject`.

This replaces it with a standalone `VerifyPrefixTask` that lists a destination prefix once and checks every expected key exists with a matching size, cutting the request count from O(N) to O(N/1000) (`ListObjects` returns up to 1000 keys per request) and needing only `ListObject` permission.

Copy tasks (`CopyPrefixTask`/`CopyObjectsTask`) no longer verify — they only copy. The orchestrating layer runs `VerifyPrefixTask` after the copy, where operating in terms of prefixes is natural.

## Changes

- Add `VerifyPrefixTask` (`internal/storage/verify_task.go`): recursively lists a prefix once and verifies every key in `Expected` exists with a matching size.
- Add `MirrorExpected` helper (`internal/storage/funcs.go`): lists a source prefix and maps keys to destination keys (skipping directory markers), to build the expected set for prefix copies.
- Remove per-file `HeadObject` verification and the `disableVerifyCopy`/`DisableVerifyCopy` flag from the copiers and copy tasks.
- `backup`: verify per collection over the `insert_log`/`delta_log` dirs after all segments are copied.
- `migrate`/`restore`/`check`: build the expected set from the source prefix and verify the destination prefix after copy. This restores copy verification for the cloud staging volume, which only grants `ListObject`.
- Update `copier_test.go` and add `verify_task_test.go`.

### Note

Previously a size mismatch triggered a per-file retry inside the copier. With batched verification, a mismatch or missing object now fails the whole verify step (no automatic re-copy), surfacing the problem loudly for a re-run.
