### PR TITLE
fix(deps): bump google.golang.org/api to v0.259.0 (fix gcpnative 'multiple credential options provided')

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
-	google.golang.org/api v0.258.0
+	google.golang.org/api v0.259.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
-google.golang.org/api v0.258.0 h1:IKo1j5FBlN74fe5isA2PVozN3Y5pwNKriEgAXPOkDAc=
-google.golang.org/api v0.258.0/go.mod h1:qhOMTQEZ6lUps63ZNq9jhODswwjkjYYguA7fA3TBFww=
+google.golang.org/api v0.259.0 h1:90TaGVIxScrh1Vn/XI2426kRpBqHwWIzVBzJsVZ5XrQ=
+google.golang.org/api v0.259.0/go.mod h1:LC2ISWGWbRoyQVpxGntWwLWN/vLNxxKBK9KuJRI8Te4=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
## Problem
The `gcpnative` storage client fails at init with:
```
storage: create gcp native client: dialing: multiple credential options provided
```
when milvus-backup is configured with explicit GCP credentials (a JSON key →
`option.WithCredentials`) in an environment that **also** has ambient Application
Default Credentials — e.g. running on **GKE with Workload Identity**. The option
validator in `google.golang.org/api` v0.258.0 treats the explicit credential
option as a conflict.

This is **independent of #1047** (the standard-GCS endpoint fix): with #1047 in
place, `WithEndpoint` is correctly skipped for the standard host so only
`option.WithCredentials` is passed — yet client init still fails on the
validation in v0.258.0.

## Fix
Bump `google.golang.org/api` v0.258.0 → v0.259.0, which includes
[googleapis/google-api-go-client#3420](https://github.com/googleapis/google-api-go-client/pull/3420)
("remove `option.WithAuthCredentials` from validation"). `go mod tidy`
regenerated; `go build ./...` passes.

## Verification
A milvus-backup build with this bump runs `gcpnative` backups to GCS
successfully in production (GKE + Workload Identity + a mounted JSON key).
Without it, the same configuration fails at client init as above.