### PR TITLE
feat(restore): resumable restore via local breakpoint ledger

### DIFF
--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -2,9 +2,12 @@ package restore
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -43,6 +46,14 @@ type options struct {
 	skipCreateCollection bool
 	rbac                 bool
 	useV2Restore         bool
+
+	// resumable restore (breakpoint)
+	segmentsPerBatch int
+	maxRetry         int
+	retryBackoffSec  int
+	maxBackoffSec    int
+	breakpoint       string
+	resume           bool
 }
 
 func (o *options) validate() error {
@@ -81,6 +92,10 @@ func (o *options) validate() error {
 		return errors.New("suffix and rename flag cannot be set at the same time")
 	}
 
+	if o.resume && o.breakpoint == "" {
+		return errors.New("--resume requires --breakpoint to point at the ledger from the previous run")
+	}
+
 	if o.dropExistCollection && o.skipCreateCollection {
 		return errors.New("drop_exist_collection and skip_create_collection cannot be true at the same time")
 	}
@@ -114,6 +129,14 @@ func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.skipCreateCollection, "skip_create_collection", "", false, "if true, will skip collection, use when collection exist, restore index or data")
 	cmd.Flags().BoolVarP(&o.rbac, "rbac", "", false, "whether restore RBAC meta")
 	cmd.Flags().BoolVarP(&o.useV2Restore, "use_v2_restore", "", false, "if true, use multi-segment merged restore")
+
+	// resumable restore (breakpoint). Only active when --breakpoint is set.
+	cmd.Flags().StringVarP(&o.breakpoint, "breakpoint", "", "", "local JSON file recording restore progress; supply the same path with --resume to continue an interrupted restore")
+	cmd.Flags().BoolVarP(&o.resume, "resume", "", false, "resume from --breakpoint: skip already-imported segments and reconcile in-flight import jobs")
+	cmd.Flags().IntVarP(&o.segmentsPerBatch, "segments_per_batch", "", 0, "max segments per import job (smaller = smaller blast radius on a failure); 0 keeps the default 256")
+	cmd.Flags().IntVarP(&o.maxRetry, "max_retry", "", 0, "extra retries for a failed import job, with exponential backoff (0 = no retry)")
+	cmd.Flags().IntVarP(&o.retryBackoffSec, "retry_backoff_sec", "", 5, "base backoff in seconds between import-job retries")
+	cmd.Flags().IntVarP(&o.maxBackoffSec, "retry_max_backoff_sec", "", 60, "max backoff in seconds between import-job retries")
 }
 
 func (o *options) toOption() *restore.Option {
@@ -128,6 +151,12 @@ func (o *options) toOption() *restore.Option {
 		MetaOnly:             o.metaOnly,
 		UseV2Restore:         o.useV2Restore,
 		RestoreRBAC:          o.rbac,
+
+		SegmentsPerBatch: o.segmentsPerBatch,
+		MaxRetry:         o.maxRetry,
+		RetryBaseBackoff: time.Duration(o.retryBackoffSec) * time.Second,
+		RetryMaxBackoff:  time.Duration(o.maxBackoffSec) * time.Second,
+		Resume:           o.resume,
 	}
 }
 
@@ -286,15 +315,30 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 		return restore.TaskArgs{}, fmt.Errorf("read backup meta: %w", err)
 	}
 
+	// With a breakpoint the restore identity must be stable across runs (it
+	// drives temp-dir naming, so a re-run can reuse already-copied files). Derive
+	// it deterministically from the breakpoint path. Without a breakpoint, keep
+	// the historical per-run UUID.
+	taskID := uuid.NewString()
+	breakpointPath := o.breakpoint
+	if breakpointPath != "" {
+		if abs, aerr := filepath.Abs(breakpointPath); aerr == nil {
+			breakpointPath = abs
+		}
+		sum := sha256.Sum256([]byte(breakpointPath))
+		taskID = "restore_bp_" + hex.EncodeToString(sum[:8])
+	}
+
 	return restore.TaskArgs{
-		TaskID:        uuid.NewString(),
-		Backup:        backup,
-		Plan:          plan,
-		Option:        o.toOption(),
-		Params:        params,
-		BackupDir:     mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
-		BackupStorage: backupStorage,
-		MilvusStorage: milvusStorage,
+		TaskID:         taskID,
+		Backup:         backup,
+		Plan:           plan,
+		Option:         o.toOption(),
+		Params:         params,
+		BackupDir:      mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
+		BackupStorage:  backupStorage,
+		MilvusStorage:  milvusStorage,
+		BreakpointPath: breakpointPath,
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}, nil

