### PR TITLE
restore: support secondary import two-phase commit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -594,8 +594,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Two scenarios:
+        # Three scenarios:
         #   - same-version:          source and target are both the latest 2.6.
+        #   - same-version-master:   source and target are both the latest master,
+        #     the only line that has import two-phase commit. #1080 dropped master
+        #     from CI because red master jobs hid regressions on the released
+        #     line; this brings it back for secondary restore alone, next to the
+        #     2.6 scenario rather than in place of it, so the 2PC path is covered
+        #     without master failures masking a 2.6 one.
         #   - cross-version-upgrade: source data is created on a pre-#46419 Milvus
         #     (v2.6.7, where the auto-appended $meta field has no Nullable nor
         #     DefaultValue), then the cluster is upgraded to a CDC-capable image
@@ -608,6 +614,9 @@ jobs:
           - scenario: same-version
             prepare_image_tag: 2.6-latest
             run_image_tag: 2.6-latest
+          - scenario: same-version-master
+            prepare_image_tag: master-latest
+            run_image_tag: master-latest
           - scenario: cross-version-upgrade
             prepare_image_tag: v2.6.7
             run_image_tag: 2.6-latest

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -2,7 +2,7 @@ package secondary
 
 import (
 	"context"
-	"errors"
+	"encoding/base64"
 	"fmt"
 	"math/rand/v2"
 	"strconv"
@@ -11,11 +11,13 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 
@@ -31,6 +33,8 @@ const (
 	_bulkInsertTimeout             = 60 * time.Minute
 	_bulkInsertRestfulAPIChunkSize = 256
 	_bulkInsertCheckInterval       = 3 * time.Second
+	_commitImportMessageType       = 45
+	_commitImportMessageVersion    = 2
 )
 
 type partitionDir struct {
@@ -62,6 +66,7 @@ type batch struct {
 func (b *batch) options() map[string]string {
 	opts := map[string]string{
 		"skip_disk_quota_check": "true",
+		"auto_commit":           "false",
 		"end_ts":                strconv.FormatUint(b.timestamp, 10),
 		"storage_version":       strconv.FormatInt(b.storageVersion, 10),
 	}
@@ -247,7 +252,7 @@ func (dmlt *collDMLTask) checkBulkInsertJobs(ctx context.Context, jobIDs []int64
 	g, subCtx := errgroup.WithContext(ctx)
 	for _, jobID := range jobIDs {
 		g.Go(func() error {
-			if err := dmlt.checkBulkInsertJob(subCtx, strconv.Itoa(int(jobID))); err != nil {
+			if err := dmlt.checkBulkInsertJob(subCtx, jobID); err != nil {
 				return fmt.Errorf("secondary: check bulk insert job %d: %w", jobID, err)
 			}
 			return nil
@@ -261,41 +266,123 @@ func (dmlt *collDMLTask) checkBulkInsertJobs(ctx context.Context, jobIDs []int64
 	return nil
 }
 
-func (dmlt *collDMLTask) checkBulkInsertJob(ctx context.Context, jobID string) error {
-	// wait for bulk insert job done
-	var lastProgress int
-	lastUpdateTime := time.Now()
-	for range time.Tick(_bulkInsertCheckInterval) {
-		resp, err := dmlt.restfulCli.GetBulkInsertState(ctx, dmlt.collBackup.GetDbName(), jobID)
-		if err != nil {
-			return fmt.Errorf("secondary: get bulk insert state: %w", err)
-		}
-
-		dmlt.logger.Info("bulk insert task state", zap.String("job_id", jobID),
-			zap.String("state", resp.Data.State),
-			zap.Int("progress", resp.Data.Progress))
-		switch resp.Data.State {
-		case string(milvus.ImportStateFailed):
-			return fmt.Errorf("secondary: bulk insert failed: %s", resp.Data.Reason)
-		case string(milvus.ImportStateCompleted):
-			dmlt.logger.Info("bulk insert task success", zap.String("job_id", jobID))
-			return nil
-		default:
-			currentProgress := resp.Data.Progress
-			if currentProgress > lastProgress {
-				lastProgress = currentProgress
-				lastUpdateTime = time.Now()
-			} else if time.Since(lastUpdateTime) >= _bulkInsertTimeout {
-				dmlt.logger.Warn("bulk insert task no progress for too long, may milvus is not healthy",
-					zap.String("job_id", jobID),
-					zap.Duration("timeout", _bulkInsertTimeout))
-				lastUpdateTime = time.Now()
-			}
-			continue
-		}
+func (dmlt *collDMLTask) checkBulkInsertJob(ctx context.Context, jobID int64) error {
+	state, err := dmlt.waitBulkInsertReadyToCommit(ctx, jobID)
+	if err != nil {
+		return err
 	}
 
-	return errors.New("secondary: walk into unreachable code")
+	switch state {
+	case milvus.ImportStateCompleted:
+		return nil
+	case milvus.ImportStateUncommitted:
+		if err := dmlt.sendCommitImportMsg(ctx, jobID); err != nil {
+			return fmt.Errorf("secondary: send commit import msg: %w", err)
+		}
+	case milvus.ImportStateCommitting:
+		// Another coordinator already initiated the commit; only wait for completion.
+	default:
+		return fmt.Errorf("secondary: unexpected bulk insert state %s", state)
+	}
+
+	return dmlt.waitBulkInsertCompleted(ctx, jobID)
+}
+
+func (dmlt *collDMLTask) waitBulkInsertReadyToCommit(ctx context.Context, jobID int64) (milvus.ImportState, error) {
+	return dmlt.waitBulkInsertState(ctx, jobID, func(state milvus.ImportState) bool {
+		return state == milvus.ImportStateCompleted ||
+			state == milvus.ImportStateUncommitted ||
+			state == milvus.ImportStateCommitting
+	})
+}
+
+func (dmlt *collDMLTask) waitBulkInsertCompleted(ctx context.Context, jobID int64) error {
+	_, err := dmlt.waitBulkInsertState(ctx, jobID, func(state milvus.ImportState) bool {
+		return state == milvus.ImportStateCompleted
+	})
+	return err
+}
+
+func (dmlt *collDMLTask) waitBulkInsertState(
+	ctx context.Context,
+	jobID int64,
+	done func(milvus.ImportState) bool,
+) (milvus.ImportState, error) {
+	jobIDStr := strconv.FormatInt(jobID, 10)
+
+	var lastProgress int
+	lastUpdateTime := time.Now()
+	ticker := time.NewTicker(_bulkInsertCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		resp, err := dmlt.restfulCli.GetBulkInsertState(ctx, dmlt.collBackup.GetDbName(), jobIDStr)
+		if err != nil {
+			return "", fmt.Errorf("secondary: get bulk insert state: %w", err)
+		}
+
+		state := milvus.ImportState(resp.Data.State)
+		dmlt.logger.Info("bulk insert task state", zap.Int64("job_id", jobID),
+			zap.String("state", resp.Data.State),
+			zap.Int("progress", resp.Data.Progress))
+		if state == milvus.ImportStateFailed {
+			return "", fmt.Errorf("secondary: bulk insert failed: %s", resp.Data.Reason)
+		}
+		if done(state) {
+			if state == milvus.ImportStateCompleted {
+				dmlt.logger.Info("bulk insert task success", zap.Int64("job_id", jobID))
+			}
+			return state, nil
+		}
+
+		currentProgress := resp.Data.Progress
+		if currentProgress > lastProgress {
+			lastProgress = currentProgress
+			lastUpdateTime = time.Now()
+		} else if time.Since(lastUpdateTime) >= _bulkInsertTimeout {
+			dmlt.logger.Warn("bulk insert task no progress for too long, may milvus is not healthy",
+				zap.Int64("job_id", jobID),
+				zap.Duration("timeout", _bulkInsertTimeout))
+			lastUpdateTime = time.Now()
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (dmlt *collDMLTask) sendCommitImportMsg(ctx context.Context, jobID int64) error {
+	header := protowire.AppendTag(nil, 1, protowire.VarintType)
+	header = protowire.AppendVarint(header, uint64(dmlt.collBackup.GetCollectionId()))
+	header = protowire.AppendTag(header, 2, protowire.VarintType)
+	header = protowire.AppendVarint(header, uint64(jobID))
+
+	broadcastHeader, err := message.EncodeProto(&messagespb.BroadcastHeader{
+		Vchannels: dmlt.collBackup.GetVirtualChannelNames(),
+	})
+	if err != nil {
+		return fmt.Errorf("secondary: encode commit import broadcast header: %w", err)
+	}
+
+	properties := map[string]string{
+		"_t":  strconv.Itoa(_commitImportMessageType),
+		"_v":  strconv.Itoa(_commitImportMessageVersion),
+		"_h":  base64.StdEncoding.EncodeToString(header),
+		"_bh": broadcastHeader,
+	}
+
+	if err := dmlt.streamCli.Send(ctx, func(uint64) []message.MutableMessage {
+		broadcast := message.NewBroadcastMutableMessageBeforeAppend(nil, properties).
+			WithBroadcastID(rand.Uint64())
+		return broadcast.SplitIntoMutableMessage()
+	}); err != nil {
+		return fmt.Errorf("secondary: broadcast commit import: %w", err)
+	}
+
+	return nil
 }
 
 func (dmlt *collDMLTask) nonL0SegBatches(ctx context.Context, segs []*backuppb.SegmentBackupInfo) ([]batch, error) {

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -2,17 +2,23 @@ package secondary
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
@@ -60,6 +66,19 @@ func (s *recordingStream) Forward(_ context.Context, msgs ...*commonpb.Immutable
 func (s *recordingStream) WaitConfirm() {}
 func (s *recordingStream) Close()       {}
 
+func (s *recordingStream) messagesByType(messageType string) []*commonpb.ImmutableMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var result []*commonpb.ImmutableMessage
+	for _, msg := range s.msgs {
+		if msg.GetProperties()["_t"] == messageType {
+			result = append(result, msg)
+		}
+	}
+	return result
+}
+
 // timestampsByPch returns the timestamps grouped by physical channel, in send order.
 func (s *recordingStream) timestampsByPch() map[string][]uint64 {
 	s.mu.Lock()
@@ -88,6 +107,62 @@ func (r *completedRestful) GetBulkInsertState(context.Context, string, string) (
 }
 
 func (r *completedRestful) GetSegmentInfo(context.Context, string, int64, int64) (*milvus.SegmentInfo, error) {
+	return nil, nil
+}
+
+type sequencedRestful struct {
+	mu     sync.Mutex
+	states []milvus.ImportState
+	calls  int
+}
+
+func (r *sequencedRestful) BulkInsert(context.Context, milvus.BulkInsertV2Input) (string, error) {
+	return "", nil
+}
+
+func (r *sequencedRestful) GetBulkInsertState(context.Context, string, string) (*milvus.GetProcessResp, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	stateIndex := min(r.calls, len(r.states)-1)
+	r.calls++
+	resp := &milvus.GetProcessResp{}
+	resp.Data.State = string(r.states[stateIndex])
+	return resp, nil
+}
+
+func (r *sequencedRestful) GetSegmentInfo(context.Context, string, int64, int64) (*milvus.SegmentInfo, error) {
+	return nil, nil
+}
+
+type perJobSequencedRestful struct {
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (r *perJobSequencedRestful) BulkInsert(context.Context, milvus.BulkInsertV2Input) (string, error) {
+	return "", nil
+}
+
+func (r *perJobSequencedRestful) GetBulkInsertState(_ context.Context, _, jobID string) (*milvus.GetProcessResp, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.calls == nil {
+		r.calls = make(map[string]int)
+	}
+	state := milvus.ImportStateUncommitted
+	if r.calls[jobID] > 0 {
+		state = milvus.ImportStateCompleted
+	}
+	r.calls[jobID]++
+
+	resp := &milvus.GetProcessResp{}
+	resp.Data.State = string(state)
+	return resp, nil
+}
+
+func (r *perJobSequencedRestful) GetSegmentInfo(context.Context, string, int64, int64) (*milvus.SegmentInfo, error) {
 	return nil, nil
 }
 
@@ -392,4 +467,157 @@ func TestSendBatches(t *testing.T) {
 
 	// Each batch broadcasts to all vchannels, so total messages = 2 batches * 2 vchannels.
 	assert.Len(t, stream.msgs, 4)
+}
+
+func TestCheckBulkInsertJob_Import2PCStates(t *testing.T) {
+	vchannels := newTestVChannels()
+	collBackup := newTestCollBackup(vchannels, nil, nil)
+
+	t.Run("LegacyCompletedSendsNoCommit", func(t *testing.T) {
+		stream := &recordingStream{}
+		task := newTestDMLTask(t, collBackup, stream)
+		task.restfulCli = &sequencedRestful{states: []milvus.ImportState{milvus.ImportStateCompleted}}
+
+		err := task.checkBulkInsertJob(context.Background(), 101)
+		assert.NoError(t, err)
+		assert.Empty(t, stream.messagesByType(strconv.Itoa(_commitImportMessageType)))
+	})
+
+	t.Run("UncommittedSendsOneCommitAndWaits", func(t *testing.T) {
+		stream := &recordingStream{}
+		restful := &sequencedRestful{states: []milvus.ImportState{
+			milvus.ImportStateUncommitted,
+			milvus.ImportStateCompleted,
+		}}
+		task := newTestDMLTask(t, collBackup, stream)
+		task.restfulCli = restful
+
+		err := task.checkBulkInsertJob(context.Background(), 102)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, restful.calls)
+		assert.Len(t, stream.messagesByType(strconv.Itoa(_commitImportMessageType)), len(vchannels))
+	})
+
+	t.Run("CommittingOnlyWaits", func(t *testing.T) {
+		stream := &recordingStream{}
+		restful := &sequencedRestful{states: []milvus.ImportState{
+			milvus.ImportStateCommitting,
+			milvus.ImportStateCompleted,
+		}}
+		task := newTestDMLTask(t, collBackup, stream)
+		task.restfulCli = restful
+
+		err := task.checkBulkInsertJob(context.Background(), 103)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, restful.calls)
+		assert.Empty(t, stream.messagesByType(strconv.Itoa(_commitImportMessageType)))
+	})
+}
+
+func TestSendImportMsg_DisablesAutoCommit(t *testing.T) {
+	vchannels := newTestVChannels()
+	collBackup := newTestCollBackup(vchannels, nil, nil)
+	stream := &recordingStream{}
+	task := newTestDMLTask(t, collBackup, stream)
+
+	_, err := task.sendImportMsg(context.Background(), 1, batch{
+		timestamp:      100,
+		storageVersion: 2,
+		partitionDirs:  []partitionDir{{insertLogDir: "/insert"}},
+	})
+	assert.NoError(t, err)
+
+	importMessages := stream.messagesByType(strconv.Itoa(int(message.MessageTypeImport)))
+	assert.NotEmpty(t, importMessages)
+	importBody := &msgpb.ImportMsg{}
+	assert.NoError(t, proto.Unmarshal(importMessages[0].GetPayload(), importBody))
+	assert.Equal(t, "false", importBody.GetOptions()["auto_commit"])
+}
+
+func TestSendCommitImportMsg_WireCompatibilityAndFanout(t *testing.T) {
+	vchannels := newTestVChannels()
+	collBackup := newTestCollBackup(vchannels, nil, nil)
+	stream := &recordingStream{}
+	task := newTestDMLTask(t, collBackup, stream)
+	jobID := int64(456)
+
+	err := task.sendCommitImportMsg(context.Background(), jobID)
+	assert.NoError(t, err)
+
+	commitMessages := stream.messagesByType(strconv.Itoa(_commitImportMessageType))
+	assert.Len(t, commitMessages, len(vchannels))
+	for i, msg := range commitMessages {
+		properties := msg.GetProperties()
+		assert.Equal(t, strconv.Itoa(_commitImportMessageType), properties["_t"])
+		assert.Equal(t, strconv.Itoa(_commitImportMessageVersion), properties["_v"])
+		assert.NotEmpty(t, properties["_h"])
+		assert.NotEmpty(t, properties["_bh"])
+		assert.Empty(t, msg.GetPayload())
+		assert.Equal(t, vchannels[i], milvus.GetVch(msg))
+
+		header, decodeErr := base64.StdEncoding.DecodeString(properties["_h"])
+		assert.NoError(t, decodeErr)
+		fieldNumber, wireType, consumed := protowire.ConsumeTag(header)
+		assert.Equal(t, protowire.Number(1), fieldNumber)
+		assert.Equal(t, protowire.VarintType, wireType)
+		collectionID, valueBytes := protowire.ConsumeVarint(header[consumed:])
+		assert.Greater(t, valueBytes, 0)
+		header = header[consumed+valueBytes:]
+		fieldNumber, wireType, consumed = protowire.ConsumeTag(header)
+		assert.Equal(t, protowire.Number(2), fieldNumber)
+		assert.Equal(t, protowire.VarintType, wireType)
+		wireJobID, valueBytes := protowire.ConsumeVarint(header[consumed:])
+		assert.Greater(t, valueBytes, 0)
+		assert.Empty(t, header[consumed+valueBytes:])
+		assert.Equal(t, uint64(collBackup.GetCollectionId()), collectionID)
+		assert.Equal(t, uint64(jobID), wireJobID)
+
+		broadcastHeader := &messagespb.BroadcastHeader{}
+		assert.NoError(t, message.DecodeProto(properties["_bh"], broadcastHeader))
+		assert.NotZero(t, broadcastHeader.GetBroadcastId())
+		assert.Equal(t, vchannels, broadcastHeader.GetVchannels())
+	}
+}
+
+func TestExecute_Import2PCPreservesPhaseAndTimestampOrdering(t *testing.T) {
+	vchannels := newTestVChannels()
+	partitions := []*backuppb.PartitionBackupInfo{
+		{
+			PartitionId:   1,
+			PartitionName: "part1",
+			SegmentBackups: []*backuppb.SegmentBackupInfo{
+				{PartitionId: 1, VChannel: vchannels[0], GroupId: 1, Size: 100, StorageVersion: 2},
+				{PartitionId: 1, VChannel: vchannels[0], GroupId: 2, Size: 100, IsL0: true, StorageVersion: 2},
+			},
+		},
+	}
+	allPartitionL0 := []*backuppb.SegmentBackupInfo{
+		{PartitionId: 1, VChannel: vchannels[0], GroupId: 3, Size: 100, IsL0: true, StorageVersion: 2},
+	}
+	collBackup := newTestCollBackup(vchannels, partitions, allPartitionL0)
+	stream := &recordingStream{}
+	task := newTestDMLTask(t, collBackup, stream)
+	task.restfulCli = &perJobSequencedRestful{}
+
+	err := task.Execute(context.Background())
+	assert.NoError(t, err)
+
+	var messageTypes []string
+	for _, msg := range stream.msgs {
+		messageTypes = append(messageTypes, msg.GetProperties()["_t"])
+	}
+	importType := strconv.Itoa(int(message.MessageTypeImport))
+	commitType := strconv.Itoa(_commitImportMessageType)
+	assert.Equal(t, []string{
+		importType, importType, commitType, commitType,
+		importType, importType, commitType, commitType,
+		importType, importType, commitType, commitType,
+	}, messageTypes)
+
+	for pch, timestamps := range stream.timestampsByPch() {
+		for i := 1; i < len(timestamps); i++ {
+			assert.Greater(t, timestamps[i], timestamps[i-1],
+				"timestamps on pch %s should be strictly increasing, got %v", pch, timestamps)
+		}
+	}
 }

--- a/internal/client/milvus/restful.go
+++ b/internal/client/milvus/restful.go
@@ -18,10 +18,12 @@ import (
 type ImportState string
 
 const (
-	ImportStatePending   ImportState = "Pending"
-	ImportStateImporting ImportState = "Importing"
-	ImportStateCompleted ImportState = "Completed"
-	ImportStateFailed    ImportState = "Failed"
+	ImportStatePending     ImportState = "Pending"
+	ImportStateImporting   ImportState = "Importing"
+	ImportStateUncommitted ImportState = "Uncommitted"
+	ImportStateCommitting  ImportState = "Committing"
+	ImportStateCompleted   ImportState = "Completed"
+	ImportStateFailed      ImportState = "Failed"
 )
 
 type BulkInsertV2Input struct {


### PR DESCRIPTION
## Summary
Add state-based compatibility for Milvus Import 2PC during Secondary restore.

Milvus master rejects `auto_commit=true` imports in a replicating cluster, so the
import must be committed explicitly. The commit is driven by a CommitImport V2 WAL
message broadcast over the collection's data vchannels, keeping the commit ordered
inside the replicate stream rather than stamped by the target cluster's own clock.

## Changes
- disable automatic import commit for replicated Secondary import messages
- detect Uncommitted and Committing states without Milvus version checks
- broadcast wire-compatible CommitImport V2 messages over collection data vchannels
- preserve non-L0 and L0 phase barriers and per-pchannel timestamp ordering
- cover legacy and 2PC state paths, wire properties, header/body encoding, and fanout
- add a `same-version-master` scenario to the secondary restore CI job, alongside
  the existing 2.6 one, so the 2PC path is actually exercised — import 2PC only
  exists on the master line, which #1080 had dropped from the matrix

/kind improvement
