### PR TITLE
restore: drop max_field_id property when creating collection

### DIFF
--- a/core/restore/coll_ddl_task.go
+++ b/core/restore/coll_ddl_task.go
@@ -21,6 +21,19 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/validate"
 )
 
+// maxFieldIDKey is a server-managed collection property that records the highest
+// field ID ever assigned, so that IDs are not reused after a field is dropped.
+// Milvus derives it from the schema when absent, and CreateCollection keeps
+// whichever value is larger, so replaying a backed-up value makes AddField
+// allocate IDs above the source's maximum instead of reproducing the source IDs.
+// The binlog directories are named after the source field IDs, so the import
+// then finds no data for the added fields and silently fills them with NULL.
+// Always drop it and let Milvus recompute it for the restored collection.
+//
+// Not defined in pkg/v2/common at the pinned Milvus version: the property only
+// exists on Milvus master (milvus-io/milvus#48988).
+const maxFieldIDKey = "max_field_id"
+
 type collDDLTask struct {
 	option       *Option
 	collOverride CollOverride
@@ -160,7 +173,10 @@ func (ddlt *collDDLTask) addFields(ctx context.Context, fields []*schemapb.Field
 // properties returns the properties of the collection.
 // If milvus support func runtime check, add disable_auto_function to properties to avoid error when create collection.
 func (ddlt *collDDLTask) properties() []*commonpb.KeyValuePair {
-	props := pbconv.BakKVToMilvusKV(ddlt.collBackup.GetSchema().GetProperties(), ddlt.option.SkipParams.CollectionProperties...)
+	skipKeys := make([]string, 0, len(ddlt.option.SkipParams.CollectionProperties)+1)
+	skipKeys = append(skipKeys, ddlt.option.SkipParams.CollectionProperties...)
+	skipKeys = append(skipKeys, maxFieldIDKey)
+	props := pbconv.BakKVToMilvusKV(ddlt.collBackup.GetSchema().GetProperties(), skipKeys...)
 
 	if len(ddlt.collBackup.GetSchema().GetFunctions()) == 0 {
 		ddlt.logger.Info("no functions, skip disable_auto_function")
@@ -239,7 +255,7 @@ func (ddlt *collDDLTask) createColl(ctx context.Context) error {
 		Functions:          functions,
 		Fields:             createFields,
 		EnableDynamicField: ddlt.collBackup.GetSchema().GetEnableDynamicField(),
-		Properties:         pbconv.BakKVToMilvusKV(ddlt.collBackup.GetSchema().GetProperties()),
+		Properties:         pbconv.BakKVToMilvusKV(ddlt.collBackup.GetSchema().GetProperties(), maxFieldIDKey),
 		StructArrayFields:  structArrayFields,
 	}
 	ddlt.logger.Info("create collection", zap.Any("schema", schema))

--- a/core/restore/coll_ddl_task_test.go
+++ b/core/restore/coll_ddl_task_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
@@ -183,6 +184,27 @@ func TestCollDDLTask_properties(t *testing.T) {
 		assert.Equal(t, common.DisableFuncRuntimeCheck, props[1].GetKey())
 		assert.Equal(t, "true", props[1].GetValue())
 	})
+
+	t.Run("DropMaxFieldID", func(t *testing.T) {
+		ddlt := newTestCollDDLTask()
+		ddlt.option.SkipParams.CollectionProperties = []string{"skipped"}
+		ddlt.collBackup = &backuppb.CollectionBackupInfo{
+			Schema: &backuppb.CollectionSchema{
+				Properties: []*backuppb.KeyValuePair{
+					{Key: "key", Value: "val"},
+					{Key: "skipped", Value: "val"},
+					{Key: maxFieldIDKey, Value: "110"},
+				},
+			},
+		}
+
+		props := ddlt.properties()
+		assert.Len(t, props, 1)
+		assert.Equal(t, "key", props[0].GetKey())
+
+		// the caller-configured skip list must not be mutated
+		assert.Equal(t, []string{"skipped"}, ddlt.option.SkipParams.CollectionProperties)
+	})
 }
 
 func TestCollDDLTask_restoreFuncRuntimeCheck(t *testing.T) {
@@ -311,6 +333,41 @@ func TestCollDDLTask_createColl(t *testing.T) {
 			assert.Equal(t, "true", coll.Properties[1].GetValue())
 		})
 		cli.EXPECT().HasFeature(milvus.FuncRuntimeCheck).Return(true).Once()
+		ct.grpcCli = cli
+		err := ct.createColl(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("DropMaxFieldID", func(t *testing.T) {
+		ct := newTestCollDDLTask()
+		ct.targetNS = namespace.New("db1", "coll1")
+		ct.collBackup = &backuppb.CollectionBackupInfo{
+			Schema: &backuppb.CollectionSchema{
+				Fields: []*backuppb.FieldSchema{{
+					FieldID:      common.StartOfUserFieldID,
+					Name:         "field",
+					DataType:     backuppb.DataType_Int64,
+					IsPrimaryKey: true},
+				},
+				Properties: []*backuppb.KeyValuePair{
+					{Key: "key", Value: "val"},
+					{Key: maxFieldIDKey, Value: "110"},
+				},
+			},
+		}
+
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().CreateCollection(mock.Anything, mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+			coll := args[1].(milvus.CreateCollectionInput)
+			// Milvus reads max_field_id from both the schema and the request
+			// properties, so it must be absent from both.
+			assert.NotContains(t, lo.Map(coll.Schema.GetProperties(), func(kv *commonpb.KeyValuePair, _ int) string {
+				return kv.GetKey()
+			}), maxFieldIDKey)
+			assert.NotContains(t, lo.Map(coll.Properties, func(kv *commonpb.KeyValuePair, _ int) string {
+				return kv.GetKey()
+			}), maxFieldIDKey)
+		})
 		ct.grpcCli = cli
 		err := ct.createColl(context.Background())
 		assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Restoring a collection whose fields were added via `add_collection_field` silently loses all data in those fields — they come back `NULL` for every row, with no error. Original fields round-trip correctly. This reproduces only against Milvus `master` images, which is why `master-latest` CI is red while `2.6-latest` passes.

**Root cause.** Milvus master records a server-managed `max_field_id` collection property so that field IDs are not reused after a field is dropped (milvus-io/milvus#48988). Restore replayed it verbatim into `CreateCollection` — in both `schema.Properties` and the request `Properties`, and Milvus reads it from both — and `updateMaxFieldIDProperty` keeps whichever value is larger.

For a source collection with fields `100-104`, `$meta` `105`, and added fields `106-110`, the backup carries `max_field_id=110`. On restore:

1. `CreateCollection` makes fields `100-104` + `$meta` `105`, whose real maximum is `105`, but persists the inherited `max_field_id=110`.
2. The replayed `AddField` calls compute `maxAssignedFieldIDFromSchema(schema) + 1` = `max(105, 110) + 1` → they allocate **`111-115`** instead of `106-110`.
3. The backed-up binlogs live in field-ID directories `106-110`. The import skips them because they are not in the target schema, and NULL-fills `111-115`, which are nullable and have no data. No error is raised.

Confirmed from CI logs, which show both ID sets on the same run:

```
fieldID:106..110  added_int64 … added_json   <- source collection
fieldID:111..115  added_int64 … added_json   <- restored collection
```

Milvus 2.6 has no `max_field_id` property, so `AddField` computes `105 + 1` = `106` there and the IDs line up.

## Changes

- Strip `max_field_id` from the properties passed to `CreateCollection`, both in the schema and in the request properties, and let Milvus recompute it from the restored schema
- Add unit tests covering both call sites, and assert the caller-configured `SkipParams.CollectionProperties` slice is not mutated

The secondary restore path is unaffected: it sends the full schema with explicit field IDs, so the property stays consistent with the schema there.

/kind improvement