### PR TITLE
feat: add wash command to fold L0 deletes into per-segment deltalogs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zilliztech/milvus-backup/cmd/restore"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/cmd/server"
+	"github.com/zilliztech/milvus-backup/cmd/wash"
 )
 
 func Execute() {
@@ -28,6 +29,7 @@ func Execute() {
 	cmd.AddCommand(restore.NewCmd(&opt))
 	cmd.AddCommand(server.NewCmd(&opt))
 	cmd.AddCommand(migrate.NewCmd(&opt))
+	cmd.AddCommand(wash.NewCmd(&opt))
 
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)

--- a/cmd/wash/wash.go
+++ b/cmd/wash/wash.go
@@ -1,0 +1,77 @@
+package wash
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+	"github.com/zilliztech/milvus-backup/core/wash"
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+)
+
+type options struct {
+	name        string
+	l0fanoutBin string
+}
+
+func (o *options) validate() error {
+	if o.name == "" {
+		return errors.New("backup name is required")
+	}
+
+	return nil
+}
+
+func (o *options) addFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.name, "name", "n", "", "wash the backup with this name")
+	cmd.Flags().StringVar(&o.l0fanoutBin, "l0fanout", "l0fanout",
+		"path to the Milvus l0fanout binary (the deltalog codec)")
+}
+
+func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	if err != nil {
+		return fmt.Errorf("wash: create backup storage: %w", err)
+	}
+
+	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.name)
+	task := wash.NewTask(backupStorage, backupDir, params, o.l0fanoutBin)
+	if err := task.Execute(context.Background()); err != nil {
+		return fmt.Errorf("wash: execute task: %w", err)
+	}
+
+	cmd.Println("wash backup done")
+
+	return nil
+}
+
+func NewCmd(opt *root.Options) *cobra.Command {
+	var o options
+
+	cmd := &cobra.Command{
+		Use:   "wash",
+		Short: "fold a backup's L0 (delete-only) segments into per-segment deltalogs so it restores without L0 import.",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params := opt.InitGlobalVars()
+
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			err := o.run(cmd, params)
+			cobra.CheckErr(err)
+
+			return nil
+		},
+	}
+
+	o.addFlags(cmd)
+
+	return cmd
+}

