### PR TITLE
milvus: collapse four-part hotfix versions for feature detection

### DIFF
--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -471,7 +471,12 @@ func (g *GrpcClient) checkFeature(ctx context.Context) error {
 // "2.6-20260404-31fb3fc" as "2.6.0-20260404-31fb3fc" — a prerelease of 2.6.0 — which
 // compares LESS than 2.6.x and silently disables features on dev builds.
 func (g *GrpcClient) parseVersionForFeature(ver string) *semver.Version {
-	sem, err := semver.StrictNewVersion(strings.TrimPrefix(ver, "v"))
+	v := strings.TrimPrefix(ver, "v")
+	// Collapse four-part hotfix versions to their release base, e.g. "2.3.22.6" -> "2.3.22".
+	if parts := strings.SplitN(v, ".", 4); len(parts) == 4 {
+		v = strings.Join(parts[:3], ".")
+	}
+	sem, err := semver.StrictNewVersion(v)
 	if err != nil {
 		g.logger.Warn("cannot parse server version as strict semver, treat as latest dev build",
 			zap.String("version", ver), zap.Error(err))

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -208,6 +208,16 @@ func TestGrpcClient_parseVersionForFeature(t *testing.T) {
 		{"VPrefixV2.6.5_HasMultiL0", "v2.6.5", ">= 2.6.5-0", true},
 		{"VPrefixV2.5.20_HasReplicateMessage", "v2.5.20", ">= 2.5.0-0, < 2.6.0-0", true},
 
+		// Four-part versions collapse to their release base. Without the collapse
+		// these fail StrictNewVersion, fall back to _latestDevVersion, and wrongly
+		// enable features the underlying release does not implement.
+		// "v2.4.0.1-gpu-beta" and "v2.4.0.2-gpu-beta" are real milvusdb/milvus tags;
+		// the trailing component (with its prerelease suffix) is dropped to "2.4.0".
+		{"FourPartV2.4.0.1GpuBeta_NoMultiL0", "v2.4.0.1-gpu-beta", ">= 2.6.5-0", false},
+		{"FourPartV2.4.0.1GpuBeta_NoDescribeDatabase", "v2.4.0.1-gpu-beta", ">= 2.4.3-0", false},
+		{"FourPartV2.3.22.6_NoMultiL0", "v2.3.22.6", ">= 2.6.5-0", false},
+		{"FourPartV2.6.5.3_HasMultiL0", "v2.6.5.3", ">= 2.6.5-0", true},
+
 		// Dev RC tag: must be treated as latest dev (and pass all >= constraints).
 		// Without StrictNewVersion this regresses: lenient parser turns it into
 		// 2.6.0-20260404-31fb3fc, which is LESS than 2.6.5-0 and disables features.


### PR DESCRIPTION
## Summary
`parseVersionForFeature` parses the server's `BuildTags` with `StrictNewVersion`, which only accepts `MAJOR.MINOR.PATCH`. Four-part version strings (e.g. the real `v2.4.0.1-gpu-beta` Docker image tag, or internal/enterprise patch-line versions like `v2.3.22.6`) fail strict parsing and fall back to the `_latestDevVersion` sentinel (99.0.0). That silently enables every `>=` gated feature — e.g. `FlushAll` (>= 2.6.11) and `MultiL0InOneJob` (>= 2.6.5) — on a server that does not implement them, leading to runtime `Unimplemented` errors.

These four-part versions are an image/release-layer construct rather than source release tags (`git describe` never emits a four-part dotted version), but the backup tool should stay robust against whatever `BuildTags` the server reports.

## Changes
- collapse four-part (or longer) versions to their `MAJOR.MINOR.PATCH` release base before strict semver parsing, e.g. `v2.4.0.1-gpu-beta` -> `2.4.0`; the dropped trailing component takes any prerelease suffix with it
- leave the existing dev-build fallback untouched: tags like `2.6-20260404-31fb3fc` and `master-20260226-abcdef` have fewer than four dot-separated parts, so they still fall through to `_latestDevVersion`
- add tests covering real (`v2.4.0.1-gpu-beta`) and synthetic four-part versions

/kind improvement