--- a/core/restore/breakpoint/breakpoint.go
+++ b/core/restore/breakpoint/breakpoint.go
@@ -1,0 +1,206 @@
+// Package breakpoint provides a local-disk, JSON-backed resume ledger for the
+// restore flow. It records which backup segments have been confirmed imported
+// (so a re-run skips them) and which import jobs were issued but not yet
+// confirmed (so a re-run can reconcile them against Milvus and avoid importing
+// the same data twice).
+//
+// The ledger is a single JSON file on the local filesystem. Writes are
+// infrequent (one per import-job state transition, and jobs take seconds to
+// minutes), so a mutex-guarded full rewrite is more than fast enough. Every
+// write goes to a temp file and is renamed into place, so a crash never leaves
+// a half-written ledger.
+package breakpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// InflightJob records an import job that was issued but whose terminal state
+// has not yet been persisted. On resume these are reconciled against Milvus via
+// GetImportState before any segment is re-issued.
+type InflightJob struct {
+	NS   string  `json:"ns"`   // target namespace, "db.collection"
+	Segs []int64 `json:"segs"` // backup segment IDs covered by this job
+}
+
+// state is the on-disk shape of the ledger.
+type state struct {
+	RestoreID  string                 `json:"restoreId"`
+	BackupName string                 `json:"backupName"`
+	Completed  map[string][]int64     `json:"completed"` // ns -> confirmed-imported segment IDs
+	Inflight   map[string]InflightJob `json:"inflight"`  // jobID -> issued-but-unconfirmed
+}
+
+// Tracker is a concurrency-safe handle over the ledger file.
+type Tracker struct {
+	path string
+
+	mu sync.Mutex
+	st state
+	// completedIdx mirrors st.Completed as sets for O(1) membership tests.
+	completedIdx map[string]map[int64]struct{}
+}
+
+// Open loads the ledger at path. If the file does not exist a fresh ledger is
+// created in memory (and written on the first mutation) seeded with restoreID
+// and backupName. If the file exists, restoreID/backupName from the file win so
+// a resumed run keeps a stable identity (the restore ID drives temp-dir naming).
+func Open(path, restoreID, backupName string) (*Tracker, error) {
+	t := &Tracker{
+		path: path,
+		st: state{
+			RestoreID:  restoreID,
+			BackupName: backupName,
+			Completed:  make(map[string][]int64),
+			Inflight:   make(map[string]InflightJob),
+		},
+		completedIdx: make(map[string]map[int64]struct{}),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return t, nil
+		}
+		return nil, fmt.Errorf("breakpoint: read ledger %q: %w", path, err)
+	}
+
+	if err := json.Unmarshal(data, &t.st); err != nil {
+		return nil, fmt.Errorf("breakpoint: parse ledger %q: %w", path, err)
+	}
+	if t.st.Completed == nil {
+		t.st.Completed = make(map[string][]int64)
+	}
+	if t.st.Inflight == nil {
+		t.st.Inflight = make(map[string]InflightJob)
+	}
+	for ns, segs := range t.st.Completed {
+		set := make(map[int64]struct{}, len(segs))
+		for _, s := range segs {
+			set[s] = struct{}{}
+		}
+		t.completedIdx[ns] = set
+	}
+	return t, nil
+}
+
+// RestoreID returns the stable restore identity persisted in the ledger.
+func (t *Tracker) RestoreID() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.st.RestoreID
+}
+
+// IsCompleted reports whether the given backup segment of ns is already
+// confirmed imported.
+func (t *Tracker) IsCompleted(ns string, segID int64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	set, ok := t.completedIdx[ns]
+	if !ok {
+		return false
+	}
+	_, ok = set[segID]
+	return ok
+}
+
+// MarkInflight records an issued import job before its terminal state is known.
+// Persisted immediately so a crash right after issuing is recoverable.
+func (t *Tracker) MarkInflight(jobID, ns string, segs []int64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.st.Inflight[jobID] = InflightJob{NS: ns, Segs: append([]int64(nil), segs...)}
+	return t.save()
+}
+
+// Complete promotes an inflight job's segments to the completed set and removes
+// the inflight record. Safe to call with a jobID that is no longer inflight
+// (e.g. recovered via a different code path) as long as ns/segs are supplied by
+// the caller; here we rely on the inflight record, falling back to a no-op.
+func (t *Tracker) Complete(jobID string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	infl, ok := t.st.Inflight[jobID]
+	if !ok {
+		return nil
+	}
+	t.addCompletedLocked(infl.NS, infl.Segs)
+	delete(t.st.Inflight, jobID)
+	return t.save()
+}
+
+// Fail drops an inflight job's record without completing it; its segments stay
+// uncompleted and will be re-batched on the next run.
+func (t *Tracker) Fail(jobID string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.st.Inflight[jobID]; !ok {
+		return nil
+	}
+	delete(t.st.Inflight, jobID)
+	return t.save()
+}
+
+// Inflight returns a snapshot of currently-inflight jobs for reconciliation.
+func (t *Tracker) Inflight() map[string]InflightJob {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make(map[string]InflightJob, len(t.st.Inflight))
+	for k, v := range t.st.Inflight {
+		out[k] = v
+	}
+	return out
+}
+
+func (t *Tracker) addCompletedLocked(ns string, segs []int64) {
+	set, ok := t.completedIdx[ns]
+	if !ok {
+		set = make(map[int64]struct{})
+		t.completedIdx[ns] = set
+	}
+	for _, s := range segs {
+		if _, dup := set[s]; dup {
+			continue
+		}
+		set[s] = struct{}{}
+		t.st.Completed[ns] = append(t.st.Completed[ns], s)
+	}
+}
+
+// save writes the ledger atomically: temp file in the same dir + rename.
+// Caller must hold t.mu.
+func (t *Tracker) save() error {
+	data, err := json.MarshalIndent(&t.st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("breakpoint: marshal ledger: %w", err)
+	}
+	dir := filepath.Dir(t.path)
+	tmp, err := os.CreateTemp(dir, ".restore-bp-*.tmp")
+	if err != nil {
+		return fmt.Errorf("breakpoint: create temp ledger: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("breakpoint: write temp ledger: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("breakpoint: sync temp ledger: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("breakpoint: close temp ledger: %w", err)
+	}
+	if err := os.Rename(tmpName, t.path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("breakpoint: rename ledger into place: %w", err)
+	}
+	return nil
+}

--- a/core/restore/breakpoint/breakpoint_test.go
+++ b/core/restore/breakpoint/breakpoint_test.go
@@ -1,0 +1,99 @@
+package breakpoint
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenFreshAndPersistAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bp.json")
+
+	tr, err := Open(path, "rid-1", "backup-a")
+	require.NoError(t, err)
+	assert.Equal(t, "rid-1", tr.RestoreID())
+
+	// issue + complete one job
+	require.NoError(t, tr.MarkInflight("job-1", "db.coll", []int64{10, 11, 12}))
+	require.NoError(t, tr.Complete("job-1"))
+
+	// reopen: completed must survive, restoreID from file wins over the seed
+	tr2, err := Open(path, "rid-IGNORED", "backup-a")
+	require.NoError(t, err)
+	assert.Equal(t, "rid-1", tr2.RestoreID(), "restoreID persisted in ledger must win over the seed")
+	for _, seg := range []int64{10, 11, 12} {
+		assert.True(t, tr2.IsCompleted("db.coll", seg), "seg %d should be completed after reopen", seg)
+	}
+	assert.False(t, tr2.IsCompleted("db.coll", 99))
+	assert.False(t, tr2.IsCompleted("db.other", 10), "completion is per-namespace")
+	assert.Empty(t, tr2.Inflight(), "completed job must not remain inflight")
+}
+
+func TestFailDropsInflightWithoutCompleting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bp.json")
+	tr, err := Open(path, "rid", "b")
+	require.NoError(t, err)
+
+	require.NoError(t, tr.MarkInflight("job-x", "db.coll", []int64{1, 2}))
+	assert.Len(t, tr.Inflight(), 1)
+
+	require.NoError(t, tr.Fail("job-x"))
+	assert.Empty(t, tr.Inflight())
+	// a failed job's segments must NOT be marked completed (they re-enter to-do)
+	assert.False(t, tr.IsCompleted("db.coll", 1))
+	assert.False(t, tr.IsCompleted("db.coll", 2))
+}
+
+func TestInflightSurvivesCrashForReconciliation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bp.json")
+	tr, err := Open(path, "rid", "b")
+	require.NoError(t, err)
+
+	// simulate: job issued, then the tool "crashes" (no Complete/Fail)
+	require.NoError(t, tr.MarkInflight("job-crash", "db.coll", []int64{7, 8}))
+
+	// reopen sees the inflight record so the caller can reconcile via Milvus
+	tr2, err := Open(path, "rid", "b")
+	require.NoError(t, err)
+	infl := tr2.Inflight()
+	require.Len(t, infl, 1)
+	assert.ElementsMatch(t, []int64{7, 8}, infl["job-crash"].Segs)
+	assert.Equal(t, "db.coll", infl["job-crash"].NS)
+
+	// reconciling it as completed promotes the segments and clears inflight
+	require.NoError(t, tr2.Complete("job-crash"))
+	assert.True(t, tr2.IsCompleted("db.coll", 7))
+	assert.Empty(t, tr2.Inflight())
+}
+
+func TestCompleteIsIdempotentAndDedups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bp.json")
+	tr, err := Open(path, "rid", "b")
+	require.NoError(t, err)
+
+	require.NoError(t, tr.MarkInflight("j1", "db.coll", []int64{1, 2}))
+	require.NoError(t, tr.Complete("j1"))
+	// overlapping segment set in a later job must not duplicate entries
+	require.NoError(t, tr.MarkInflight("j2", "db.coll", []int64{2, 3}))
+	require.NoError(t, tr.Complete("j2"))
+
+	tr2, err := Open(path, "rid", "b")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int64{1, 2, 3}, tr2.completedIdxKeys("db.coll"))
+
+	// Complete on an unknown job is a no-op, not an error
+	require.NoError(t, tr2.Complete("does-not-exist"))
+}
+
+// completedIdxKeys is a test helper exposing the completed set for a namespace.
+func (t *Tracker) completedIdxKeys(ns string) []int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]int64, 0)
+	for s := range t.completedIdx[ns] {
+		out = append(out, s)
+	}
+	return out
+}