--- a/core/wash/wash.go
+++ b/core/wash/wash.go
@@ -1,0 +1,356 @@
+// Package wash folds a backup's L0 (delete-only) segments into per-data-segment
+// deltalogs — the offline equivalent of Milvus L0 compaction's fan-out. It does
+// NOT rewrite insert data: the deletes are written as additional deltalogs on
+// the data segments, and a plain restore drops the deleted rows at read time via
+// the existing per-segment delta path. After a wash the backup contains no L0
+// segments, so it restores correctly on any Milvus version (no new import
+// option, no version skew in the shared datanode pool) and its data segments are
+// commit_timestamp-safe.
+//
+// The deltalog codec itself lives in a separate Milvus binary (`l0fanout`); this
+// package computes the fan-out plan, invokes that binary, folds the results back
+// into the backup metadata, and drops the L0 segments.
+package wash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/samber/lo"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/log"
+	"github.com/zilliztech/milvus-backup/internal/meta"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+)
+
+// allPartitionID marks a collection-wide (all-partitions) L0 segment.
+const allPartitionID int64 = -1
+
+// -------- JSON contract with the Milvus `l0fanout` binary --------
+
+type fanoutPlan struct {
+	Tasks []fanoutTask `json:"tasks"`
+}
+
+type fanoutTask struct {
+	L0DeltaPaths     []string       `json:"l0DeltaPaths"`
+	L0StorageVersion int64          `json:"l0StorageVersion"`
+	PkType           string         `json:"pkType"`
+	Targets          []fanoutTarget `json:"targets"`
+}
+
+type fanoutTarget struct {
+	CollectionID   int64  `json:"collectionID"`
+	PartitionID    int64  `json:"partitionID"`
+	SegmentID      int64  `json:"segmentID"`
+	LogID          int64  `json:"logID"`
+	OutputPath     string `json:"outputPath"`
+	StorageVersion int64  `json:"storageVersion"`
+}
+
+type fanoutResult struct {
+	Written []fanoutWritten `json:"written"`
+}
+
+type fanoutWritten struct {
+	SegmentID     int64  `json:"segmentID"`
+	LogID         int64  `json:"logID"`
+	Path          string `json:"path"`
+	EntriesNum    int64  `json:"entriesNum"`
+	MemorySize    int64  `json:"memorySize"`
+	TimestampFrom uint64 `json:"timestampFrom"`
+	TimestampTo   uint64 `json:"timestampTo"`
+}
+
+// Task washes one backup.
+type Task struct {
+	cli         storage.Client
+	backupDir   string
+	params      *cfg.Config
+	l0fanoutBin string
+}
+
+func NewTask(cli storage.Client, backupDir string, params *cfg.Config, l0fanoutBin string) *Task {
+	return &Task{cli: cli, backupDir: backupDir, params: params, l0fanoutBin: l0fanoutBin}
+}
+
+func (t *Task) Execute(ctx context.Context) error {
+	info, err := meta.Read(ctx, t.cli, t.backupDir)
+	if err != nil {
+		return fmt.Errorf("wash: read backup meta: %w", err)
+	}
+
+	plan, dataSegByID, err := t.buildPlan(ctx, info)
+	if err != nil {
+		return fmt.Errorf("wash: build plan: %w", err)
+	}
+	if len(plan.Tasks) == 0 {
+		log.Info("wash: no L0 segments to fold, nothing to do", zap.String("backupDir", t.backupDir))
+		return nil
+	}
+
+	result, err := t.runFanout(ctx, plan)
+	if err != nil {
+		return fmt.Errorf("wash: run l0fanout: %w", err)
+	}
+
+	// Fold the written deltalogs onto the data segments.
+	for _, w := range result.Written {
+		seg := dataSegByID[w.SegmentID]
+		if seg == nil {
+			return fmt.Errorf("wash: l0fanout reported unknown segment %d", w.SegmentID)
+		}
+		seg.Deltalogs = append(seg.Deltalogs, &backuppb.FieldBinlog{
+			Binlogs: []*backuppb.Binlog{{
+				LogId:         w.LogID,
+				LogPath:       w.Path,
+				LogSize:       w.MemorySize,
+				EntriesNum:    w.EntriesNum,
+				TimestampFrom: w.TimestampFrom,
+				TimestampTo:   w.TimestampTo,
+			}},
+		})
+	}
+
+	dropL0(info)
+
+	if err := meta.Write(ctx, t.cli, t.backupDir, info); err != nil {
+		return fmt.Errorf("wash: write backup meta: %w", err)
+	}
+	log.Info("wash: done",
+		zap.String("backupDir", t.backupDir),
+		zap.Int("foldedDeltalogs", len(result.Written)))
+	return nil
+}
+
+// buildPlan computes the fan-out plan and a segmentID -> data-segment index (for
+// folding the results back). Partition-level L0 segments fan into same-partition
+// data segments; collection-level L0 segments (partitionID == allPartitionID)
+// fan into every data segment of the collection.
+func (t *Task) buildPlan(ctx context.Context, info *backuppb.BackupInfo) (*fanoutPlan, map[int64]*backuppb.SegmentBackupInfo, error) {
+	plan := &fanoutPlan{}
+	dataSegByID := make(map[int64]*backuppb.SegmentBackupInfo)
+	var logSeq int64
+
+	for _, coll := range info.GetCollectionBackups() {
+		collID := coll.GetCollectionId()
+		pkType, err := pkTypeName(coll)
+		if err != nil {
+			return nil, nil, fmt.Errorf("collection %d: %w", collID, err)
+		}
+
+		// Index data segments (non-L0) per partition and globally.
+		dataByPart := make(map[int64][]*backuppb.SegmentBackupInfo)
+		var allData []*backuppb.SegmentBackupInfo
+		for _, part := range coll.GetPartitionBackups() {
+			for _, seg := range part.GetSegmentBackups() {
+				if seg.GetIsL0() {
+					continue
+				}
+				dataByPart[part.GetPartitionId()] = append(dataByPart[part.GetPartitionId()], seg)
+				allData = append(allData, seg)
+				dataSegByID[seg.GetSegmentId()] = seg
+			}
+		}
+
+		// Collect L0 segments: partition-scoped (inside partitions) and
+		// collection-scoped (CollectionBackupInfo.L0Segments).
+		addTask := func(l0 *backuppb.SegmentBackupInfo, targets []*backuppb.SegmentBackupInfo) error {
+			if len(targets) == 0 {
+				return nil
+			}
+			deltaPaths, err := t.listL0Deltalogs(ctx, collID, l0)
+			if err != nil {
+				return err
+			}
+			if len(deltaPaths) == 0 {
+				return nil
+			}
+			ft := fanoutTask{
+				L0DeltaPaths:     deltaPaths,
+				L0StorageVersion: l0.GetStorageVersion(),
+				PkType:           pkType,
+			}
+			for _, seg := range targets {
+				logSeq++
+				logID := logID(l0.GetSegmentId(), logSeq)
+				ft.Targets = append(ft.Targets, fanoutTarget{
+					CollectionID:   collID,
+					PartitionID:    seg.GetPartitionId(),
+					SegmentID:      seg.GetSegmentId(),
+					LogID:          logID,
+					OutputPath:     t.deltalogKey(collID, seg.GetPartitionId(), seg.GetSegmentId(), logID),
+					StorageVersion: seg.GetStorageVersion(),
+				})
+			}
+			plan.Tasks = append(plan.Tasks, ft)
+			return nil
+		}
+
+		for _, part := range coll.GetPartitionBackups() {
+			for _, seg := range part.GetSegmentBackups() {
+				if !seg.GetIsL0() {
+					continue
+				}
+				if err := addTask(seg, dataByPart[part.GetPartitionId()]); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+		for _, l0 := range coll.GetL0Segments() {
+			if err := addTask(l0, allData); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	return plan, dataSegByID, nil
+}
+
+// listL0Deltalogs lists the deltalog object keys of one L0 segment.
+func (t *Task) listL0Deltalogs(ctx context.Context, collID int64, l0 *backuppb.SegmentBackupInfo) ([]string, error) {
+	dir := mpath.BackupDeltaLogDir(t.backupDir,
+		mpath.CollectionID(collID),
+		mpath.PartitionID(l0.GetPartitionId()),
+		mpath.SegmentID(l0.GetSegmentId()),
+	)
+	keys, _, err := storage.ListPrefixFlat(ctx, t.cli, dir, true)
+	if err != nil {
+		return nil, fmt.Errorf("list L0 deltalogs under %s: %w", dir, err)
+	}
+	return keys, nil
+}
+
+// deltalogKey builds the output object key for a new deltalog on a data segment.
+func (t *Task) deltalogKey(collID, partID, segID, logID int64) string {
+	dir := mpath.BackupDeltaLogDir(t.backupDir,
+		mpath.CollectionID(collID),
+		mpath.PartitionID(partID),
+		mpath.SegmentID(segID),
+	)
+	return dir + strconv.FormatInt(logID, 10)
+}
+
+// runFanout serializes the plan, invokes the l0fanout binary, and parses the result.
+func (t *Task) runFanout(ctx context.Context, plan *fanoutPlan) (*fanoutResult, error) {
+	tmpDir, err := os.MkdirTemp("", "wash-l0-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	planPath := tmpDir + "/plan.json"
+	resultPath := tmpDir + "/result.json"
+	cfgPath := tmpDir + "/milvus.yaml"
+
+	planBytes, err := json.Marshal(plan)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(planPath, planBytes, 0o600); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(cfgPath, []byte(t.milvusYAML()), 0o600); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, t.l0fanoutBin,
+		"--config", cfgPath, "--plan", planPath, "--output", resultPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("l0fanout %s: %w", t.l0fanoutBin, err)
+	}
+
+	resultBytes, err := os.ReadFile(resultPath)
+	if err != nil {
+		return nil, err
+	}
+	result := &fanoutResult{}
+	if err := json.Unmarshal(resultBytes, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// milvusYAML renders a minimal milvus.yaml describing the backup object storage,
+// so l0fanout's paramtable-based chunk manager can read/write the backup files.
+func (t *Task) milvusYAML() string {
+	m := &t.params.Minio
+	storageType := m.BackupStorageType.Val
+	if storageType == "" {
+		storageType = m.StorageType.Val
+	}
+	commonType := "remote"
+	if storageType == "local" {
+		commonType = "local"
+	}
+	return fmt.Sprintf(`common:
+  storageType: %s
+minio:
+  address: %s
+  port: %d
+  accessKeyID: %s
+  secretAccessKey: %s
+  token: %s
+  useSSL: %t
+  bucketName: %s
+  rootPath: %s
+  useIAM: %t
+  iamEndpoint: %s
+  region: %s
+  cloudProvider: %s
+  gcpCredentialJSON: %s
+`,
+		commonType,
+		m.BackupAddress.Val, m.BackupPort.Val,
+		m.BackupAccessKeyID.Val, m.BackupSecretAccessKey.Val, m.BackupToken.Val,
+		m.BackupUseSSL.Val, m.BackupBucketName.Val, m.BackupRootPath.Val,
+		m.BackupUseIAM.Val, m.BackupIAMEndpoint.Val, m.BackupRegion.Val,
+		storageType, m.BackupGcpCredentialJSON.Val,
+	)
+}
+
+// dropL0 removes every L0 segment from the metadata so a restore does not
+// re-import them (their deletes are now folded into the data segments).
+func dropL0(info *backuppb.BackupInfo) {
+	for _, coll := range info.GetCollectionBackups() {
+		coll.L0Segments = nil
+		for _, part := range coll.GetPartitionBackups() {
+			part.SegmentBackups = lo.Filter(part.GetSegmentBackups(), func(seg *backuppb.SegmentBackupInfo, _ int) bool {
+				return !seg.GetIsL0()
+			})
+		}
+	}
+}
+
+// pkTypeName returns the primary-key field type name ("Int64" | "VarChar").
+func pkTypeName(coll *backuppb.CollectionBackupInfo) (string, error) {
+	for _, field := range coll.GetSchema().GetFields() {
+		if !field.GetIsPrimaryKey() {
+			continue
+		}
+		switch field.GetDataType() {
+		case backuppb.DataType_Int64:
+			return "Int64", nil
+		case backuppb.DataType_VarChar:
+			return "VarChar", nil
+		default:
+			return "", fmt.Errorf("unsupported primary key type %v", field.GetDataType())
+		}
+	}
+	return "", fmt.Errorf("no primary key field in schema")
+}
+
+// logID derives a deltalog id that is unique within a data segment's delta dir.
+// L0 segment ids and a per-run sequence make collisions with existing logIDs of
+// the target segment vanishingly unlikely.
+func logID(l0SegID, seq int64) int64 {
+	return l0SegID*1_000_000 + seq
+}

--- a/core/wash/wash_test.go
+++ b/core/wash/wash_test.go
@@ -1,0 +1,61 @@
+package wash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+)
+
+func TestPkTypeName(t *testing.T) {
+	int64Coll := &backuppb.CollectionBackupInfo{Schema: &backuppb.CollectionSchema{Fields: []*backuppb.FieldSchema{
+		{Name: "vec", DataType: backuppb.DataType_FloatVector},
+		{Name: "id", IsPrimaryKey: true, DataType: backuppb.DataType_Int64},
+	}}}
+	pt, err := pkTypeName(int64Coll)
+	assert.NoError(t, err)
+	assert.Equal(t, "Int64", pt)
+
+	varcharColl := &backuppb.CollectionBackupInfo{Schema: &backuppb.CollectionSchema{Fields: []*backuppb.FieldSchema{
+		{Name: "id", IsPrimaryKey: true, DataType: backuppb.DataType_VarChar},
+	}}}
+	pt, err = pkTypeName(varcharColl)
+	assert.NoError(t, err)
+	assert.Equal(t, "VarChar", pt)
+
+	noPk := &backuppb.CollectionBackupInfo{Schema: &backuppb.CollectionSchema{Fields: []*backuppb.FieldSchema{
+		{Name: "vec", DataType: backuppb.DataType_FloatVector},
+	}}}
+	_, err = pkTypeName(noPk)
+	assert.Error(t, err)
+}
+
+func TestDropL0(t *testing.T) {
+	info := &backuppb.BackupInfo{CollectionBackups: []*backuppb.CollectionBackupInfo{{
+		CollectionId: 1,
+		// collection-level (all-partitions) L0
+		L0Segments: []*backuppb.SegmentBackupInfo{{SegmentId: 100, IsL0: true, PartitionId: allPartitionID}},
+		PartitionBackups: []*backuppb.PartitionBackupInfo{{
+			PartitionId: 10,
+			SegmentBackups: []*backuppb.SegmentBackupInfo{
+				{SegmentId: 200, IsL0: false},
+				{SegmentId: 201, IsL0: true}, // partition-level L0
+				{SegmentId: 202, IsL0: false},
+			},
+		}},
+	}}}
+
+	dropL0(info)
+
+	coll := info.GetCollectionBackups()[0]
+	assert.Nil(t, coll.GetL0Segments(), "collection-level L0 must be dropped")
+
+	segs := coll.GetPartitionBackups()[0].GetSegmentBackups()
+	assert.Len(t, segs, 2, "partition-level L0 must be dropped, data segments kept")
+	for _, seg := range segs {
+		assert.False(t, seg.GetIsL0())
+	}
+	assert.Equal(t, int64(200), segs[0].GetSegmentId())
+	assert.Equal(t, int64(202), segs[1].GetSegmentId())
+}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -130,6 +130,61 @@ func Read(ctx context.Context, cli storage.Client, backupDir string) (*backuppb.
 	return readFromLevel(ctx, backupDir, cli)
 }
 
+// Write persists a modified BackupInfo tree back to a backup directory, writing
+// all five meta files (full + the four leveled files) so that both read paths in
+// Read stay consistent. It MUTATES info while splitting it into leveled files
+// (the full-meta bytes are captured first), so the caller must not reuse info
+// afterwards. This is the inverse of levelToTree and mirrors the leveled layout
+// produced by core/backup's meta builder.
+func Write(ctx context.Context, cli storage.Client, backupDir string, info *backuppb.BackupInfo) error {
+	// 1. full meta (authoritative: Read prefers it when present).
+	fullBytes, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("meta: marshal full meta %w", err)
+	}
+	if err := storage.Write(ctx, cli, mpath.MetaKey(backupDir, mpath.FullMeta), fullBytes); err != nil {
+		return fmt.Errorf("meta: write full meta %w", err)
+	}
+
+	// 2. split the tree into the four leveled files. Segment objects are shared
+	// (only marshaled), so we mutate the collection/partition nesting in place.
+	colls := info.GetCollectionBackups()
+	var parts []*backuppb.PartitionBackupInfo
+	for _, c := range colls {
+		parts = append(parts, c.GetPartitionBackups()...)
+	}
+	var segs []*backuppb.SegmentBackupInfo
+	for _, p := range parts {
+		segs = append(segs, p.GetSegmentBackups()...)
+		p.SegmentBackups = nil
+	}
+	for _, c := range colls {
+		c.PartitionBackups = nil
+		c.L0Segments = nil
+	}
+	info.CollectionBackups = nil // info is now the top-level backup summary
+
+	levels := []struct {
+		metaType mpath.MetaType
+		value    any
+	}{
+		{mpath.BackupMeta, info},
+		{mpath.CollectionMeta, &backuppb.CollectionLevelBackupInfo{Infos: colls}},
+		{mpath.PartitionMeta, &backuppb.PartitionLevelBackupInfo{Infos: parts}},
+		{mpath.SegmentMeta, &backuppb.SegmentLevelBackupInfo{Infos: segs}},
+	}
+	for _, lv := range levels {
+		byts, err := json.Marshal(lv.value)
+		if err != nil {
+			return fmt.Errorf("meta: marshal %s %w", lv.metaType, err)
+		}
+		if err := storage.Write(ctx, cli, mpath.MetaKey(backupDir, lv.metaType), byts); err != nil {
+			return fmt.Errorf("meta: write %s %w", lv.metaType, err)
+		}
+	}
+	return nil
+}
+
 func Exist(ctx context.Context, cli storage.Client, backupDir string) (bool, error) {
 	key := mpath.MetaKey(backupDir, mpath.BackupMeta)
 	exist, err := storage.Exist(ctx, cli, key)

--- a/internal/meta/meta_write_test.go
+++ b/internal/meta/meta_write_test.go
@@ -1,0 +1,63 @@
+package meta
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+)
+
+// TestWriteReadRoundTrip verifies Write persists the whole tree and Read
+// reconstructs it (via the full-meta path and, after removing full_meta, via the
+// leveled files).
+func TestWriteReadRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	cli, err := storage.NewClient(ctx, storage.Config{Provider: cfg.Local})
+	require.NoError(t, err)
+
+	backupDir := t.TempDir() + "/mybackup"
+
+	info := &backuppb.BackupInfo{
+		Id:   "bk-1",
+		Name: "mybackup",
+		CollectionBackups: []*backuppb.CollectionBackupInfo{{
+			CollectionId: 1,
+			PartitionBackups: []*backuppb.PartitionBackupInfo{{
+				CollectionId: 1,
+				PartitionId:  10,
+				SegmentBackups: []*backuppb.SegmentBackupInfo{
+					{SegmentId: 200, CollectionId: 1, PartitionId: 10, Size: 5},
+					{SegmentId: 201, CollectionId: 1, PartitionId: 10, Size: 7},
+				},
+			}},
+		}},
+	}
+
+	require.NoError(t, Write(ctx, cli, backupDir, info))
+
+	// Read (full-meta path).
+	got, err := Read(ctx, cli, backupDir)
+	require.NoError(t, err)
+	require.Len(t, got.GetCollectionBackups(), 1)
+	parts := got.GetCollectionBackups()[0].GetPartitionBackups()
+	require.Len(t, parts, 1)
+	segs := parts[0].GetSegmentBackups()
+	require.Len(t, segs, 2)
+	assert.Equal(t, int64(200), segs[0].GetSegmentId())
+	assert.Equal(t, int64(201), segs[1].GetSegmentId())
+
+	// Remove full_meta so Read must reassemble from the leveled files.
+	require.NoError(t, cli.DeleteObject(ctx, mpath.MetaKey(backupDir, mpath.FullMeta)))
+	got2, err := Read(ctx, cli, backupDir)
+	require.NoError(t, err)
+	require.Len(t, got2.GetCollectionBackups(), 1)
+	segs2 := got2.GetCollectionBackups()[0].GetPartitionBackups()[0].GetSegmentBackups()
+	require.Len(t, segs2, 2, "leveled reassembly must re-nest segments into partitions")
+	assert.Equal(t, int64(201), segs2[1].GetSegmentId())
+}


### PR DESCRIPTION
## What

Adds a `wash` command that reprocesses an existing backup so it no longer contains **L0 (delete-only) segments**. Each L0 segment's deltalogs are **fanned out into the data segments' own deltalogs** — the offline equivalent of Milvus L0 compaction. Insert data is **not** rewritten; the deletes are just added as deltalogs, and a plain restore drops the deleted rows at read time via the existing per-segment delta path.

```
milvus-backup wash --name <backup> [--l0fanout <path-to-l0fanout-binary>]
```

- `core/wash` — computes the partition-scoped fan-out plan (partition L0 → same-partition data segments; collection-level L0 → all data segments), invokes the `l0fanout` codec binary, folds the written deltalogs into the metadata, and drops the L0 segments.
- `internal/meta` — new `Write()` to persist a modified `BackupInfo` (full + the four leveled meta files), the inverse of `levelToTree`.
- `cmd/wash` — the `wash` cobra command.

## Why

Restoring L0 segments is incompatible with Milvus `commit_timestamp` (2PC / replication imports): the L0 deletes carry original timestamps while data segments are stamped with `commit_ts`, so the deletes are silently dropped. In the shared datanode pool, a kernel-side "apply L0 during import" option would also be silently ignored by older workers. Folding L0 into per-segment deltalogs offline sidesteps both: the washed backup restores correctly under `commit_timestamp` **and on any datanode version** — no new import option, no version skew. See milvus-io/milvus#51177.

## Dependency

The deltalog codec runs in a separate Milvus binary, `l0fanout` (milvus-io/milvus **#51203**), which this command shells out to. Milvus also disables legacy L0 import by default (milvus-io/milvus **#51194**), so backups must be washed before restore.

## Testing

milvus-backup is pure Go, so this is verified locally:
- `go build ./...` passes.
- `TestDropL0` — L0 dropped from both collection-level (`L0Segments`) and partition-level (`IsL0` in `SegmentBackups`), data segments kept.
- `TestPkTypeName` — pk-type detection (Int64/VarChar/none).
- `TestWriteReadRoundTrip` — `meta.Write`→`Read` round-trips via both the full-meta path and the leveled-reassembly path.

End-to-end fan-out (invoking the real `l0fanout` against object storage) requires the Milvus binary and is not exercised here.

## Scope / follow-ups

- The generated `l0fanout` config covers the common object-storage cases (static creds / IAM); provider-specific nuances (GCP JSON, Azure) may need refinement.
- No PK routing: each target receives the whole delete set (non-matching PKs are no-ops at restore); partition scoping is handled from the backup metadata.