### PR TITLE
backup: scope index extra etcd scan to backed-up collections

### DIFF
--- a/core/backup/coll_index_extra_task.go
+++ b/core/backup/coll_index_extra_task.go
@@ -35,28 +35,38 @@ func newCollIndexExtraTask(taskID string, kv clientv3.KV, etcdRootPath string, m
 }
 
 func (ciet *collIndexExtraTask) Execute(ctx context.Context) error {
-	prefix := fmt.Sprintf("%s/meta/field-index/", ciet.etcdRootPath)
-	ciet.logger.Info("start to get index info from etcd", zap.String("prefix", prefix))
-	resp, err := ciet.kv.Get(ctx, prefix, clientv3.WithPrefix())
-	if err != nil {
-		return fmt.Errorf("backup: get indexes from etcd %w", err)
-	}
-	ciet.logger.Info("get indexes from etcd done", zap.Int("count", len(resp.Kvs)))
+	// The etcd field-index key is "field-index/{collectionID}/{indexID}", so we
+	// scope the scan to the backed-up collections instead of reading the whole
+	// instance. A cluster-wide scan would return indexes of collections that are
+	// not part of this backup, which have no matching IndexInfo to merge into.
+	collIDs := ciet.metaBuilder.backupCollectionIDs()
 
-	indexes := make([]*indexpb.FieldIndex, 0, len(resp.Kvs))
-	for _, kv := range resp.Kvs {
-		index := &indexpb.FieldIndex{}
-		if err := proto.Unmarshal(kv.Value, index); err != nil {
-			return fmt.Errorf("backup: unmarshal index %w", err)
+	indexes := make([]*indexpb.FieldIndex, 0)
+	for _, collID := range collIDs {
+		prefix := fmt.Sprintf("%s/meta/field-index/%d/", ciet.etcdRootPath, collID)
+		ciet.logger.Info("start to get index info from etcd", zap.String("prefix", prefix))
+		resp, err := ciet.kv.Get(ctx, prefix, clientv3.WithPrefix())
+		if err != nil {
+			return fmt.Errorf("backup: get indexes from etcd %w", err)
 		}
-		if index.GetDeleted() {
-			ciet.logger.Info("skip deleted index", zap.Int64("index_id", index.GetIndexInfo().GetIndexID()))
-			continue
+		ciet.logger.Info("get indexes from etcd done", zap.Int64("coll_id", collID), zap.Int("count", len(resp.Kvs)))
+
+		for _, kv := range resp.Kvs {
+			index := &indexpb.FieldIndex{}
+			if err := proto.Unmarshal(kv.Value, index); err != nil {
+				return fmt.Errorf("backup: unmarshal index %w", err)
+			}
+			if index.GetDeleted() {
+				ciet.logger.Info("skip deleted index", zap.Int64("index_id", index.GetIndexInfo().GetIndexID()))
+				continue
+			}
+			indexes = append(indexes, index)
 		}
-		indexes = append(indexes, index)
 	}
 
-	ciet.metaBuilder.addIndexExtraInfo(indexes)
+	if err := ciet.metaBuilder.addIndexExtraInfo(indexes); err != nil {
+		return fmt.Errorf("backup: add index extra info %w", err)
+	}
 
 	ciet.logger.Info("backup index extra info done")
 	return nil

--- a/core/backup/coll_index_extra_task_test.go
+++ b/core/backup/coll_index_extra_task_test.go
@@ -1,0 +1,103 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/namespace"
+)
+
+// fakeKV implements clientv3.KV but only supports prefix Get, which is all the
+// index extra task needs. Any other method would panic via the embedded nil
+// interface, surfacing accidental use.
+type fakeKV struct {
+	clientv3.KV
+
+	data map[string][]byte
+}
+
+func (f *fakeKV) Get(_ context.Context, key string, _ ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	resp := &clientv3.GetResponse{}
+	for k, v := range f.data {
+		if strings.HasPrefix(k, key) {
+			resp.Kvs = append(resp.Kvs, &mvccpb.KeyValue{Key: []byte(k), Value: v})
+		}
+	}
+
+	return resp, nil
+}
+
+func mustMarshalFieldIndex(t *testing.T, idx *indexpb.FieldIndex) []byte {
+	data, err := proto.Marshal(idx)
+	require.NoError(t, err)
+	return data
+}
+
+func TestCollIndexExtraTaskExecute(t *testing.T) {
+	const rootPath = "by-dev"
+
+	newBuilder := func() *metaBuilder {
+		builder := newMetaBuilder("task1", "backup1")
+		builder.addCollection(namespace.New("db1", "coll1"), &backuppb.CollectionBackupInfo{
+			CollectionId:   1,
+			DbName:         "db1",
+			CollectionName: "coll1",
+			IndexInfos:     []*backuppb.IndexInfo{{IndexId: 100, FieldName: "vec", IndexName: "vec_idx"}},
+		})
+
+		return builder
+	}
+
+	t.Run("ScopesToBackupCollections", func(t *testing.T) {
+		builder := newBuilder()
+		kv := &fakeKV{data: map[string][]byte{
+			// backed-up collection, matching index -> merged
+			fmt.Sprintf("%s/meta/field-index/1/100", rootPath): mustMarshalFieldIndex(t, &indexpb.FieldIndex{
+				IndexInfo:  &indexpb.IndexInfo{CollectionID: 1, IndexID: 100, FieldID: 5},
+				CreateTime: 123,
+			}),
+			// deleted index of the backed-up collection -> skipped
+			fmt.Sprintf("%s/meta/field-index/1/101", rootPath): mustMarshalFieldIndex(t, &indexpb.FieldIndex{
+				IndexInfo: &indexpb.IndexInfo{CollectionID: 1, IndexID: 101},
+				Deleted:   true,
+			}),
+			// index of a collection NOT in this backup -> must not be fetched,
+			// otherwise it would have no matching IndexInfo and fail.
+			fmt.Sprintf("%s/meta/field-index/999/200", rootPath): mustMarshalFieldIndex(t, &indexpb.FieldIndex{
+				IndexInfo: &indexpb.IndexInfo{CollectionID: 999, IndexID: 200},
+			}),
+		}}
+
+		task := newCollIndexExtraTask("task1", kv, rootPath, builder)
+		assert.NoError(t, task.Execute(context.Background()))
+
+		got := builder.collectionBackups[1].GetIndexInfos()[0]
+		assert.Equal(t, int64(5), got.GetFieldId())
+		assert.Equal(t, uint64(123), got.GetCreateTime())
+	})
+
+	t.Run("MissingIndexInBackupReturnsError", func(t *testing.T) {
+		builder := newBuilder()
+		kv := &fakeKV{data: map[string][]byte{
+			// backed-up collection, but index id is not in IndexInfos
+			fmt.Sprintf("%s/meta/field-index/1/300", rootPath): mustMarshalFieldIndex(t, &indexpb.FieldIndex{
+				IndexInfo: &indexpb.IndexInfo{CollectionID: 1, IndexID: 300},
+			}),
+		}}
+
+		task := newCollIndexExtraTask("task1", kv, rootPath, builder)
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not in backup index infos")
+	})
+}

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -133,7 +133,30 @@ func (builder *metaBuilder) addSegments(segments []*backuppb.SegmentBackupInfo) 
 	return nil
 }
 
-func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) {
+// backupCollectionIDs returns the collection ids that have been captured by
+// this backup. The index extra task uses it to scope the etcd field-index scan
+// to the backed-up collections only.
+func (builder *metaBuilder) backupCollectionIDs() []int64 {
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	colls := builder.data.GetCollectionBackups()
+	ids := make([]int64, 0, len(colls))
+	for _, coll := range colls {
+		ids = append(ids, coll.GetCollectionId())
+	}
+
+	return ids
+}
+
+// addIndexExtraInfo merges the extra index attributes read from etcd into the
+// index infos already collected via DescribeIndex. The caller must only pass
+// indexes that belong to backed-up collections (the etcd scan is scoped per
+// collection). Every index is expected to have a matching IndexInfo; a miss
+// means etcd and DescribeIndex disagree, which would produce an incomplete
+// backup that breaks CDC secondary restore, so it is reported as an error
+// rather than silently skipped.
+func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) error {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
 
@@ -148,7 +171,16 @@ func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) {
 
 	for _, index := range indexes {
 		info := index.GetIndexInfo()
-		indexInfo := indexMap[info.GetCollectionID()][info.GetIndexID()]
+		collIndexes, ok := indexMap[info.GetCollectionID()]
+		if !ok {
+			return fmt.Errorf("backup: index extra info references collection %d not in backup", info.GetCollectionID())
+		}
+		indexInfo, ok := collIndexes[info.GetIndexID()]
+		if !ok {
+			return fmt.Errorf("backup: index %d of collection %d exists in etcd but not in backup index infos",
+				info.GetIndexID(), info.GetCollectionID())
+		}
+
 		indexInfo.FieldId = info.GetFieldID()
 		indexInfo.TypeParams = pbconv.MilvusKVToBakKV(info.GetTypeParams())
 		indexInfo.CreateTime = index.GetCreateTime()
@@ -158,6 +190,8 @@ func (builder *metaBuilder) addIndexExtraInfo(indexes []*indexpb.FieldIndex) {
 		indexInfo.MinIndexVersion = info.GetMinIndexVersion()
 		indexInfo.MaxIndexVersion = info.GetMaxIndexVersion()
 	}
+
+	return nil
 }
 
 // addDynamicFields injects the dynamic field schema (read directly from etcd)

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
@@ -295,4 +296,67 @@ func TestSequentialBuildDoesNotCorruptData(t *testing.T) {
 		totalSegs += len(part.GetSegmentBackups())
 	}
 	assert.Equal(t, 2, totalSegs)
+}
+
+func newIndexExtraTestBuilder() *metaBuilder {
+	builder := newMetaBuilder("task1", "backup1")
+	ns := namespace.New("db1", "coll1")
+	builder.addCollection(ns, &backuppb.CollectionBackupInfo{
+		CollectionId:   1,
+		DbName:         "db1",
+		CollectionName: "coll1",
+		IndexInfos:     []*backuppb.IndexInfo{{IndexId: 100, FieldName: "vec", IndexName: "vec_idx"}},
+	})
+
+	return builder
+}
+
+func TestAddIndexExtraInfo(t *testing.T) {
+	t.Run("MergesExtraAttributes", func(t *testing.T) {
+		builder := newIndexExtraTestBuilder()
+
+		indexes := []*indexpb.FieldIndex{
+			{
+				IndexInfo:  &indexpb.IndexInfo{CollectionID: 1, IndexID: 100, FieldID: 7, IsAutoIndex: true, MinIndexVersion: 1, MaxIndexVersion: 2},
+				CreateTime: 42,
+			},
+		}
+		assert.NoError(t, builder.addIndexExtraInfo(indexes))
+
+		got := builder.collectionBackups[1].GetIndexInfos()[0]
+		assert.Equal(t, int64(7), got.GetFieldId())
+		assert.Equal(t, uint64(42), got.GetCreateTime())
+		assert.True(t, got.GetIsAutoIndex())
+		assert.Equal(t, int32(1), got.GetMinIndexVersion())
+		assert.Equal(t, int32(2), got.GetMaxIndexVersion())
+	})
+
+	t.Run("UnknownCollectionID", func(t *testing.T) {
+		builder := newIndexExtraTestBuilder()
+
+		indexes := []*indexpb.FieldIndex{
+			{IndexInfo: &indexpb.IndexInfo{CollectionID: 999, IndexID: 100}},
+		}
+		err := builder.addIndexExtraInfo(indexes)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "collection 999 not in backup")
+	})
+
+	t.Run("IndexNotInBackupInfos", func(t *testing.T) {
+		builder := newIndexExtraTestBuilder()
+
+		indexes := []*indexpb.FieldIndex{
+			{IndexInfo: &indexpb.IndexInfo{CollectionID: 1, IndexID: 300}},
+		}
+		err := builder.addIndexExtraInfo(indexes)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not in backup index infos")
+	})
+}
+
+func TestBackupCollectionIDs(t *testing.T) {
+	builder := newIndexExtraTestBuilder()
+	builder.addCollection(namespace.New("db1", "coll2"), &backuppb.CollectionBackupInfo{CollectionId: 2})
+
+	assert.ElementsMatch(t, []int64{1, 2}, builder.backupCollectionIDs())
 }


### PR DESCRIPTION
## Summary
Fix a nil pointer panic (SIGSEGV) in the index extra info backup task. The task scanned the whole instance's `meta/field-index/` etcd prefix but matched the results only against the backed-up collections. A non-deleted index belonging to a collection outside the backup had no matching `IndexInfo`, so `addIndexExtraInfo` dereferenced a nil pointer and panicked.

## Changes
- `coll_index_extra_task`: scope the etcd scan per backed-up collection using the `field-index/{collectionID}/` key prefix, so indexes of collections outside this backup are never fetched.
- `metaBuilder`: add `backupCollectionIDs()`; make `addIndexExtraInfo` return an error instead of panicking or silently skipping when an index of a backed-up collection has no matching `IndexInfo` — a missing index would produce an incomplete backup that breaks CDC secondary restore.
- Add unit tests covering merge, unknown collection, missing index, and the per-collection scan scoping (out-of-scope collections are not fetched, deleted indexes skipped).

/kind improvement