### PR TITLE
feat(restore): expose resumable restore over REST + object-storage ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ For more details, refer to the [backup.yaml](configs/backup.yaml) configuration 
 
 3. [Segment Merging Restore](docs/user_guide/mul_seg_restore.md): In segment merging restore mode (v2 restore), multiple segments are grouped into a single job and restored together. This significantly improves restore performance, especially in scenarios with many small segments.
 
+4. [Resumable Restore](docs/user_guide/resumable_restore.md): Opt-in, failure-isolated resumable restore for slow / unreliable object storage. A single import failure no longer aborts the whole restore — re-run with `--resume` to continue from where it left off, with no duplicated or lost data.
+
 
 ## Examples
 

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -2,8 +2,6 @@ package restore
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/restore"
+	"github.com/zilliztech/milvus-backup/core/restore/breakpoint"
 	"github.com/zilliztech/milvus-backup/internal/cfg"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
@@ -320,25 +319,29 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 	// it deterministically from the breakpoint path. Without a breakpoint, keep
 	// the historical per-run UUID.
 	taskID := uuid.NewString()
-	breakpointPath := o.breakpoint
-	if breakpointPath != "" {
-		if abs, aerr := filepath.Abs(breakpointPath); aerr == nil {
-			breakpointPath = abs
+	var bpTracker *breakpoint.Tracker
+	if o.breakpoint != "" {
+		bpPath := o.breakpoint
+		if abs, aerr := filepath.Abs(bpPath); aerr == nil {
+			bpPath = abs
 		}
-		sum := sha256.Sum256([]byte(breakpointPath))
-		taskID = "restore_bp_" + hex.EncodeToString(sum[:8])
+		taskID = breakpoint.DeriveID(bpPath)
+		bpTracker, err = breakpoint.OpenFile(bpPath, taskID, backup.GetName())
+		if err != nil {
+			return restore.TaskArgs{}, fmt.Errorf("open breakpoint ledger: %w", err)
+		}
 	}
 
 	return restore.TaskArgs{
-		TaskID:         taskID,
-		Backup:         backup,
-		Plan:           plan,
-		Option:         o.toOption(),
-		Params:         params,
-		BackupDir:      mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
-		BackupStorage:  backupStorage,
-		MilvusStorage:  milvusStorage,
-		BreakpointPath: breakpointPath,
+		TaskID:        taskID,
+		Backup:        backup,
+		Plan:          plan,
+		Option:        o.toOption(),
+		Params:        params,
+		BackupDir:     mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
+		BackupStorage: backupStorage,
+		MilvusStorage: milvusStorage,
+		Breakpoint:    bpTracker,
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}, nil

--- a/core/proto/backup.proto
+++ b/core/proto/backup.proto
@@ -394,6 +394,26 @@ message RestoreBackupRequest {
   RestorePlan restorePlan = 24;
   // map of old ezk to new ezk, used to replace encryption keys during restore
   map<string, string> ezkMapping = 25;
+
+  // ── resumable restore (breakpoint) ──
+  // breakpoint, when non-empty, enables resumable restore. It is a stable label
+  // identifying the restore; the server persists progress to an object in
+  // object storage keyed by it. Pass the same value (with resume=true) to
+  // continue an interrupted restore. (CLI uses --breakpoint as a local path.)
+  string breakpoint = 26;
+  // resume continues from the breakpoint: skip already-imported segments and
+  // reconcile in-flight import jobs. Omit on the first run; set on every re-run.
+  bool resume = 27;
+  // segments_per_batch caps how many segments go into a single import job.
+  // Smaller value => smaller blast radius per failure. 0 keeps the default.
+  int32 segments_per_batch = 28;
+  // max_retry is the number of extra attempts for a failed import job (with
+  // exponential backoff). 0 means no retry.
+  int32 max_retry = 29;
+  // retry_backoff_sec / retry_max_backoff_sec bound the backoff between retries
+  // (seconds). 0 keeps the defaults (5s / 60s).
+  int32 retry_backoff_sec = 30;
+  int32 retry_max_backoff_sec = 31;
 }
 
 message RestorePlan {

--- a/core/proto/backuppb/backup.pb.go
+++ b/core/proto/backuppb/backup.pb.go
@@ -2365,10 +2365,17 @@ type RestoreBackupRequest struct {
 	DbCollectionsAfterRename *_struct.Value `protobuf:"bytes,23,opt,name=db_collections_after_rename,json=dbCollectionsAfterRename,proto3" json:"db_collections_after_rename,omitempty"`
 	RestorePlan              *RestorePlan   `protobuf:"bytes,24,opt,name=restorePlan,proto3" json:"restorePlan,omitempty"`
 	// map of old ezk to new ezk, used to replace encryption keys during restore
-	EzkMapping           map[string]string `protobuf:"bytes,25,rep,name=ezkMapping,proto3" json:"ezkMapping,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	EzkMapping map[string]string `protobuf:"bytes,25,rep,name=ezkMapping,proto3" json:"ezkMapping,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// resumable restore (breakpoint) fields
+	Breakpoint           string   `protobuf:"bytes,26,opt,name=breakpoint,proto3" json:"breakpoint,omitempty"`
+	Resume               bool     `protobuf:"varint,27,opt,name=resume,proto3" json:"resume,omitempty"`
+	SegmentsPerBatch     int32    `protobuf:"varint,28,opt,name=segments_per_batch,json=segmentsPerBatch,proto3" json:"segments_per_batch,omitempty"`
+	MaxRetry             int32    `protobuf:"varint,29,opt,name=max_retry,json=maxRetry,proto3" json:"max_retry,omitempty"`
+	RetryBackoffSec      int32    `protobuf:"varint,30,opt,name=retry_backoff_sec,json=retryBackoffSec,proto3" json:"retry_backoff_sec,omitempty"`
+	RetryMaxBackoffSec   int32    `protobuf:"varint,31,opt,name=retry_max_backoff_sec,json=retryMaxBackoffSec,proto3" json:"retry_max_backoff_sec,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *RestoreBackupRequest) Reset()         { *m = RestoreBackupRequest{} }
@@ -2570,6 +2577,48 @@ func (m *RestoreBackupRequest) GetEzkMapping() map[string]string {
 		return m.EzkMapping
 	}
 	return nil
+}
+
+func (m *RestoreBackupRequest) GetBreakpoint() string {
+	if m != nil {
+		return m.Breakpoint
+	}
+	return ""
+}
+
+func (m *RestoreBackupRequest) GetResume() bool {
+	if m != nil {
+		return m.Resume
+	}
+	return false
+}
+
+func (m *RestoreBackupRequest) GetSegmentsPerBatch() int32 {
+	if m != nil {
+		return m.SegmentsPerBatch
+	}
+	return 0
+}
+
+func (m *RestoreBackupRequest) GetMaxRetry() int32 {
+	if m != nil {
+		return m.MaxRetry
+	}
+	return 0
+}
+
+func (m *RestoreBackupRequest) GetRetryBackoffSec() int32 {
+	if m != nil {
+		return m.RetryBackoffSec
+	}
+	return 0
+}
+
+func (m *RestoreBackupRequest) GetRetryMaxBackoffSec() int32 {
+	if m != nil {
+		return m.RetryMaxBackoffSec
+	}
+	return 0
 }
 
 type RestorePlan struct {

--- a/core/proto/backuppb/resumable_fields_test.go
+++ b/core/proto/backuppb/resumable_fields_test.go
@@ -1,0 +1,50 @@
+package backuppb
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The server binds the REST body with gin's ShouldBindJSON (encoding/json over
+// the struct json tags). This guards that a curl JSON body using the documented
+// snake_case keys actually populates the resumable-restore fields.
+func TestRestoreBackupRequest_ResumableJSONBinding(t *testing.T) {
+	body := `{
+		"backup_name": "rrtest2",
+		"useV2Restore": true,
+		"breakpoint": "apple_recover1",
+		"resume": true,
+		"segments_per_batch": 20,
+		"max_retry": 5,
+		"retry_backoff_sec": 3,
+		"retry_max_backoff_sec": 20
+	}`
+
+	var req RestoreBackupRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got := req.GetBreakpoint(); got != "apple_recover1" {
+		t.Errorf("breakpoint = %q, want apple_recover1", got)
+	}
+	if !req.GetResume() {
+		t.Error("resume = false, want true")
+	}
+	if got := req.GetSegmentsPerBatch(); got != 20 {
+		t.Errorf("segments_per_batch = %d, want 20", got)
+	}
+	if got := req.GetMaxRetry(); got != 5 {
+		t.Errorf("max_retry = %d, want 5", got)
+	}
+	if got := req.GetRetryBackoffSec(); got != 3 {
+		t.Errorf("retry_backoff_sec = %d, want 3", got)
+	}
+	if got := req.GetRetryMaxBackoffSec(); got != 20 {
+		t.Errorf("retry_max_backoff_sec = %d, want 20", got)
+	}
+	// sanity: existing field still binds
+	if !req.GetUseV2Restore() {
+		t.Error("useV2Restore = false, want true")
+	}
+}

--- a/core/restore/breakpoint/breakpoint.go
+++ b/core/restore/breakpoint/breakpoint.go
@@ -1,23 +1,145 @@
-// Package breakpoint provides a local-disk, JSON-backed resume ledger for the
-// restore flow. It records which backup segments have been confirmed imported
-// (so a re-run skips them) and which import jobs were issued but not yet
-// confirmed (so a re-run can reconcile them against Milvus and avoid importing
-// the same data twice).
+// Package breakpoint provides a resume ledger for the restore flow. It records
+// which backup segments have been confirmed imported (so a re-run skips them)
+// and which import jobs were issued but not yet confirmed (so a re-run can
+// reconcile them against Milvus and avoid importing the same data twice).
 //
-// The ledger is a single JSON file on the local filesystem. Writes are
-// infrequent (one per import-job state transition, and jobs take seconds to
-// minutes), so a mutex-guarded full rewrite is more than fast enough. Every
-// write goes to a temp file and is renamed into place, so a crash never leaves
-// a half-written ledger.
+// The ledger is persisted through a pluggable Store:
+//
+//   - fileStore   — a single local JSON file (atomic temp+rename). Used by the
+//     CLI, which runs on a stable host.
+//   - objectStore — a single object in object storage. Used by the HTTP server,
+//     where the restore runs inside a (possibly ephemeral, possibly replicated)
+//     pod and a local file would not survive a restart or a different replica.
+//
+// Writes are infrequent (one per import-job state transition, and jobs take
+// seconds to minutes), so a mutex-guarded full rewrite of the ledger is more
+// than fast enough for either backend.
 package breakpoint
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/zilliztech/milvus-backup/internal/storage"
 )
+
+// DeriveID maps a user-supplied breakpoint label (a local path for the CLI, an
+// arbitrary string for the REST API) to a stable restore identity. The same
+// label always yields the same id, so temp-dir naming and the ledger location
+// line up across runs.
+func DeriveID(label string) string {
+	sum := sha256.Sum256([]byte(label))
+	return "restore_bp_" + hex.EncodeToString(sum[:8])
+}
+
+// Store persists the ledger bytes.
+type Store interface {
+	// Load returns the persisted ledger bytes, or (nil, nil) if none exists yet.
+	Load() ([]byte, error)
+	// Save persists the ledger bytes atomically (the backend either fully
+	// writes the new content or leaves the old content intact).
+	Save(data []byte) error
+	// Location returns a human-readable location for logging.
+	Location() string
+}
+
+// ── fileStore: local JSON file (CLI) ──
+
+type fileStore struct{ path string }
+
+// NewFileStore stores the ledger as a local JSON file at path.
+func NewFileStore(path string) Store { return &fileStore{path: path} }
+
+func (f *fileStore) Location() string { return f.path }
+
+func (f *fileStore) Load() ([]byte, error) {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+func (f *fileStore) Save(data []byte) error {
+	dir := filepath.Dir(f.path)
+	tmp, err := os.CreateTemp(dir, ".restore-bp-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp ledger: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp ledger: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("sync temp ledger: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp ledger: %w", err)
+	}
+	if err := os.Rename(tmpName, f.path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename ledger into place: %w", err)
+	}
+	return nil
+}
+
+// ── objectStore: a single object in object storage (HTTP server) ──
+
+type objectStore struct {
+	ctx context.Context
+	cli storage.Client
+	key string
+}
+
+// NewObjectStore stores the ledger as a single object at key. An object-storage
+// PUT is atomic, so no temp+rename dance is needed.
+func NewObjectStore(ctx context.Context, cli storage.Client, key string) Store {
+	return &objectStore{ctx: ctx, cli: cli, key: key}
+}
+
+func (o *objectStore) Location() string { return o.key }
+
+func (o *objectStore) Load() ([]byte, error) {
+	exist, err := storage.Exist(o.ctx, o.cli, o.key)
+	if err != nil {
+		return nil, fmt.Errorf("check ledger exist: %w", err)
+	}
+	if !exist {
+		return nil, nil
+	}
+	obj, err := o.cli.GetObject(o.ctx, o.key)
+	if err != nil {
+		return nil, fmt.Errorf("get ledger object: %w", err)
+	}
+	defer obj.Body.Close()
+	return io.ReadAll(obj.Body)
+}
+
+func (o *objectStore) Save(data []byte) error {
+	in := storage.UploadObjectInput{Key: o.key, Body: bytes.NewReader(data), Size: int64(len(data))}
+	if err := o.cli.UploadObject(o.ctx, in); err != nil {
+		return fmt.Errorf("upload ledger object: %w", err)
+	}
+	return nil
+}
+
+// ── ledger ──
 
 // InflightJob records an import job that was issued but whose terminal state
 // has not yet been persisted. On resume these are reconciled against Milvus via
@@ -27,7 +149,6 @@ type InflightJob struct {
 	Segs []int64 `json:"segs"` // backup segment IDs covered by this job
 }
 
-// state is the on-disk shape of the ledger.
 type state struct {
 	RestoreID  string                 `json:"restoreId"`
 	BackupName string                 `json:"backupName"`
@@ -35,9 +156,9 @@ type state struct {
 	Inflight   map[string]InflightJob `json:"inflight"`  // jobID -> issued-but-unconfirmed
 }
 
-// Tracker is a concurrency-safe handle over the ledger file.
+// Tracker is a concurrency-safe handle over the ledger.
 type Tracker struct {
-	path string
+	store Store
 
 	mu sync.Mutex
 	st state
@@ -45,13 +166,13 @@ type Tracker struct {
 	completedIdx map[string]map[int64]struct{}
 }
 
-// Open loads the ledger at path. If the file does not exist a fresh ledger is
-// created in memory (and written on the first mutation) seeded with restoreID
-// and backupName. If the file exists, restoreID/backupName from the file win so
-// a resumed run keeps a stable identity (the restore ID drives temp-dir naming).
-func Open(path, restoreID, backupName string) (*Tracker, error) {
+// Open loads the ledger from store. If the store has no content yet, a fresh
+// ledger is created in memory (written on the first mutation) seeded with
+// restoreID and backupName. If content exists, restoreID/backupName from it win
+// so a resumed run keeps a stable identity.
+func Open(store Store, restoreID, backupName string) (*Tracker, error) {
 	t := &Tracker{
-		path: path,
+		store: store,
 		st: state{
 			RestoreID:  restoreID,
 			BackupName: backupName,
@@ -61,16 +182,16 @@ func Open(path, restoreID, backupName string) (*Tracker, error) {
 		completedIdx: make(map[string]map[int64]struct{}),
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := store.Load()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return t, nil
-		}
-		return nil, fmt.Errorf("breakpoint: read ledger %q: %w", path, err)
+		return nil, fmt.Errorf("breakpoint: load ledger from %s: %w", store.Location(), err)
+	}
+	if len(data) == 0 {
+		return t, nil
 	}
 
 	if err := json.Unmarshal(data, &t.st); err != nil {
-		return nil, fmt.Errorf("breakpoint: parse ledger %q: %w", path, err)
+		return nil, fmt.Errorf("breakpoint: parse ledger from %s: %w", store.Location(), err)
 	}
 	if t.st.Completed == nil {
 		t.st.Completed = make(map[string][]int64)
@@ -88,11 +209,44 @@ func Open(path, restoreID, backupName string) (*Tracker, error) {
 	return t, nil
 }
 
+// OpenFile opens a ledger backed by a local JSON file (CLI).
+func OpenFile(path, restoreID, backupName string) (*Tracker, error) {
+	return Open(NewFileStore(path), restoreID, backupName)
+}
+
+// OpenObject opens a ledger backed by a single object in object storage (server).
+func OpenObject(ctx context.Context, cli storage.Client, key, restoreID, backupName string) (*Tracker, error) {
+	return Open(NewObjectStore(ctx, cli, key), restoreID, backupName)
+}
+
+// Location returns where the ledger is persisted (for logging).
+func (t *Tracker) Location() string { return t.store.Location() }
+
 // RestoreID returns the stable restore identity persisted in the ledger.
 func (t *Tracker) RestoreID() string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.st.RestoreID
+}
+
+// CompletedCount returns how many segments of ns are confirmed imported.
+func (t *Tracker) CompletedCount(ns string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.completedIdx[ns])
+}
+
+// InflightCount returns how many in-flight (issued, unconfirmed) jobs target ns.
+func (t *Tracker) InflightCount(ns string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for _, j := range t.st.Inflight {
+		if j.NS == ns {
+			n++
+		}
+	}
+	return n
 }
 
 // IsCompleted reports whether the given backup segment of ns is already
@@ -118,9 +272,7 @@ func (t *Tracker) MarkInflight(jobID, ns string, segs []int64) error {
 }
 
 // Complete promotes an inflight job's segments to the completed set and removes
-// the inflight record. Safe to call with a jobID that is no longer inflight
-// (e.g. recovered via a different code path) as long as ns/segs are supplied by
-// the caller; here we rely on the inflight record, falling back to a no-op.
+// the inflight record. A no-op if the jobID is not currently inflight.
 func (t *Tracker) Complete(jobID string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -171,36 +323,14 @@ func (t *Tracker) addCompletedLocked(ns string, segs []int64) {
 	}
 }
 
-// save writes the ledger atomically: temp file in the same dir + rename.
-// Caller must hold t.mu.
+// save marshals and persists the ledger. Caller must hold t.mu.
 func (t *Tracker) save() error {
 	data, err := json.MarshalIndent(&t.st, "", "  ")
 	if err != nil {
 		return fmt.Errorf("breakpoint: marshal ledger: %w", err)
 	}
-	dir := filepath.Dir(t.path)
-	tmp, err := os.CreateTemp(dir, ".restore-bp-*.tmp")
-	if err != nil {
-		return fmt.Errorf("breakpoint: create temp ledger: %w", err)
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return fmt.Errorf("breakpoint: write temp ledger: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return fmt.Errorf("breakpoint: sync temp ledger: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("breakpoint: close temp ledger: %w", err)
-	}
-	if err := os.Rename(tmpName, t.path); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("breakpoint: rename ledger into place: %w", err)
+	if err := t.store.Save(data); err != nil {
+		return fmt.Errorf("breakpoint: save ledger to %s: %w", t.store.Location(), err)
 	}
 	return nil
 }

--- a/core/restore/breakpoint/breakpoint_test.go
+++ b/core/restore/breakpoint/breakpoint_test.go
@@ -11,7 +11,7 @@ import (
 func TestOpenFreshAndPersistAcrossReopen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bp.json")
 
-	tr, err := Open(path, "rid-1", "backup-a")
+	tr, err := OpenFile(path, "rid-1", "backup-a")
 	require.NoError(t, err)
 	assert.Equal(t, "rid-1", tr.RestoreID())
 
@@ -20,7 +20,7 @@ func TestOpenFreshAndPersistAcrossReopen(t *testing.T) {
 	require.NoError(t, tr.Complete("job-1"))
 
 	// reopen: completed must survive, restoreID from file wins over the seed
-	tr2, err := Open(path, "rid-IGNORED", "backup-a")
+	tr2, err := OpenFile(path, "rid-IGNORED", "backup-a")
 	require.NoError(t, err)
 	assert.Equal(t, "rid-1", tr2.RestoreID(), "restoreID persisted in ledger must win over the seed")
 	for _, seg := range []int64{10, 11, 12} {
@@ -33,7 +33,7 @@ func TestOpenFreshAndPersistAcrossReopen(t *testing.T) {
 
 func TestFailDropsInflightWithoutCompleting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bp.json")
-	tr, err := Open(path, "rid", "b")
+	tr, err := OpenFile(path, "rid", "b")
 	require.NoError(t, err)
 
 	require.NoError(t, tr.MarkInflight("job-x", "db.coll", []int64{1, 2}))
@@ -48,14 +48,14 @@ func TestFailDropsInflightWithoutCompleting(t *testing.T) {
 
 func TestInflightSurvivesCrashForReconciliation(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bp.json")
-	tr, err := Open(path, "rid", "b")
+	tr, err := OpenFile(path, "rid", "b")
 	require.NoError(t, err)
 
 	// simulate: job issued, then the tool "crashes" (no Complete/Fail)
 	require.NoError(t, tr.MarkInflight("job-crash", "db.coll", []int64{7, 8}))
 
 	// reopen sees the inflight record so the caller can reconcile via Milvus
-	tr2, err := Open(path, "rid", "b")
+	tr2, err := OpenFile(path, "rid", "b")
 	require.NoError(t, err)
 	infl := tr2.Inflight()
 	require.Len(t, infl, 1)
@@ -70,7 +70,7 @@ func TestInflightSurvivesCrashForReconciliation(t *testing.T) {
 
 func TestCompleteIsIdempotentAndDedups(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bp.json")
-	tr, err := Open(path, "rid", "b")
+	tr, err := OpenFile(path, "rid", "b")
 	require.NoError(t, err)
 
 	require.NoError(t, tr.MarkInflight("j1", "db.coll", []int64{1, 2}))
@@ -79,12 +79,47 @@ func TestCompleteIsIdempotentAndDedups(t *testing.T) {
 	require.NoError(t, tr.MarkInflight("j2", "db.coll", []int64{2, 3}))
 	require.NoError(t, tr.Complete("j2"))
 
-	tr2, err := Open(path, "rid", "b")
+	tr2, err := OpenFile(path, "rid", "b")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []int64{1, 2, 3}, tr2.completedIdxKeys("db.coll"))
 
 	// Complete on an unknown job is a no-op, not an error
 	require.NoError(t, tr2.Complete("does-not-exist"))
+}
+
+// memStore is an in-memory Store, standing in for any non-file backend
+// (e.g. objectStore): it proves the Tracker persists and reloads through the
+// Store abstraction, independent of local disk.
+type memStore struct{ data []byte }
+
+func (m *memStore) Load() ([]byte, error) { return m.data, nil }
+func (m *memStore) Save(d []byte) error   { m.data = append([]byte(nil), d...); return nil }
+func (m *memStore) Location() string      { return "mem://ledger" }
+
+func TestPersistsThroughAnyStore(t *testing.T) {
+	store := &memStore{}
+
+	tr, err := Open(store, "rid", "b")
+	require.NoError(t, err)
+	require.NoError(t, tr.MarkInflight("j1", "db.coll", []int64{5, 6}))
+	require.NoError(t, tr.Complete("j1"))
+	require.NoError(t, tr.MarkInflight("j2", "db.coll", []int64{7}))
+	// j2 left inflight on purpose
+
+	// reopen from the SAME backing bytes -> state survived the round trip
+	tr2, err := Open(store, "ignored", "b")
+	require.NoError(t, err)
+	assert.True(t, tr2.IsCompleted("db.coll", 5))
+	assert.True(t, tr2.IsCompleted("db.coll", 6))
+	assert.False(t, tr2.IsCompleted("db.coll", 7), "inflight (uncompleted) seg must not count as completed")
+	require.Len(t, tr2.Inflight(), 1)
+	assert.ElementsMatch(t, []int64{7}, tr2.Inflight()["j2"].Segs)
+}
+
+func TestDeriveIDStableAndDistinct(t *testing.T) {
+	assert.Equal(t, DeriveID("apple_recover1"), DeriveID("apple_recover1"), "same label -> same id")
+	assert.NotEqual(t, DeriveID("apple_recover1"), DeriveID("apple_recover2"))
+	assert.Contains(t, DeriveID("x"), "restore_bp_")
 }
 
 // completedIdxKeys is a test helper exposing the completed set for a namespace.

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -195,6 +195,49 @@ func (ct *collTask) privateExecute(ctx context.Context) error {
 		return fmt.Errorf("restore_collection: restore data: %w", err)
 	}
 
+	if err := ct.verifyRowCount(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// verifyRowCount is a correctness backstop for resumable restore: after a
+// collection's data is fully restored, the target must not hold MORE rows than
+// the backup ever inserted. Because deletes only ever reduce the visible count,
+// "more rows than inserted" is an unambiguous sign of duplication (e.g. a resume
+// that re-imported already-present segments) — fail loudly. Fewer rows is only a
+// warning (expected when the backup contains deletes).
+func (ct *collTask) verifyRowCount(ctx context.Context) error {
+	if ct.bp == nil {
+		return nil // only guard resumable restores
+	}
+
+	var expected int64
+	for _, part := range ct.collBackup.GetPartitionBackups() {
+		for _, seg := range part.GetSegmentBackups() {
+			if !seg.GetIsL0() {
+				expected += seg.GetNumOfRows()
+			}
+		}
+	}
+
+	actual, err := collectionRowCount(ctx, ct.grpcCli, ct.targetNS)
+	if err != nil {
+		return fmt.Errorf("restore_collection: verify row count: %w", err)
+	}
+
+	switch {
+	case actual > expected:
+		return fmt.Errorf("restore_collection: %s holds %d rows but the backup inserted only %d — duplication detected "+
+			"(a resume likely re-imported already-present segments); drop the collection and restore fresh",
+			ct.targetNS.String(), actual, expected)
+	case actual < expected:
+		ct.logger.Warn("restored fewer rows than the backup inserted; expected only if the backup contains deletes",
+			zap.Int64("actual", actual), zap.Int64("expected_inserts", expected))
+	default:
+		ct.logger.Info("row count verified", zap.Int64("rows", actual))
+	}
 	return nil
 }
 

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -170,10 +171,12 @@ type TaskArgs struct {
 
 	TaskMgr *taskmgr.Mgr
 
-	// BreakpointPath, when non-empty, enables resumable restore: progress is
-	// persisted to this local JSON file and (with Option.Resume) read back to
-	// skip already-imported segments.
-	BreakpointPath string
+	// Breakpoint, when non-nil, enables resumable restore: progress is persisted
+	// through the tracker's Store (a local file for the CLI, an object in object
+	// storage for the HTTP server) and (with Option.Resume) read back to skip
+	// already-imported segments. The caller opens the tracker so it can choose
+	// the storage backend; nil means the feature is off.
+	Breakpoint *breakpoint.Tracker
 }
 
 type Task struct {
@@ -196,14 +199,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 
 	args.TaskMgr.AddRestoreTask(args.TaskID)
 
-	var bp *breakpoint.Tracker
-	if args.BreakpointPath != "" {
-		var err error
-		bp, err = breakpoint.Open(args.BreakpointPath, args.TaskID, args.Backup.GetName())
-		if err != nil {
-			return nil, fmt.Errorf("restore: open breakpoint ledger: %w", err)
-		}
-		logger.Info("breakpoint enabled", zap.String("path", args.BreakpointPath),
+	bp := args.Breakpoint
+	if bp != nil {
+		logger.Info("breakpoint enabled", zap.String("location", bp.Location()),
 			zap.String("restore_id", bp.RestoreID()), zap.Bool("resume", args.Option.Resume))
 	}
 
@@ -368,11 +366,53 @@ func (t *Task) checkCollsExist(ctx context.Context, collTasks []*collTask) error
 	return nil
 }
 
+// collectionRowCount returns the visible row count of a collection (sum of its
+// live persistent segments). Returns 0 if the collection does not exist.
+func collectionRowCount(ctx context.Context, grpc milvus.Grpc, ns namespace.NS) (int64, error) {
+	has, err := grpc.HasCollection(ctx, ns.DBName(), ns.CollName())
+	if err != nil {
+		return 0, fmt.Errorf("restore: check collection exist: %w", err)
+	}
+	if !has {
+		return 0, nil
+	}
+	segs, err := grpc.GetPersistentSegmentInfo(ctx, ns.DBName(), ns.CollName())
+	if err != nil {
+		return 0, fmt.Errorf("restore: get persistent segment info: %w", err)
+	}
+	var rows int64
+	for _, s := range segs {
+		if s.GetState() == commonpb.SegmentState_Dropped {
+			continue // compacted-away segments are not live data
+		}
+		rows += s.GetNumRows()
+	}
+	return rows, nil
+}
+
 func (t *Task) checkCollExist(ctx context.Context, task *collTask) error {
 	// Resume tolerates a pre-existing collection: it was created by an earlier
 	// run of this restore and may already hold imported data. createColl/
 	// dropExistedColl handle the "create if absent, never drop" behavior.
 	if t.args.Option.Resume {
+		// Preventive guard against duplication: if we are told to resume but the
+		// ledger has NO record of progress for this collection (after inflight
+		// reconciliation) while the target already holds data, the breakpoint
+		// label is almost certainly wrong or the ledger was lost. Re-importing
+		// every segment would duplicate. Refuse before importing anything.
+		if t.bp != nil {
+			ns := task.targetNS.String()
+			if t.bp.CompletedCount(ns) == 0 && t.bp.InflightCount(ns) == 0 {
+				rows, err := collectionRowCount(ctx, t.grpc, task.targetNS)
+				if err != nil {
+					return err
+				}
+				if rows > 0 {
+					return fmt.Errorf("restore: resume requested for %s but the breakpoint ledger records no progress while the collection already holds %d rows; "+
+						"the breakpoint label is likely wrong or the ledger was lost. Refusing to avoid duplicating data — verify --breakpoint/breakpoint, or start a fresh restore", ns, rows)
+				}
+			}
+		}
 		return nil
 	}
 

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore"
+	"github.com/zilliztech/milvus-backup/core/restore/breakpoint"
 	"github.com/zilliztech/milvus-backup/core/utils"
 	"github.com/zilliztech/milvus-backup/internal/cfg"
 	"github.com/zilliztech/milvus-backup/internal/filter"
@@ -126,9 +128,13 @@ func (h *restoreHandler) complete() {
 		h.request.RequestId = uuid.NewString()
 	}
 
-	if len(h.request.GetId()) == 0 {
-		taskID := "restore_" + fmt.Sprint(time.Now().UTC().Format("2006_01_02_15_04_05_")) + fmt.Sprint(time.Now().Nanosecond())
-		h.request.Id = taskID
+	// A breakpoint label fixes a STABLE restore id so re-runs line up (it drives
+	// the ledger object key and temp-dir naming); it wins over any caller id.
+	// Otherwise default to a per-run timestamp id.
+	if bp := h.request.GetBreakpoint(); bp != "" {
+		h.request.Id = breakpoint.DeriveID(bp)
+	} else if len(h.request.GetId()) == 0 {
+		h.request.Id = "restore_" + fmt.Sprint(time.Now().UTC().Format("2006_01_02_15_04_05_")) + fmt.Sprint(time.Now().Nanosecond())
 	}
 }
 
@@ -176,6 +182,25 @@ func (h *restoreHandler) newTask(ctx context.Context, backupDir string) (*restor
 		return nil, fmt.Errorf("server: create restore plan: %w", err)
 	}
 
+	// Resumable restore: persist the ledger to object storage (the server may
+	// run in an ephemeral / replicated pod, so a local file would not survive).
+	// The breakpoint label derives a stable id, which drives both the ledger
+	// object key and the temp-dir naming so a re-run lines up. Use a background
+	// context so ledger writes outlive the HTTP request (async restore runs on
+	// context.Background()).
+	var bpTracker *breakpoint.Tracker
+	if label := h.request.GetBreakpoint(); label != "" {
+		// h.request.Id was already set to DeriveID(label) in complete(), so the
+		// ledger key, temp-dir naming and taskmgr tracking all share one id.
+		ledgerKey := path.Join(h.backupRootPath, "_restore_ledger", h.request.GetId()+".json")
+		bpTracker, err = breakpoint.OpenObject(context.Background(), h.backupStorage, ledgerKey, h.request.GetId(), backup.GetName())
+		if err != nil {
+			return nil, fmt.Errorf("server: open breakpoint ledger: %w", err)
+		}
+		log.Info("resumable restore enabled (REST)", zap.String("ledger", ledgerKey),
+			zap.String("restore_id", h.request.GetId()), zap.Bool("resume", h.request.GetResume()))
+	}
+
 	args := restore.TaskArgs{
 		TaskID:        h.request.GetId(),
 		Backup:        backup,
@@ -185,6 +210,7 @@ func (h *restoreHandler) newTask(ctx context.Context, backupDir string) (*restor
 		BackupDir:     backupDir,
 		BackupStorage: h.backupStorage,
 		MilvusStorage: h.milvusStorage,
+		Breakpoint:    bpTracker,
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}
@@ -262,6 +288,14 @@ func newOptionFromRequest(request *backuppb.RestoreBackupRequest) *restore.Optio
 		TruncateBinlogByTs:   request.GetTruncateBinlogByTs(),
 		RestoreRBAC:          request.GetRbac(),
 		EZKMapping:           request.GetEzkMapping(),
+
+		// resumable restore (breakpoint). The breakpoint tracker itself is
+		// attached in newTask; these knobs come straight from the request.
+		Resume:           request.GetResume(),
+		SegmentsPerBatch: int(request.GetSegmentsPerBatch()),
+		MaxRetry:         int(request.GetMaxRetry()),
+		RetryBaseBackoff: time.Duration(request.GetRetryBackoffSec()) * time.Second,
+		RetryMaxBackoff:  time.Duration(request.GetRetryMaxBackoffSec()) * time.Second,
 	}
 }
 

--- a/docs/user_guide/resumable_restore.md
+++ b/docs/user_guide/resumable_restore.md
@@ -120,6 +120,38 @@ curl -X POST http://<backup-server>:8080/api/v1/restore \
 > rather than risk duplicating it. The field is `useV2Restore` (camelCase), and the ledger is
 > stored under `<backup-root>/_restore_ledger/` in the backup bucket.
 
+### REST request fields
+
+| JSON field | Meaning | Default |
+| --- | --- | --- |
+| `backup_name` | Name of the backup to restore (required). | — |
+| `useV2Restore` *(camelCase)* | Use the v2 restore path. Resumable restore is on this path — set `true`. | false |
+| `breakpoint` | Stable label identifying this restore; enables resumable mode. Reuse it on every run. | — (off) |
+| `resume` | Skip already-imported segments and reconcile in-flight jobs. Omit on the first run; set `true` on re-runs. | false |
+| `segments_per_batch` | Max segments per import job (smaller = smaller blast radius). | 256 |
+| `max_retry` | Extra retries for a failed import job, with exponential backoff. | 0 |
+| `retry_backoff_sec` / `retry_max_backoff_sec` | Base / cap of the retry backoff (seconds). | 5 / 60 |
+| `async` | Return immediately instead of blocking until the restore finishes. | false |
+
+## REST vs CLI
+
+The same resumable restore is available from the CLI; the only real difference is **where the
+progress ledger is stored** and how you identify the restore.
+
+| Aspect | CLI | REST server |
+| --- | --- | --- |
+| Ledger storage | **Local JSON file** at the `--breakpoint` path | **Object in object storage** (`<backup-root>/_restore_ledger/`) |
+| Identity | The `--breakpoint /path` (a file path) | The `breakpoint` label (a JSON string) |
+| Survives host / pod restart | Only if the path is on persistent disk | **Yes** — it lives in the bucket |
+| Works across replicas | No (file is local to one host) | **Yes** (any replica reads the same object) |
+| Trigger resume | `--resume` flag | `"resume": true` field |
+| Best fit | An operator running the CLI on a stable host | A long-running server in Kubernetes / a pod |
+
+**Why REST uses object storage:** a server typically runs in an ephemeral, possibly replicated
+pod. A local file would be lost on restart and would not be shared across replicas, so resume
+could not work. Storing the ledger in the bucket removes that dependency. The CLI keeps the
+simpler local-file behavior because it runs on a stable host.
+
 ## Recommended settings for slow / unreliable object storage
 
 - **Lower the concurrency:** set `backup.parallelism.importJob` to a small number (e.g. `3`–`10`)

--- a/docs/user_guide/resumable_restore.md
+++ b/docs/user_guide/resumable_restore.md
@@ -1,0 +1,112 @@
+# Resumable Restore
+
+On slow or unreliable object storage, a large restore can fail partway through when a
+single import job times out — and a normal re-run starts over from zero. **Resumable
+restore** makes a restore **failure-isolated and continuable**: each run makes forward
+progress, and re-running picks up exactly where it left off — with **no duplicated and
+no lost data**.
+
+It is fully **opt-in**: the feature activates only when you pass `--breakpoint`. Without
+that flag, `restore` behaves exactly as before. It applies to the `--use_v2_restore`
+(restful) path.
+
+## Getting the tool
+
+This feature ships in a beta build. Download the pre-built binary for your platform from
+the release page:
+
+> 📦 https://github.com/czs007/milvus-backup/releases/tag/v0.5.17-beta.1
+
+Pick the asset matching your OS / CPU architecture (run `uname -s` and `uname -m` to check):
+
+| Platform | `uname -s` / `-m` | Asset |
+| --- | --- | --- |
+| Linux x86-64 | Linux / x86_64 | `milvus-backup_0.5.17-beta.1_Linux_x86_64.tar.gz` |
+| Linux ARM64 | Linux / aarch64 | `milvus-backup_0.5.17-beta.1_Linux_arm64.tar.gz` |
+| macOS Intel | Darwin / x86_64 | `milvus-backup_0.5.17-beta.1_Darwin_x86_64.tar.gz` |
+| macOS Apple Silicon | Darwin / arm64 | `milvus-backup_0.5.17-beta.1_Darwin_arm64.tar.gz` |
+
+Then verify, extract and run (example for Linux x86-64):
+
+```bash
+# download the tarball + checksums from the release page, then:
+sha256sum -c milvus-backup_0.5.17-beta.1_checksums.txt   # verify integrity (optional)
+tar xzf milvus-backup_0.5.17-beta.1_Linux_x86_64.tar.gz
+./milvus-backup --help                                   # the new flags appear under `restore`
+```
+
+The binary is statically linked (no dependencies to install). Point it at your Milvus /
+object-storage with your existing `backup.yaml`, exactly as with any other milvus-backup
+release.
+
+## Parameters
+
+| Flag | What it does | Default | Recommended (slow / unreliable storage) |
+| --- | --- | --- | --- |
+| `--breakpoint <path>` | Local JSON file that records restore progress. **Supplying it enables resumable mode.** Use the *same path* on every re-run. | — (off) | A stable path on the host, e.g. `/data/restore_x.json` |
+| `--resume` | Continue from the breakpoint file: skip segments already imported and reconcile any in-flight import jobs. **Omit on the first run; add it on every re-run.** | off | Add on every re-run |
+| `--segments_per_batch <N>` | Maximum number of segments packed into one import job. Smaller value = smaller "blast radius" if a job fails. | 256 | Lower it, e.g. `50` |
+| `--max_retry <K>` | Extra retries for a failed import job, with exponential backoff. | 0 (no retry) | `5` |
+| `--retry_backoff_sec <s>` | Base backoff between import-job retries (seconds). | 5 | 5 |
+| `--retry_max_backoff_sec <s>` | Cap on the backoff (seconds) — avoids hammering a throttling store. | 60 | 60 |
+| `backup.parallelism.importJob` *(config file, not a CLI flag)* | Number of import jobs issued concurrently. The default is high and can overwhelm a slow object store. | 768 | Lower it, e.g. `3`–`10` |
+
+## How to use it
+
+### 1. First run
+
+Run the restore as usual, adding `--breakpoint` (do **not** add `--resume` the first time):
+
+```bash
+milvus-backup restore -n <backup_name> --use_v2_restore \
+  --breakpoint /data/restore_x.json \
+  --segments_per_batch 50 --max_retry 5
+```
+
+### 2. If it is interrupted or reports a failure — resume
+
+Re-run the *same command* with the *same* `--breakpoint` path, adding `--resume`. It skips
+everything already imported and continues:
+
+```bash
+milvus-backup restore -n <backup_name> --use_v2_restore \
+  --breakpoint /data/restore_x.json --resume \
+  --segments_per_batch 50 --max_retry 5
+```
+
+**Repeat step 2 until the command exits with code 0.** Every run makes forward progress; a
+restore that hits transient storage failures will complete after one or more resumes.
+
+> **Exit code:** `0` = fully complete. Non-zero = some segments did not finish (the message
+> says *"re-run with --resume to continue"*). Wrap it in a loop on non-zero with `--resume`
+> if you want it fully unattended.
+
+## Recommended settings for slow / unreliable object storage
+
+- **Lower the concurrency:** set `backup.parallelism.importJob` to a small number (e.g. `3`–`10`)
+  so you are not issuing hundreds of simultaneous reads against a struggling store.
+- **Smaller batches:** `--segments_per_batch 50` keeps the cost of redoing any one failed job low.
+- **Enable retries:** `--max_retry 5` absorbs short transient blips without needing a resume.
+- **Run on a stable host:** the breakpoint file is on local disk and must survive between runs.
+  Use a persistent path (or a mounted volume), not an ephemeral container filesystem.
+- **Do not drop the target collection between resume runs** — that would discard the progress
+  already made.
+
+## How it works (in brief)
+
+The breakpoint file tracks two things: the set of segments confirmed imported, and the import
+jobs that were issued but not yet confirmed. On `--resume`, the tool first asks Milvus for the
+real state of each previously in-flight job (`GetImportState`): a job Milvus already finished
+is claimed — so it is **not** re-imported — and anything else goes back into the to-do set. It
+then re-issues only the segments still missing.
+
+Correctness rests on a Milvus guarantee: a failed or interrupted import job commits **no visible
+data** (its segments stay invisible and are garbage-collected by Milvus). So re-issuing a failed
+or unknown job can never produce duplicates, and the leftovers of interrupted jobs are cleaned up
+by Milvus automatically — there is nothing to clean up by hand.
+
+## Notes
+
+- This feature is on the `--use_v2_restore` (restful) restore path.
+- The breakpoint file is human-readable JSON; it is safe to inspect, and you may delete it to
+  start a fresh (non-resumable) restore.

--- a/docs/user_guide/resumable_restore.md
+++ b/docs/user_guide/resumable_restore.md
@@ -51,7 +51,7 @@ release.
 | `--retry_max_backoff_sec <s>` | Cap on the backoff (seconds) — avoids hammering a throttling store. | 60 | 60 |
 | `backup.parallelism.importJob` *(config file, not a CLI flag)* | Number of import jobs issued concurrently. The default is high and can overwhelm a slow object store. | 768 | Lower it, e.g. `3`–`10` |
 
-## How to use it
+## Using it from the CLI
 
 ### 1. First run
 
@@ -81,14 +81,54 @@ restore that hits transient storage failures will complete after one or more res
 > says *"re-run with --resume to continue"*). Wrap it in a loop on non-zero with `--resume`
 > if you want it fully unattended.
 
+## Using it over the REST API
+
+When you drive `milvus-backup` through its HTTP server (`POST /api/v1/restore`) the same
+capability is available — and the breakpoint ledger is stored in **object storage** (not a local
+file), so it survives a backup-server pod restart and works across replicas. The `breakpoint`
+field is a stable label you reuse across runs (it keys the ledger object); `resume` continues.
+
+First run (omit `resume`):
+
+```bash
+curl -X POST http://<backup-server>:8080/api/v1/restore \
+  -H 'Content-Type: application/json' -d '{
+    "backup_name": "<backup_name>",
+    "useV2Restore": true,
+    "breakpoint": "my-restore-1",
+    "segments_per_batch": 50,
+    "max_retry": 5
+  }'
+```
+
+Resume (same `breakpoint` label, add `resume`):
+
+```bash
+curl -X POST http://<backup-server>:8080/api/v1/restore \
+  -H 'Content-Type: application/json' -d '{
+    "backup_name": "<backup_name>",
+    "useV2Restore": true,
+    "breakpoint": "my-restore-1",
+    "resume": true,
+    "segments_per_batch": 50,
+    "max_retry": 5
+  }'
+```
+
+> **Reuse the same `breakpoint` label on every run.** A different label points at a different
+> (empty) ledger; the server refuses such a resume when the target collection already holds data,
+> rather than risk duplicating it. The field is `useV2Restore` (camelCase), and the ledger is
+> stored under `<backup-root>/_restore_ledger/` in the backup bucket.
+
 ## Recommended settings for slow / unreliable object storage
 
 - **Lower the concurrency:** set `backup.parallelism.importJob` to a small number (e.g. `3`–`10`)
   so you are not issuing hundreds of simultaneous reads against a struggling store.
 - **Smaller batches:** `--segments_per_batch 50` keeps the cost of redoing any one failed job low.
 - **Enable retries:** `--max_retry 5` absorbs short transient blips without needing a resume.
-- **Run on a stable host:** the breakpoint file is on local disk and must survive between runs.
-  Use a persistent path (or a mounted volume), not an ephemeral container filesystem.
+- **Persist the ledger:** the **CLI** keeps the breakpoint as a local file, so run it on a stable
+  host (or a mounted volume), not an ephemeral filesystem. The **REST server** stores the ledger
+  in object storage, so no stable host is needed there — it survives a pod restart.
 - **Do not drop the target collection between resume runs** — that would discard the progress
   already made.
 
@@ -108,5 +148,10 @@ by Milvus automatically — there is nothing to clean up by hand.
 ## Notes
 
 - This feature is on the `--use_v2_restore` (restful) restore path.
-- The breakpoint file is human-readable JSON; it is safe to inspect, and you may delete it to
-  start a fresh (non-resumable) restore.
+- The ledger is human-readable JSON. The CLI keeps it in the local `--breakpoint` file; the REST
+  server keeps it as an object under `<backup-root>/_restore_ledger/`. Either is safe to inspect,
+  and removing it starts a fresh (non-resumable) restore.
+- Two guards protect against duplication on resume: the server **refuses** a resume whose ledger
+  shows no progress while the target collection already holds data (most often a wrong breakpoint
+  label), and after a restore it **fails loudly** if a collection ends up with more rows than the
+  backup inserted.


### PR DESCRIPTION
Targets the `breakpoint-beta` branch (builds on the resumable-restore feature from #1070).

## Problem

Resumable restore was **CLI-only** and persisted progress to a **local JSON file**. When a
restore is driven through the HTTP server (`POST /api/v1/restore`):

- The breakpoint / resume / segments_per_batch / max_retry fields did not exist on
  `RestoreBackupRequest`, so a curl-driven restore silently dropped them — it ran a plain,
  non-resumable restore. A retry then hit `collection already exist`.
- Even if the fields existed, a local file does not survive a backup-server pod restart and is
  not shared across replicas, so resume could not work in a server deployment.

## What this does

**Pluggable ledger store** (`core/restore/breakpoint`):
- `fileStore` — local JSON file (temp + rename). **CLI behavior is unchanged.**
- `objectStore` — a single object in object storage, used by the server. An object-storage PUT
  is atomic, the ledger survives a pod crash/restart, and it is reachable from any replica.

**REST exposure:**
- `RestoreBackupRequest` gains `breakpoint`, `resume`, `segments_per_batch`, `max_retry`,
  `retry_backoff_sec`, `retry_max_backoff_sec`.
- `newOptionFromRequest` / `newTask` wire them through and open an object-storage-backed tracker.
  A `breakpoint` label derives a stable restore id that keys the ledger object, the temp-dir
  naming and the taskmgr entry, so re-runs line up.
- This also fixes the `collection already exist` retry error, since `resume` now reaches the
  create-if-absent / never-drop DDL path.

**Two correctness guards against duplication on resume:**
- *Preventive* — refuse a resume whose ledger records no progress while the target collection
  already holds data (almost always a wrong breakpoint label / lost ledger).
- *Detective* — after a restore, fail if a collection ends up with **more** rows than the backup
  inserted. Deletes only ever reduce the count, so "more than inserted" is unambiguous
  duplication.

## Validation (end-to-end, two-cluster REST)

- **Backup-server crash mid-restore + restart + resume** — the ledger survived in object storage,
  a fresh server process read it, reconciled the in-flight job via `GetImportState` (no
  re-import), and completed: exact row count, no duplicates. (A local-file ledger cannot survive
  this.)
- **Real import failure** (a segment's binlog corrupted → Milvus `Failed`) → retry → failure
  isolation → `resume` re-issued only the failed batch → exact row count.
- Both guards fire: a wrong-label resume is refused (no rows imported); an under-reporting ledger
  produces a detected/failed duplication.

CLI (local file) behavior is unchanged.

> Note on generated code: `backup.pb.go` is hand-edited (new scalar fields + getters) because the
> server binds the request with `ShouldBindJSON` (struct json tags), and the repo's proto
> toolchain (vendored protoc + `protoc-gen-go@v1.3.2`) was not available in my environment. The
> `.proto` is updated to match; a regen will reconcile the descriptor.
