### PR TITLE
test: drop schema version consistency gate before add_collection_field

### DIFF
--- a/example/prepare_data.py
+++ b/example/prepare_data.py
@@ -15,85 +15,7 @@ from pymilvus import (
     Collection,
     MilvusClient,
 )
-from pymilvus.exceptions import MilvusException
 import argparse
-
-
-SCHEMA_VERSION_CONSISTENT_KEY = "schema_version_consistent_segments"
-SCHEMA_VERSION_TOTAL_KEY = "schema_version_total_segments"
-
-
-def is_schema_version_not_ready(exc):
-    message = str(exc)
-    return (
-        "schema version" in message
-        and (
-            "not ready" in message
-            or "consistency check failed" in message
-        )
-    )
-
-
-def wait_schema_version_consistent(client, collection_name, timeout=60, poll_interval=0.2):
-    deadline = time.time() + timeout
-    last_consistent = None
-    last_total = None
-
-    while time.time() < deadline:
-        stats = client.get_collection_stats(collection_name=collection_name)
-        consistent = stats.get(SCHEMA_VERSION_CONSISTENT_KEY)
-        total = stats.get(SCHEMA_VERSION_TOTAL_KEY)
-
-        if consistent is None and total is None:
-            return
-        if consistent is not None and total is not None and int(consistent) == int(total):
-            return
-
-        last_consistent = consistent
-        last_total = total
-        time.sleep(poll_interval)
-
-    raise TimeoutError(
-        f"schema version is not consistent for {collection_name}: "
-        f"{last_consistent}/{last_total} segments are consistent"
-    )
-
-
-def add_collection_field_with_schema_retry(
-    client,
-    collection_name,
-    field_name,
-    data_type,
-    timeout=120,
-    **kwargs,
-):
-    deadline = time.time() + timeout
-    last_error = None
-
-    while time.time() < deadline:
-        wait_schema_version_consistent(
-            client,
-            collection_name,
-            timeout=max(1, min(30, deadline - time.time())),
-        )
-        try:
-            return client.add_collection_field(
-                collection_name=collection_name,
-                field_name=field_name,
-                data_type=data_type,
-                **kwargs,
-            )
-        except MilvusException as exc:
-            if not is_schema_version_not_ready(exc):
-                raise
-            last_error = exc
-            print(f"schema version not ready after adding fields, retrying: {exc}")
-            time.sleep(1)
-
-    raise TimeoutError(
-        f"timed out adding field {field_name} to {collection_name}"
-    ) from last_error
-
 
 
 def main(uri="http://127.0.0.1:19530", token="root:Milvus", stage=None, total_entities=3000):
@@ -356,11 +278,10 @@ def main_added(uri="http://127.0.0.1:19530", token="root:Milvus", total_entities
         ("added_json", DataType.JSON, {"nullable": True}),
     ]
     for field_name, data_type, kwargs in added_fields:
-        add_collection_field_with_schema_retry(
-            client,
-            "hello_milvus_added",
-            field_name,
-            data_type,
+        client.add_collection_field(
+            collection_name="hello_milvus_added",
+            field_name=field_name,
+            data_type=data_type,
             **kwargs,
         )
         print(f"added field {field_name} ({data_type.name}) {kwargs}")

--- a/tests/testcases/test_restore_backup.py
+++ b/tests/testcases/test_restore_backup.py
@@ -7,7 +7,6 @@ import pandas as pd
 import random
 from collections import defaultdict
 from pymilvus import db, list_collections, Collection, DataType, Function, FunctionType
-from pymilvus.exceptions import MilvusException
 from base.client_base import TestcaseBase
 from common import common_func as cf
 from common import common_type as ct
@@ -22,80 +21,6 @@ fake_en = Faker("en_US")
 prefix = "restore_backup"
 backup_prefix = "backup"
 suffix = "_bak"
-SCHEMA_VERSION_CONSISTENT_KEY = "schema_version_consistent_segments"
-SCHEMA_VERSION_TOTAL_KEY = "schema_version_total_segments"
-
-
-def is_schema_version_not_ready(exc):
-    message = str(exc)
-    return (
-        "schema version" in message
-        and (
-            "not ready" in message
-            or "consistency check failed" in message
-        )
-    )
-
-
-def wait_schema_version_consistent(client, collection_name, timeout=60, poll_interval=0.2):
-    deadline = time.time() + timeout
-    last_consistent = None
-    last_total = None
-
-    while time.time() < deadline:
-        stats = client.get_collection_stats(collection_name=collection_name)
-        consistent = stats.get(SCHEMA_VERSION_CONSISTENT_KEY)
-        total = stats.get(SCHEMA_VERSION_TOTAL_KEY)
-
-        if consistent is None and total is None:
-            return
-        if consistent is not None and total is not None and int(consistent) == int(total):
-            return
-
-        last_consistent = consistent
-        last_total = total
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"schema version is not consistent for {collection_name}: "
-        f"{last_consistent}/{last_total} segments are consistent"
-    )
-
-
-def add_collection_field_with_schema_retry(
-    client,
-    collection_name,
-    field_name,
-    data_type,
-    timeout=120,
-    **kwargs,
-):
-    deadline = time.time() + timeout
-    last_error = None
-
-    while time.time() < deadline:
-        wait_schema_version_consistent(
-            client,
-            collection_name,
-            timeout=max(1, min(30, deadline - time.time())),
-        )
-        try:
-            return client.add_collection_field(
-                collection_name=collection_name,
-                field_name=field_name,
-                data_type=data_type,
-                **kwargs
-            )
-        except MilvusException as exc:
-            if not is_schema_version_not_ready(exc):
-                raise
-            last_error = exc
-            log.info(f"schema version not ready after adding fields, retrying: {exc}")
-            time.sleep(1)
-
-    raise AssertionError(
-        f"timed out adding field {field_name} to {collection_name}"
-    ) from last_error
 
 
 class TestRestoreBackup(TestcaseBase):
@@ -2107,11 +2032,10 @@ class TestRestoreBackup(TestcaseBase):
 
         added_field_names = []
         for field_name, data_type, kwargs in fields_to_add:
-            add_collection_field_with_schema_retry(
-                self.milvus_client,
-                name_origin,
-                field_name,
-                data_type,
+            self.milvus_client.add_collection_field(
+                collection_name=name_origin,
+                field_name=field_name,
+                data_type=data_type,
                 **kwargs
             )
             added_field_names.append(field_name)


### PR DESCRIPTION
## Summary

The CI helper that polls `schema_version_consistent_segments` before calling `add_collection_field` is both unnecessary and unsatisfiable on current `master-latest` Milvus images. It is the cause of the `test_milvus_restore_backup_with_add_field` failures and the `Backup and restore secondary` → "Prepare data on upstream" failure. Release images (`2.6-latest`) pass only because the stat does not exist there, so the poll short-circuits.

**It is unnecessary.** Milvus removed the proxy-side schema version consistency gate for schema-change DDLs (milvus-io/milvus#49733). Added fields are required to be nullable, and segcore fills them on older sealed segments with a virtual default/NULL column at load time, so schema-version skew across segments is tolerated by design. `add_collection_field` no longer rejects a collection whose segments lag behind.

**It is unsatisfiable.** The always-on backfill compaction policy was replaced by bump_schema_version compaction (milvus-io/milvus#48808), which defaults to disabled. In a small CI collection that never reaches the trigger threshold for mix or sort compaction, nothing advances a sealed segment's schema version, so `schema_version_consistent_segments` stays at `0/1` and the 60s poll always times out:

```
TimeoutError: schema version is not consistent for hello_milvus_added: 0/1 segments are consistent
```

## Changes

- Remove `wait_schema_version_consistent`, `add_collection_field_with_schema_retry`, and `is_schema_version_not_ready` from `example/prepare_data.py` and `tests/testcases/test_restore_backup.py`
- Call `client.add_collection_field` directly at both call sites

/kind improvement