--- a/core/restore/coll_ddl_task.go
+++ b/core/restore/coll_ddl_task.go
@@ -75,6 +75,12 @@ func (ddlt *collDDLTask) Execute(ctx context.Context) error {
 }
 
 func (ddlt *collDDLTask) dropExistedColl(ctx context.Context) error {
+	// Resume must never drop: an existing collection may already hold data
+	// imported by a previous run. Resume wins over DropExistCollection.
+	if ddlt.option.Resume {
+		ddlt.logger.Info("resume mode: never drop existing collection")
+		return nil
+	}
 	if !ddlt.option.DropExistCollection {
 		ddlt.logger.Info("skip drop existed collection")
 		return nil
@@ -221,6 +227,20 @@ func (ddlt *collDDLTask) createColl(ctx context.Context) error {
 	if ddlt.option.SkipCreateCollection {
 		ddlt.logger.Info("skip create collection")
 		return nil
+	}
+
+	// Resume mode: if the collection already exists (created by an earlier run
+	// of this same restore) reuse it and skip creation; never recreate. This is
+	// the "create if absent, never drop" semantics that resume needs.
+	if ddlt.option.Resume {
+		exist, err := ddlt.grpcCli.HasCollection(ctx, ddlt.targetNS.DBName(), ddlt.targetNS.CollName())
+		if err != nil {
+			return fmt.Errorf("collection: check collection exist for resume: %w", err)
+		}
+		if exist {
+			ddlt.logger.Info("resume: collection already exists, skip create")
+			return nil
+		}
 	}
 
 	createFields, addFields, err := ddlt.fields()

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"path"
 	"slices"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/core/restore/breakpoint"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -61,6 +63,9 @@ type collTask struct {
 	grpcCli    milvus.Grpc
 	restfulCli milvus.Restful
 
+	// bp is the resume ledger; nil when the breakpoint feature is off.
+	bp *breakpoint.Tracker
+
 	tearDownFn struct {
 		mu  sync.Mutex
 		fns []tearDownFn
@@ -99,6 +104,8 @@ type collTaskArgs struct {
 
 	grpcCli    milvus.Grpc
 	restfulCli milvus.Restful
+
+	bp *breakpoint.Tracker
 }
 
 func newCollTask(args collTaskArgs) *collTask {
@@ -139,6 +146,8 @@ func newCollTask(args collTaskArgs) *collTask {
 
 		grpcCli:    args.grpcCli,
 		restfulCli: args.restfulCli,
+
+		bp: args.bp,
 
 		vchTimestamp: struct {
 			mu    sync.RWMutex
@@ -210,12 +219,24 @@ func (ct *collTask) restoreData(ctx context.Context) error {
 }
 
 func (ct *collTask) restoreDataV2(ctx context.Context) error {
+	isolate := ct.bp != nil
+	var (
+		mu       sync.Mutex
+		partErrs []error
+	)
+
 	// restore partition segment
 	ct.logger.Info("start restore partition segment", zap.Int("partition_num", len(ct.collBackup.GetPartitionBackups())))
 	g, subCtx := errgroup.WithContext(ctx)
 	for _, part := range ct.collBackup.GetPartitionBackups() {
 		g.Go(func() error {
 			if err := ct.restorePartitionV2(subCtx, part); err != nil {
+				if isolate {
+					mu.Lock()
+					partErrs = append(partErrs, err)
+					mu.Unlock()
+					return nil
+				}
 				return fmt.Errorf("restore_collection: restore partition v2: %w", err)
 			}
 			return nil
@@ -225,10 +246,18 @@ func (ct *collTask) restoreDataV2(ctx context.Context) error {
 		return fmt.Errorf("restore_collection: wait for partition restore: %w", err)
 	}
 
-	// restore all partition l0 segment
+	// restore all partition l0 segment (still attempted even if some partition
+	// failed, so resume maximizes forward progress)
 	ct.logger.Info("start restore all partition L0 segment", zap.Int("l0_segments", len(ct.collBackup.GetL0Segments())))
 	if err := ct.restoreL0SegV2(ctx, "", ct.collBackup.GetL0Segments()); err != nil {
-		return fmt.Errorf("restore_collection: restore global L0 segment: %w", err)
+		if !isolate {
+			return fmt.Errorf("restore_collection: restore global L0 segment: %w", err)
+		}
+		partErrs = append(partErrs, err)
+	}
+
+	if len(partErrs) > 0 {
+		return fmt.Errorf("restore_collection: %d partition/L0 group(s) incomplete: %w", len(partErrs), errors.Join(partErrs...))
 	}
 
 	return nil
@@ -260,8 +289,16 @@ func (ct *collTask) restoreDataV1(ctx context.Context) error {
 }
 
 func (ct *collTask) tearDown(ctx context.Context) error {
-	if ct.keepTempFiles {
-		ct.logger.Info("skip clean temporary files")
+	// In resumable mode never delete temp files at teardown: a failed run may
+	// leave Milvus import jobs still reading them, and the next --resume run
+	// reuses already-copied files. They are cleaned only after the whole
+	// restore completes (or manually via the breakpoint's temp prefix).
+	if ct.keepTempFiles || ct.bp != nil {
+		if ct.bp != nil {
+			ct.logger.Info("breakpoint enabled: keep temporary files for resume")
+		} else {
+			ct.logger.Info("skip clean temporary files")
+		}
 		return nil
 	}
 
@@ -423,6 +460,21 @@ func (ct *collTask) restoreNotL0SegV2(ctx context.Context, part *backuppb.Partit
 		return fmt.Errorf("restore_collection: get not L0 groups: %w", err)
 	}
 
+	return ct.runBatchesV2(ctx, part.GetPartitionName(), batches, "not-L0")
+}
+
+// runBatchesV2 issues all batches concurrently. In breakpoint mode a single
+// batch failure is isolated (recorded, reported at the end) so its siblings
+// still run and the breakpoint captures their progress; otherwise the first
+// failure aborts the group (legacy behavior).
+func (ct *collTask) runBatchesV2(ctx context.Context, partitionName string, batches []batch, kind string) error {
+	isolate := ct.bp != nil
+	var (
+		mu      sync.Mutex
+		errCnt  int
+		lastErr error
+	)
+
 	g, subCtx := errgroup.WithContext(ctx)
 	for _, b := range batches {
 		if err := ct.bulkInsertSem.Acquire(ctx, 1); err != nil {
@@ -432,19 +484,30 @@ func (ct *collTask) restoreNotL0SegV2(ctx context.Context, part *backuppb.Partit
 			defer ct.bulkInsertSem.Release(1)
 
 			bat, err := ct.copyAndRewriteDir(subCtx, b)
+			if err == nil {
+				err = ct.bulkInsertViaRestful(subCtx, partitionName, bat)
+			}
 			if err != nil {
-				return fmt.Errorf("restore_collection: restore data v2 copy files: %w", err)
+				if isolate {
+					mu.Lock()
+					errCnt++
+					lastErr = err
+					mu.Unlock()
+					ct.logger.Error("batch failed; other batches continue",
+						zap.String("kind", kind), zap.String("partition", partitionName), zap.Error(err))
+					return nil
+				}
+				return fmt.Errorf("restore_collection: restore %s batch: %w", kind, err)
 			}
-			if err := ct.bulkInsertViaRestful(subCtx, part.GetPartitionName(), bat); err != nil {
-				return fmt.Errorf("restore_collection: bulk insert via restful: %w", err)
-			}
-
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("restore_collection: wait for not L0 segment restore: %w", err)
+		return fmt.Errorf("restore_collection: wait for %s segment restore: %w", kind, err)
+	}
+	if errCnt > 0 {
+		return fmt.Errorf("restore_collection: %d %s batch(es) failed for partition %q, last error: %w", errCnt, kind, partitionName, lastErr)
 	}
 
 	return nil
@@ -475,32 +538,7 @@ func (ct *collTask) restoreL0SegV2(ctx context.Context, partitionName string, l0
 		return fmt.Errorf("restore_collection: get L0 batches: %w", err)
 	}
 
-	g, subCtx := errgroup.WithContext(ctx)
-	for _, b := range batches {
-		if err := ct.bulkInsertSem.Acquire(ctx, 1); err != nil {
-			return fmt.Errorf("restore_collection: acquire bulk insert semaphore %w", err)
-		}
-
-		g.Go(func() error {
-			defer ct.bulkInsertSem.Release(1)
-
-			bat, err := ct.copyAndRewriteDir(subCtx, b)
-			if err != nil {
-				return fmt.Errorf("restore_collection: restore L0 segment copy files: %w", err)
-			}
-			if err := ct.bulkInsertViaRestful(subCtx, partitionName, bat); err != nil {
-				return fmt.Errorf("restore_collection: restore L0 segment bulk insert via restful: %w", err)
-			}
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("restore_collection: wait for L0 segment restore: %w", err)
-	}
-
-	return nil
+	return ct.runBatchesV2(ctx, partitionName, batches, "L0")
 }
 
 func (ct *collTask) restorePartitionV1(ctx context.Context, part *backuppb.PartitionBackupInfo) error {
@@ -596,6 +634,9 @@ type batchKey struct {
 }
 
 func (ct *collTask) notL0SegBatchesWithGroupID(ctx context.Context, notL0Segs []*backuppb.SegmentBackupInfo) ([]batch, error) {
+	// drop segments already imported in a previous run (resume)
+	notL0Segs = ct.dropCompleted(notL0Segs)
+
 	// group by vchannel and storage version
 	segBatch := lo.GroupBy(notL0Segs, func(seg *backuppb.SegmentBackupInfo) batchKey {
 		return batchKey{vch: seg.GetVChannel(), sv: seg.GetStorageVersion()}
@@ -610,9 +651,10 @@ func (ct *collTask) notL0SegBatchesWithGroupID(ctx context.Context, notL0Segs []
 
 		// because the restful api has a limitation on the number of segments in one request,
 		// we need to chunk the segments into multiple batches
-		chunkedSegs := lo.Chunk(segs, _bulkInsertRestfulAPIChunkSize)
+		chunkedSegs := lo.Chunk(segs, ct.chunkSize())
 		for _, chunk := range chunkedSegs {
 			dirs := make([]partitionDir, 0, len(chunk))
+			segIDs := make([]int64, 0, len(chunk))
 			for _, seg := range chunk {
 				opts := []mpath.Option{
 					mpath.CollectionID(ct.collBackup.GetCollectionId()),
@@ -625,9 +667,10 @@ func (ct *collTask) notL0SegBatchesWithGroupID(ctx context.Context, notL0Segs []
 					return nil, fmt.Errorf("restore_collection: get partition backup binlog files: %w", err)
 				}
 				dirs = append(dirs, dir)
+				segIDs = append(segIDs, seg.GetSegmentId())
 			}
 
-			b := batch{timestamp: ts, partitionDirs: dirs, storageVersion: key.sv}
+			b := batch{timestamp: ts, partitionDirs: dirs, storageVersion: key.sv, segmentIDs: segIDs}
 			batches = append(batches, b)
 		}
 	}
@@ -662,13 +705,16 @@ func (ct *collTask) notL0SegmentBatches(ctx context.Context, part *backuppb.Part
 }
 
 func (ct *collTask) l0SegmentBatches(l0Segs []*backuppb.SegmentBackupInfo) ([]batch, error) {
+	// drop L0 segments already imported in a previous run (resume)
+	l0Segs = ct.dropCompleted(l0Segs)
+
 	segBatch := lo.GroupBy(l0Segs, func(seg *backuppb.SegmentBackupInfo) batchKey {
 		return batchKey{vch: seg.GetVChannel(), sv: seg.GetStorageVersion()}
 	})
 
 	chunkSize := 1
 	if ct.grpcCli.HasFeature(milvus.MultiL0InOneJob) {
-		chunkSize = _bulkInsertRestfulAPIChunkSize
+		chunkSize = ct.chunkSize()
 	}
 
 	var batches []batch
@@ -681,6 +727,7 @@ func (ct *collTask) l0SegmentBatches(l0Segs []*backuppb.SegmentBackupInfo) ([]ba
 		chunkedSegs := lo.Chunk(segs, chunkSize)
 		for _, chunk := range chunkedSegs {
 			dirs := make([]partitionDir, 0, len(chunk))
+			segIDs := make([]int64, 0, len(chunk))
 			for _, seg := range chunk {
 				opts := []mpath.Option{
 					mpath.CollectionID(ct.collBackup.GetCollectionId()),
@@ -690,8 +737,9 @@ func (ct *collTask) l0SegmentBatches(l0Segs []*backuppb.SegmentBackupInfo) ([]ba
 
 				deltaLogDir := mpath.BackupDeltaLogDir(ct.backupDir, opts...)
 				dirs = append(dirs, partitionDir{deltaLogDir: deltaLogDir, size: seg.GetSize()})
+				segIDs = append(segIDs, seg.GetSegmentId())
 			}
-			b := batch{isL0: true, timestamp: ts, partitionDirs: dirs, storageVersion: key.sv}
+			b := batch{isL0: true, timestamp: ts, partitionDirs: dirs, storageVersion: key.sv, segmentIDs: segIDs}
 			batches = append(batches, b)
 		}
 	}
@@ -712,6 +760,42 @@ type batch struct {
 	storageVersion int64
 
 	partitionDirs []partitionDir
+
+	// segmentIDs are the backup segment IDs covered by this batch, used to
+	// record progress in the breakpoint ledger. Empty for the legacy
+	// without-group-id path (which is not segment-resumable).
+	segmentIDs []int64
+}
+
+// chunkSize returns how many segments go into one import job. A positive
+// Option.SegmentsPerBatch overrides the historical default.
+func (ct *collTask) chunkSize() int {
+	if ct.option.SegmentsPerBatch > 0 {
+		return ct.option.SegmentsPerBatch
+	}
+	return _bulkInsertRestfulAPIChunkSize
+}
+
+// dropCompleted filters out segments already confirmed imported in a previous
+// run. A no-op when the breakpoint feature is off or not resuming.
+func (ct *collTask) dropCompleted(segs []*backuppb.SegmentBackupInfo) []*backuppb.SegmentBackupInfo {
+	if ct.bp == nil || !ct.option.Resume {
+		return segs
+	}
+	ns := ct.targetNS.String()
+	kept := segs[:0:0]
+	skipped := 0
+	for _, seg := range segs {
+		if ct.bp.IsCompleted(ns, seg.GetSegmentId()) {
+			skipped++
+			continue
+		}
+		kept = append(kept, seg)
+	}
+	if skipped > 0 {
+		ct.logger.Info("skip already-imported segments (resume)", zap.Int("skipped", skipped), zap.Int("remaining", len(kept)))
+	}
+	return kept
 }
 
 func (ct *collTask) checkBulkInsertViaGrpc(ctx context.Context, jobID int64) error {
@@ -831,6 +915,31 @@ func (ct *collTask) checkBulkInsertViaRestful(ctx context.Context, jobID string)
 	return errors.New("restore_collection: walk into unreachable code")
 }
 
+// retryBackoff returns the exponential backoff (with jitter) for the given
+// retry attempt (1-based). Bounded by Option.RetryBaseBackoff / RetryMaxBackoff.
+func (ct *collTask) retryBackoff(attempt int) time.Duration {
+	base := ct.option.RetryBaseBackoff
+	if base <= 0 {
+		base = 5 * time.Second
+	}
+	maxB := ct.option.RetryMaxBackoff
+	if maxB <= 0 {
+		maxB = 60 * time.Second
+	}
+	d := base
+	for i := 1; i < attempt && d < maxB; i++ {
+		d *= 2
+	}
+	if d > maxB {
+		d = maxB
+	}
+	// up to +25% jitter so concurrent retries don't synchronize (429 storms)
+	if d > 0 {
+		d += time.Duration(rand.Int63n(int64(d)/4 + 1))
+	}
+	return d
+}
+
 func (ct *collTask) bulkInsertViaRestful(ctx context.Context, partition string, b batch) error {
 	ct.logger.Info("start bulk insert via restful", zap.Int("batch_num", len(b.partitionDirs)), zap.String("partition", partition))
 	paths := lo.Map(b.partitionDirs, func(dir partitionDir, _ int) []string { return toPaths(dir) })
@@ -844,20 +953,62 @@ func (ct *collTask) bulkInsertViaRestful(ctx context.Context, partition string, 
 		StorageVersion: b.storageVersion,
 		EZK:            ct.ezk(),
 	}
-
-	jobID, err := ct.restfulCli.BulkInsert(ctx, in)
-	if err != nil {
-		return fmt.Errorf("restore_collection: failed to bulk insert via restful: %w", err)
-	}
-	ct.logger.Info("create bulk insert via restful success", zap.String("job_id", jobID))
-
 	size := lo.SumBy(b.partitionDirs, func(dir partitionDir) int64 { return dir.size })
-	ct.taskMgr.UpdateRestoreTask(ct.taskID, taskmgr.AddRestoreImportJob(ct.targetNS, jobID, size))
-	if err := ct.checkBulkInsertViaRestful(ctx, jobID); err != nil {
-		return fmt.Errorf("restore_collection: check bulk insert via restful: %w", err)
+	record := ct.bp != nil && len(b.segmentIDs) > 0
+
+	attempts := ct.option.MaxRetry + 1
+	if attempts < 1 {
+		attempts = 1
 	}
 
-	return nil
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			backoff := ct.retryBackoff(attempt)
+			ct.logger.Warn("retry bulk insert after backoff", zap.String("partition", partition),
+				zap.Int("attempt", attempt), zap.Duration("backoff", backoff), zap.Error(lastErr))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		jobID, err := ct.restfulCli.BulkInsert(ctx, in)
+		if err != nil {
+			lastErr = fmt.Errorf("restore_collection: failed to bulk insert via restful: %w", err)
+			continue
+		}
+		ct.logger.Info("create bulk insert via restful success", zap.String("job_id", jobID))
+		ct.taskMgr.UpdateRestoreTask(ct.taskID, taskmgr.AddRestoreImportJob(ct.targetNS, jobID, size))
+
+		// Record the issued job BEFORE polling so a crash mid-poll is recoverable.
+		if record {
+			if err := ct.bp.MarkInflight(jobID, ct.targetNS.String(), b.segmentIDs); err != nil {
+				return fmt.Errorf("restore_collection: record inflight job: %w", err)
+			}
+		}
+
+		if err := ct.checkBulkInsertViaRestful(ctx, jobID); err != nil {
+			lastErr = fmt.Errorf("restore_collection: check bulk insert via restful: %w", err)
+			if record {
+				if ferr := ct.bp.Fail(jobID); ferr != nil {
+					return fmt.Errorf("restore_collection: record failed job: %w", ferr)
+				}
+			}
+			continue
+		}
+
+		// Success: promote this job's segments to the completed set.
+		if record {
+			if err := ct.bp.Complete(jobID); err != nil {
+				return fmt.Errorf("restore_collection: record completed job: %w", err)
+			}
+		}
+		return nil
+	}
+
+	return lastErr
 }
 
 func getProcess(infos []*commonpb.KeyValuePair) int {

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -3,6 +3,9 @@ package restore
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/samber/lo"
@@ -11,6 +14,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/core/restore/breakpoint"
 	"github.com/zilliztech/milvus-backup/core/restore/conv"
 	"github.com/zilliztech/milvus-backup/internal/cfg"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
@@ -128,6 +132,26 @@ type Option struct {
 	// During restore, the old EZK from backup is looked up in this map
 	// and replaced with the new EZK if a match is found.
 	EZKMapping map[string]string
+
+	// ── Resumable restore (breakpoint) options ──
+	// All of the following only take effect when a breakpoint tracker is
+	// attached to the task (i.e. --breakpoint was supplied). With no
+	// breakpoint the restore behaves exactly as before.
+
+	// SegmentsPerBatch caps how many segments go into a single import job.
+	// Smaller value => smaller blast radius per failure. <=0 keeps the
+	// historical default (_bulkInsertRestfulAPIChunkSize).
+	SegmentsPerBatch int
+	// MaxRetry is the number of extra attempts for a failed import job
+	// (with exponential backoff). 0 means no retry (issue once).
+	MaxRetry int
+	// RetryBaseBackoff / RetryMaxBackoff bound the backoff between retries.
+	RetryBaseBackoff time.Duration
+	RetryMaxBackoff  time.Duration
+	// Resume, when true, skips segments already recorded complete in the
+	// breakpoint ledger and reconciles in-flight jobs against Milvus. It
+	// also switches collection DDL to "create if absent, never drop".
+	Resume bool
 }
 
 type TaskArgs struct {
@@ -145,6 +169,11 @@ type TaskArgs struct {
 	MilvusStorage storage.Client
 
 	TaskMgr *taskmgr.Mgr
+
+	// BreakpointPath, when non-empty, enables resumable restore: progress is
+	// persisted to this local JSON file and (with Option.Resume) read back to
+	// skip already-imported segments.
+	BreakpointPath string
 }
 
 type Task struct {
@@ -156,6 +185,9 @@ type Task struct {
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
 
+	// bp is the resume ledger; nil when BreakpointPath is empty (feature off).
+	bp *breakpoint.Tracker
+
 	logger *zap.Logger
 }
 
@@ -164,11 +196,24 @@ func NewTask(args TaskArgs) (*Task, error) {
 
 	args.TaskMgr.AddRestoreTask(args.TaskID)
 
+	var bp *breakpoint.Tracker
+	if args.BreakpointPath != "" {
+		var err error
+		bp, err = breakpoint.Open(args.BreakpointPath, args.TaskID, args.Backup.GetName())
+		if err != nil {
+			return nil, fmt.Errorf("restore: open breakpoint ledger: %w", err)
+		}
+		logger.Info("breakpoint enabled", zap.String("path", args.BreakpointPath),
+			zap.String("restore_id", bp.RestoreID()), zap.Bool("resume", args.Option.Resume))
+	}
+
 	return &Task{
 		args: args,
 
 		copySem:       semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.CopyData.Val)),
 		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.ImportJob.Val)),
+
+		bp: bp,
 
 		logger: logger,
 	}, nil
@@ -276,6 +321,7 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 			bulkInsertSem: t.bulkInsertSem,
 			grpcCli:       t.grpc,
 			restfulCli:    t.restful,
+			bp:            t.bp,
 		}
 
 		tasks = append(tasks, newCollTask(args))
@@ -323,6 +369,13 @@ func (t *Task) checkCollsExist(ctx context.Context, collTasks []*collTask) error
 }
 
 func (t *Task) checkCollExist(ctx context.Context, task *collTask) error {
+	// Resume tolerates a pre-existing collection: it was created by an earlier
+	// run of this restore and may already hold imported data. createColl/
+	// dropExistedColl handle the "create if absent, never drop" behavior.
+	if t.args.Option.Resume {
+		return nil
+	}
+
 	has, err := t.grpc.HasCollection(ctx, task.targetNS.DBName(), task.targetNS.CollName())
 	if err != nil {
 		return fmt.Errorf("restore: check collection %w", err)
@@ -388,6 +441,12 @@ func (t *Task) Execute(ctx context.Context) error {
 
 func (t *Task) privateExecute(ctx context.Context) error {
 	t.args.TaskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreExecuting())
+
+	if t.bp != nil && t.args.Option.Resume {
+		if err := t.reconcileInflight(ctx); err != nil {
+			return fmt.Errorf("restore: reconcile breakpoint inflight jobs: %w", err)
+		}
+	}
 
 	dbTasks, collTasks := t.newDBAndCollTasks(t.args.Backup)
 
@@ -505,14 +564,102 @@ func (t *Task) prepareDB(ctx context.Context, collTasks []*collTask) error {
 	return nil
 }
 
+// reconcileInflight resolves jobs that were issued in a previous run but whose
+// terminal state was never persisted (e.g. the tool was killed right after the
+// job completed). For each it queries Milvus: a completed job is promoted to the
+// completed set so its segments are NOT re-imported (which would duplicate
+// data); a failed/missing job is dropped so its segments fall back into the
+// to-do set (re-import is safe — a non-completed import commits no visible
+// data); an in-progress job is polled to a terminal state first.
+func (t *Task) reconcileInflight(ctx context.Context) error {
+	inflight := t.bp.Inflight()
+	if len(inflight) == 0 {
+		return nil
+	}
+	t.logger.Info("reconciling breakpoint inflight jobs", zap.Int("count", len(inflight)))
+
+	for jobID, infl := range inflight {
+		ns, err := namespace.Parse(infl.NS)
+		if err != nil {
+			return fmt.Errorf("reconcile: parse ns %q: %w", infl.NS, err)
+		}
+
+		state, reason, err := t.waitImportTerminal(ctx, ns.DBName(), jobID)
+		if err != nil {
+			t.logger.Warn("reconcile: cannot resolve inflight job, its segments will be re-imported",
+				zap.String("job_id", jobID), zap.Error(err))
+			if ferr := t.bp.Fail(jobID); ferr != nil {
+				return ferr
+			}
+			continue
+		}
+
+		if state == string(milvus.ImportStateCompleted) {
+			t.logger.Info("reconcile: inflight job already completed, keeping its segments",
+				zap.String("job_id", jobID))
+			if cerr := t.bp.Complete(jobID); cerr != nil {
+				return cerr
+			}
+			continue
+		}
+
+		t.logger.Info("reconcile: inflight job not completed, dropping",
+			zap.String("job_id", jobID), zap.String("state", state), zap.String("reason", reason))
+		if ferr := t.bp.Fail(jobID); ferr != nil {
+			return ferr
+		}
+	}
+
+	return nil
+}
+
+// waitImportTerminal polls an import job until it reaches Completed or Failed.
+func (t *Task) waitImportTerminal(ctx context.Context, db, jobID string) (string, string, error) {
+	for {
+		resp, err := t.restful.GetBulkInsertState(ctx, db, jobID)
+		if err != nil {
+			return "", "", err
+		}
+		switch resp.Data.State {
+		case string(milvus.ImportStateCompleted):
+			return resp.Data.State, "", nil
+		case string(milvus.ImportStateFailed):
+			return resp.Data.State, resp.Data.Reason, nil
+		default:
+			select {
+			case <-ctx.Done():
+				return "", "", ctx.Err()
+			case <-time.After(_bulkInsertCheckInterval):
+			}
+		}
+	}
+}
+
 func (t *Task) runCollTasks(ctx context.Context, collTasks []*collTask) error {
 	t.logger.Info("start restore collection")
+
+	// In resumable mode a single collection's failure must not abort the
+	// siblings: every collection that can make progress should, and the
+	// breakpoint records what is left for the next --resume run.
+	isolate := t.bp != nil
+	var (
+		mu     sync.Mutex
+		failed []string
+	)
 
 	g, subCtx := errgroup.WithContext(ctx)
 	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
 	for _, collTask := range collTasks {
 		g.Go(func() error {
 			if err := collTask.Execute(subCtx); err != nil {
+				if isolate {
+					mu.Lock()
+					failed = append(failed, fmt.Sprintf("%s: %v", collTask.targetNS.String(), err))
+					mu.Unlock()
+					t.logger.Error("restore collection failed; other collections continue",
+						zap.String("ns", collTask.targetNS.String()), zap.Error(err))
+					return nil
+				}
 				return fmt.Errorf("restore: restore collection %w", err)
 			}
 
@@ -522,6 +669,11 @@ func (t *Task) runCollTasks(ctx context.Context, collTasks []*collTask) error {
 
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("restore: wait restore collections %w", err)
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("restore: %d collection(s) did not fully complete, re-run with --resume to continue; failures: %s",
+			len(failed), strings.Join(failed, "; "))
 	}
 
 	t.logger.Info("finish restore all collections")


### PR DESCRIPTION
## What

Adds an **opt-in resumable restore** so a single object-storage failure during a large restore no longer dooms the whole operation. Enabled only when `--breakpoint <path>` is supplied; without it, restore behavior is byte-for-byte unchanged.

New flags on the V2 (restful) restore path:

- `--breakpoint <path>` — local JSON ledger; pass the same path with `--resume` to continue an interrupted restore
- `--resume` — skip already-imported segments and reconcile in-flight import jobs
- `--segments_per_batch N` — cap segments per import job (smaller = smaller blast radius per failure)
- `--max_retry K` / `--retry_backoff_sec` / `--retry_max_backoff_sec` — per import-job retry with exponential backoff + jitter

## Why

On slow / flaky object storage, one import failure aborts the whole restore (fail-fast errgroup) and a re-run starts from zero — for multi-TB restores that effectively never completes. This makes restore failure-isolated and resumable, with monotonic forward progress.

## How it works

Relies only on Milvus's existing **import-job atomicity**: a failed/aborted import job's segments are `isImporting=true` (invisible) and GC'd by datacoord. So re-issuing a failed/unknown job never duplicates visible data, and abandoned segments are cleaned by Milvus — no tool-side cleanup needed.

- The ledger (local JSON, written atomically via temp-file + rename) tracks the set of completed segment IDs plus in-flight `jobID → segmentIDs`.
- On `--resume`, every in-flight job is reconciled via `GetImportState`: `Completed` is claimed (so it is **not** re-imported); anything else returns its segments to the to-do set. Then `to-do = all − completed` is re-batched and issued. Because the unit is the segment ID, `--segments_per_batch` may change between runs without breaking matching.
- Failure isolation: a batch/partition/collection failure no longer cancels its siblings; the run exits non-zero with `re-run with --resume`.
- Resume DDL: an existing target collection is reused (create-if-absent, **never drop**).
- Temp files are kept in breakpoint mode (never delete files an in-flight import job may still be reading).

All new behavior is gated on `--breakpoint`; the default restore path is untouched.

## Validation

Verified end-to-end on two independent Milvus 2.6 clusters (backup on A → restore to B), a collection of **5,000,000 rows across 50 segments**, with `--segments_per_batch 4` (13 import jobs) and `importJob=3`:

- **3× hard `kill -9` + resume** — monotonic progress (completed 0→12→24→50); each resume reconciles the prior in-flight jobs; final = exactly **5,000,000 distinct rows**, **0 orphan segments** (13 clean `Flushed` segments summing to 5M).
- **Real import failure** (a segment's binlog corrupted → Milvus `Failed`) — retry-with-backoff → failure isolation (the other 46 segments still imported) → recorded failed → non-zero exit → `--resume` re-issues only the 4 failed segments → exactly **5,000,000 distinct rows**.
- Each run verified by `row_count`, `count(*)`, in-range count and per-PK sampling (no duplicates, no loss).

## Known limitation (follow-up, not addressed here)

If the **backup itself is incomplete** (a segment's binlogs are missing/empty in object storage), Milvus import silently imports 0 rows and reports success; the breakpoint then marks that segment `completed`, so `--resume` skips it — turning a silent partial loss permanent. Mitigation for a follow-up: verify imported `row_count > 0` (or against backup meta) before marking a segment completed, plus a final total-row reconciliation; and on the Milvus side, import should warn/error on empty segments rather than silently succeeding.

## Scope

V2 (restful) restore path. V1 (grpc) can adopt the same ledger later.
