### PR TITLE
refactor(config): clarify storage and transfer settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ The table below shows which Milvus versions can restore backups created from oth
 Milvus-backup provides command line and API server for usage.
 
 ### Configuration
-In order to use Milvus-Backup, access to Milvus proxy and Minio cluster is required. Configuration settings related to this access can be edited in [backup.yaml](configs/backup.yaml).
+To use Milvus Backup, it must be able to access the Milvus proxy, the storage used by Milvus, and the backup destination. Configure these endpoints in [backup.yaml](configs/backup.yaml).
 
 > [!NOTE]
 >
-> Please ensure that the configuration settings for Minio are accurate. There may be variations in the default value of Minio's configuration depending on how Milvus is deployed, either by docker-compose or k8s.
+> Ensure that `milvus.storage` matches the storage configuration of the Milvus deployment. Defaults can differ between Docker Compose, Kubernetes, and cloud deployments.
 > |field|docker-compose |helm|
 > |---|---|---|
 > |bucketName|a-bucket|milvus-bucket|
@@ -138,37 +138,34 @@ Below is a summary of the configurations supported in `backup.yaml`:
 |                   | `serverName `                   | Server name                                                                                                  | `localhost`             |
 |                   | `mtlsCertPath`                  | Path to your mtls certificate file                                                                           | `/path/to/certificate`  |
 |                   | `mtlsKeyPath `                  | Path to your mtls key file                                                                                   | `/path/to/key`          |
-| `minio`           | `storageType`                   | Storage type for Milvus (e.g., `local`, `minio`, `s3`, `aws`, `gcp`, `ali(aliyun)`, `azure`, `tc(tencent)`, `gcpnative`). Use `gcpnative` for the Google Cloud Platform provider.          | `minio`                 |
-|                   | `address`                       | MinIO/S3 address.                                                                                            | `localhost`             |
-|                   | `port`                          | MinIO/S3 port.                                                                                               | `9000`                  |
-|                   | `accessKeyID`                   | MinIO/S3 access key ID.                                                                                      | `minioadmin`            |
-|                   | `secretAccessKey`               | MinIO/S3 secret access key.                                                                                  | `minioadmin`            |
-|                   | `gcpCredentialJSON`             | Path to your GCP credential JSON key file. Used only for the "gcpnative" cloud provider.                     | `/path/to/json-key-file`       |
-|                   | `useSSL`                        | Whether to use SSL for MinIO/S3.                                                                             | `false`                 |
-|                   | `bucketName`                    | Bucket name in MinIO/S3.                                                                                     | `a-bucket`              |
-|                   | `rootPath`                      | Storage root path in MinIO/S3.                                                                               | `files`                 |
-| `minio (backup)`  | `backupStorageType`             | Backup storage type (e.g., `local`, `minio`, `s3`, `aws`, `gcp`, `ali(aliyun)`, `azure`, `tc(tencent)`, `gcpnative`). Use `gcpnative` for the Google Cloud Platform provider.                       | `minio`                 |
-|                   | `backupAddress`                 | Address of backup storagße.                                                                                   | `localhost`             |
-|                   | `backupPort`                    | Port of backup storage.                                                                                      | `9000`                  |
-|                   | `backupUseSSL`                  | Whether to use SSL for backup storage.                                                                       | `false`                 |
-|                   | `backupAccessKeyID`             | Backup storage access key ID.                                                                                | `minioadmin`            |
-|                   | `backupSecretAccessKey`         | Backup storage secret access key.                                                                            | `minioadmin`            |
-|                   | `backupGcpCredentialJSON`       | Path to your GCP credential JSON key file. Used only for the "gcpnative" cloud provider.                     | `/path/to/json-key-file`       |
-|                   | `backupBucketName`              | Bucket name for backups.                                                                                     | `a-bucket`              |
-|                   | `backupRootPath`                | Root path to store backup data.                                                                              | `backup`                |
-|                   | `crossStorage`                  | Enable cross-storage backups (e.g., MinIO to AWS S3).                                                        | `false`                 |
-| `backup`          | `maxSegmentGroupSize`           | Maximum segment group size for backups.                                                                      | `2G`                    |
-|                   | `parallelism.backupCollection`  | Collection-level parallelism for backup.                                                                     | `4`                     |
-|                   | `parallelism.copydata`          | Thread pool size for copying data.                                                                           | `128`                   |
-|                   | `parallelism.restoreCollection` | Collection-level parallelism for restore.                                                                    | `2`                     |
-|                   | `keepTempFiles`                 | Whether to keep temporary files during restore (for debugging).                                              | `false`                 |
+| `milvus.storage`  | `provider`                      | Provider used by Milvus: `local`, `minio`, `s3`, `aws`, `gcp`, `gcpnative`, `ali`, `azure`, `tc`, or `hwc`. | `minio`                 |
+|                   | `address`                       | Milvus storage endpoint address.                                                                             | `localhost`             |
+|                   | `port`                          | Milvus storage endpoint port.                                                                                | `9000`                  |
+|                   | `accessKeyID`                   | Milvus storage access key ID.                                                                                | `minioadmin`            |
+|                   | `secretAccessKey`               | Milvus storage secret access key.                                                                            | `minioadmin`            |
+|                   | `gcpCredentialJSON`             | Path to the GCP credential JSON key file for `gcpnative`.                                                    | `/path/to/json-key-file`|
+|                   | `useSSL`                        | Whether to use SSL.                                                                                          | `false`                 |
+|                   | `bucketName`                    | Bucket used by Milvus.                                                                                       | `a-bucket`              |
+|                   | `rootPath`                      | Storage root path used by Milvus.                                                                            | `files`                 |
+| `backup.storage`  | `provider`                      | Provider used to store backups.                                                                              | Inherits Milvus storage |
+|                   | `address`                       | Backup storage endpoint address.                                                                             | Inherits Milvus storage |
+|                   | `port`                          | Backup storage endpoint port.                                                                                | Inherits Milvus storage |
+|                   | `bucketName`                    | Bucket used to store backups.                                                                                | Inherits Milvus storage |
+|                   | `rootPath`                      | Root path used to store backups.                                                                             | Inherits Milvus storage |
+| `transfer`        | `mode`                          | `auto`, `direct` (storage COPY API), or `streaming` (through milvus-backup).                                 | `auto`                  |
+|                   | `concurrency`                   | Maximum number of objects transferred concurrently during backup, restore, check, or migrate.                | `128`                   |
+|                   | `multipartCopyThresholdMiB`     | Threshold above which multipart direct copy is used.                                                         | `500`                   |
+| `backup`          | `concurrency.collections`       | Maximum number of backup collection tasks executed concurrently.                                             | `4`                     |
+|                   | `concurrency.segments`          | Maximum number of backup segment tasks executed concurrently.                                                | `1024`                  |
 |                   | `gcPause.enable`                | Pause Milvus garbage collection during backup.                                                               | `true`                  |
-|                   | `gcPause.seconds`               | Duration to pause garbage collection (in seconds).                                                           | `7200`                  |
 |                   | `gcPause.address`               | Address for Milvus garbage collection API.                                                                   | `http://localhost:9091` |
+| `restore`         | `concurrency.collections`       | Maximum number of restore collection tasks executed concurrently.                                            | `2`                     |
+|                   | `concurrency.importJobs`        | Maximum number of Milvus import jobs submitted concurrently.                                                 | `768`                   |
+|                   | `keepTempFiles`                 | Keep temporary restore files for debugging.                                                                  | `false`                 |
 
 For more details, refer to the [backup.yaml](configs/backup.yaml) configuration file.
 
-### Advanced feature
+### Advanced features
 
 1. [Cross Storage Backup](docs/user_guide/cross_storage.md): Data is read from the source storage and written to a different storage through the Milvus-backup service. Such as, S3 -> local, S3 a -> S3 b. 
 
@@ -186,17 +183,20 @@ For more details, refer to the [backup.yaml](configs/backup.yaml) configuration 
 To back up Milvus data to an AWS S3 bucket, you need to configure the `backup.yaml` file with the following settings:
 
 ```yaml
-# Backup storage configs: Configure the storage where you want to save the backup data
-backupStorageType: "aws"                     # Specifies the storage type as AWS S3
-backupAddress: s3.{your-aws-region}.amazonaws.com  # Address of AWS S3 (replace {your-aws-region} with your bucket's region)
-backupPort: 443                              # Default port for AWS S3
-backupAccessKeyID: <your-access-key-id>      # Access key ID for your AWS S3
-backupSecretAccessKey: <your-secret-key>     # Secret access key for AWS S3
-backupGcpCredentialJSON: "/path/to/file"     # Path to your GCP credential JSON key file. Used only for the "gcpnative" cloud provider.
-backupBucketName: "your-bucket-name"         # Bucket name where the backups will be stored
-backupRootPath: "backups"                    # Root path inside the bucket to store backups
-backupUseSSL: true                           # Use SSL for secure connections (Required)
-crossStorage: "true"                         # Required for minio to S3 backups
+backup:
+  storage:
+    provider: "aws"
+    address: s3.{your-aws-region}.amazonaws.com
+    port: 443
+    accessKeyID: <your-access-key-id>
+    secretAccessKey: <your-secret-key>
+    bucketName: "your-bucket-name"
+    rootPath: "backups"
+    useSSL: true
+
+transfer:
+  mode: auto
+  concurrency: 128
 ```
 
 

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -42,10 +42,10 @@ func NewCmd(opt *root.Options) *cobra.Command {
 			grpc, err := milvus.NewGrpc(&params.Milvus)
 			cobra.CheckErr(err)
 
-			milvusStorage, err := storage.NewMilvusStorage(ctx, &params.Minio)
+			milvusStorage, err := storage.NewMilvusStorage(ctx, params)
 			cobra.CheckErr(err)
 
-			backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+			backupStorage, err := storage.NewBackupStorage(ctx, params)
 			cobra.CheckErr(err)
 
 			taskArgs := check.TaskArgs{

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -217,16 +217,16 @@ func (o *options) toOption(params *cfg.Config) (backup.Option, error) {
 }
 
 func (o *options) toArgs(params *cfg.Config) (backup.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return backup.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), &params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
 	if err != nil {
 		return backup.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	option, err := o.toOption(params)
 	if err != nil {
 		return backup.TaskArgs{}, err

--- a/cmd/del/delete.go
+++ b/cmd/del/delete.go
@@ -31,12 +31,12 @@ func (o *options) addFlags(cmd *cobra.Command) {
 }
 
 func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return fmt.Errorf("delete: create backup storage: %w", err)
 	}
 
-	task := del.NewTask(backupStorage, mpath.BackupDir(params.Minio.BackupRootPath.Val, o.name))
+	task := del.NewTask(backupStorage, mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.name))
 	if err := task.Execute(context.Background()); err != nil {
 		return fmt.Errorf("delete: execute task: %w", err)
 	}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -35,12 +35,12 @@ func (o *options) validate() error {
 func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
 	ctx := context.Background()
 
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return fmt.Errorf("create backup storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	backupInfo, err := meta.Read(ctx, backupStorage, backupDir)
 	if err != nil {
 		return fmt.Errorf("read backup meta: %w", err)

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -37,12 +37,12 @@ func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
 		return err
 	}
 
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return fmt.Errorf("cmd: create backup storage %w", err)
 	}
 
-	summaries, err := meta.List(ctx, backupStorage, params.Minio.BackupRootPath.Val)
+	summaries, err := meta.List(ctx, backupStorage, params.Backup.Storage.RootPath.Val)
 	if err != nil {
 		return fmt.Errorf("cmd: list backup %w", err)
 	}

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -263,16 +263,16 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 		return restore.TaskArgs{}, err
 	}
 
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), &params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)
@@ -292,7 +292,7 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 		Plan:          plan,
 		Option:        o.toOption(),
 		Params:        params,
-		BackupDir:     mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
+		BackupDir:     mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName),
 		BackupStorage: backupStorage,
 		MilvusStorage: milvusStorage,
 

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -43,12 +43,12 @@ func (o *secondaryOption) validate() error {
 }
 
 func (o *secondaryOption) toArgs(params *cfg.Config) (secondary.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return secondary.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
 	if err != nil {
 		return secondary.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)

--- a/configs/backup-azure.yaml
+++ b/configs/backup-azure.yaml
@@ -38,66 +38,51 @@ milvus:
   # Milvus replicate msg channel name, default is by-dev-replicate-msg
   rpcChannelName: "by-dev-replicate-msg"
 
-# Related configuration of minio, which is responsible for data persistence for Milvus.
-minio:
-  # Milvus storage configs, make them the same with milvus config
-  storageType: "azure" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent), gcpnative
-  # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials for authentication.
-  address: core.windows.net # Address of MinIO/S3
-  port: 443   # Port of MinIO/S3
-  region: "westus2"      # region of MinIO/S3
-  accessKeyID: ""  # accessKeyID of MinIO/S3
-  secretAccessKey: "" # MinIO/S3 encryption string
-  token: ""     # token of MinIO/S3
-  gcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  useSSL: true # Access to MinIO/S3 with SSL
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "milvus-data" # Milvus Bucket name in MinIO/S3, make it the same as your milvus instance
-  rootPath: "milvus/azure-instance" # Milvus storage root path in MinIO/S3, make it the same as your milvus instance
+  storage:
+    provider: "azure"
+    address: core.windows.net
+    port: 443
+    region: "westus2"
+    accessKeyID: ""
+    secretAccessKey: ""
+    token: ""
+    useSSL: true
+    useIAM: false
+    iamEndpoint: ""
+    bucketName: "milvus-data"
+    rootPath: "milvus/azure-instance"
 
-  # Backup storage configs, the storage you want to put the backup data
-  backupStorageType: "azure" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent)
-  backupAddress: core.windows.net # Address of MinIO/S3
-  backupRegion: "westus2"   # region of MinIO/S3
-  backupPort: 443   # Port of MinIO/S3
-  backupAccessKeyID: ""  # accessKeyID of MinIO/S3
-  backupSecretAccessKey: "" # MinIO/S3 encryption string
-  backupToken: ""       # token of MinIO/S3
-  backupGcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  backupBucketName: "milvus-data" # Bucket name to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupRootPath: "backup" # Rootpath to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupUseSSL: true # Access to MinIO/S3 with SSL
-
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported. 
-  # Set this option to true to enable data transfer through Milvus Backup.
-  # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
-  # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: false
-  
 backup:
-  parallelism:
-    # number of threads to copy data. reduce it if blocks your storage's network bandwidth
-    copydata: 128
+  storage:
+    provider: "azure"
+    address: core.windows.net
+    port: 443
+    region: "westus2"
+    accessKeyID: ""
+    secretAccessKey: ""
+    token: ""
+    useSSL: true
+    useIAM: false
+    iamEndpoint: ""
+    bucketName: "milvus-data"
+    rootPath: "backup"
 
-    # number of collections to backup in parallel.
-    backupCollection: 4
-    # number of segments to backup in parallel
-    backupSegment: 1024
+  concurrency:
+    collections: 4
+    segments: 1024
 
-    # Collection level parallelism to restore
-    restoreCollection: 2
-    # max number of import job to run in parallel,
-    # should be less than milvus's config dataCoord.import.maxImportJobNum
-    importJob: 768
-  
-  # keep temporary files during restore, only use to debug 
-  keepTempFiles: false
-  
-  # Pause GC during backup through Milvus Http API. 
+  # Pause GC during backup through Milvus Http API.
   gcPause:
     enable: true
     address: http://localhost:9091
-    
+
+restore:
+  concurrency:
+    collections: 2
+    importJobs: 768
+  keepTempFiles: false
+
+transfer:
+  mode: auto
+  concurrency: 128
+  multipartCopyThresholdMiB: 500

--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -39,70 +39,66 @@ milvus:
     endpoints: 127.0.0.1:2379 # you can set multiple endpoints, separated by comma, for example: "127.0.0.1:2379,127.0.0.1:2380,127.0.0.1:2381"
     rootPath: "by-dev"
 
-# Related configuration of minio, which is responsible for data persistence for Milvus.
-minio:
-  # Milvus storage configs, make them the same with milvus config
-  storageType: "minio" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent), gcpnative
-  # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials for authentication.
-  address: localhost # Address of MinIO/S3
-  port: 9000   # Port of MinIO/S3
-  region: ""      # region of MinIO/S3
-  accessKeyID: minioadmin  # accessKeyID of MinIO/S3
-  secretAccessKey: minioadmin # MinIO/S3 encryption string
-  token: ""     # token of MinIO/S3
-  gcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  useSSL: false # Access to MinIO/S3 with SSL
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "a-bucket" # Milvus Bucket name in MinIO/S3, make it the same as your milvus instance
-  rootPath: "files" # Milvus storage root path in MinIO/S3, make it the same as your milvus instance
+  # Storage used by Milvus. Keep these values aligned with the Milvus deployment.
+  storage:
+    provider: "minio" # local, minio, s3, aws, gcp, gcpnative, ali, azure, tc, hwc
+    address: localhost
+    port: 9000
+    region: ""
+    accessKeyID: minioadmin
+    secretAccessKey: minioadmin
+    token: ""
+    gcpCredentialJSON: "/path/to/json-key-file"
+    useSSL: false
+    useIAM: false
+    iamEndpoint: ""
+    bucketName: "a-bucket"
+    rootPath: "files"
 
-  # Backup storage configs, the storage you want to put the backup data
-  backupStorageType: "minio" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent)
-  backupAddress: localhost # Address of MinIO/S3
-  backupRegion: ""   # region of MinIO/S3
-  backupPort: 9000   # Port of MinIO/S3
-  backupAccessKeyID: minioadmin  # accessKeyID of MinIO/S3
-  backupSecretAccessKey: minioadmin # MinIO/S3 encryption string
-  backupToken: ""       # token of MinIO/S3
-  backupGcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  backupBucketName: "a-bucket" # Bucket name to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupRootPath: "backup" # Rootpath to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupUseSSL: false # Access to MinIO/S3 with SSL
-
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported.
-  # Set this option to true to enable data transfer through Milvus Backup.
-  # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
-  # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: false
-
-  # File size threshold (MiB) above which multipart copy is used for S3-compatible storage.
-  # Default is 500. GCP does not support multipart copy and will always use single copy.
-  multipartCopyThresholdMiB: 500
-  
 backup:
-  parallelism:
-    # number of threads to copy data. reduce it if blocks your storage's network bandwidth
-    copydata: 128
+  # Storage used to keep backup data. Omitted values inherit from milvus.storage.
+  storage:
+    provider: "minio"
+    address: localhost
+    port: 9000
+    region: ""
+    accessKeyID: minioadmin
+    secretAccessKey: minioadmin
+    token: ""
+    gcpCredentialJSON: "/path/to/json-key-file"
+    useSSL: false
+    useIAM: false
+    iamEndpoint: ""
+    bucketName: "a-bucket"
+    rootPath: "backup"
 
-    # number of collections to backup in parallel.
-    backupCollection: 4
-    # number of segments to backup in parallel
-    backupSegment: 1024
+  # Concurrency of backup task scheduling. This does not control object transfer concurrency.
+  concurrency:
+    collections: 4
+    segments: 1024
 
-    # Collection level parallelism to restore
-    restoreCollection: 2
-    # max number of import job to run in parallel,
-    # should be less than milvus's config dataCoord.import.maxImportJobNum
-    importJob: 768
-  
-  # keep temporary files during restore, only use to debug 
-  keepTempFiles: false
-  
-  # Pause GC during backup through Milvus Http API. 
+  # Pause GC during backup through Milvus Http API.
   gcPause:
     enable: true
     address: http://localhost:9091
-    
+
+restore:
+  # Concurrency of restore task scheduling and Milvus import jobs.
+  concurrency:
+    collections: 2
+    # Keep this below Milvus dataCoord.import.maxImportJobNum.
+    importJobs: 768
+
+  # Keep temporary files created during restore for debugging.
+  keepTempFiles: false
+
+# Shared object transfer policy for backup, restore, check, and migrate operations.
+transfer:
+  # auto: use direct COPY only when both endpoints are compatible
+  # direct: always use the storage provider's COPY API
+  # streaming: download and upload through the milvus-backup process
+  mode: auto
+  # Maximum number of objects copied concurrently. This is independent of task concurrency above.
+  concurrency: 128
+  # File size threshold (MiB) above which multipart direct copy is used.
+  multipartCopyThresholdMiB: 500

--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -30,7 +30,7 @@ type collDMLTask struct {
 	milvusStorage  storage.Client
 	milvusRootPath string
 
-	crossStorage bool
+	copyThroughProcess bool
 
 	backupStorage storage.Client
 	backupDir     string
@@ -58,7 +58,7 @@ func newCollDMLTask(ns namespace.NS, args collTaskArgs) *collDMLTask {
 		milvusStorage:  args.MilvusStorage,
 		milvusRootPath: args.MilvusRootPath,
 
-		crossStorage: args.CrossStorage,
+		copyThroughProcess: args.CopyThroughProcess,
 
 		backupStorage: args.BackupStorage,
 		backupDir:     args.BackupDir,
@@ -526,11 +526,11 @@ func (dmlt *collDMLTask) backupSegmentData(ctx context.Context, seg *backuppb.Se
 	attrs = append(attrs, insertAttrs...)
 	attrs = append(attrs, deltaAttrs...)
 	opt := storage.CopyObjectsOpt{
-		Src:          dmlt.milvusStorage,
-		Dest:         dmlt.backupStorage,
-		Attrs:        attrs,
-		CopyByServer: dmlt.crossStorage,
-		Sem:          dmlt.throttling.CopySem,
+		Src:                dmlt.milvusStorage,
+		Dest:               dmlt.backupStorage,
+		Attrs:              attrs,
+		CopyThroughProcess: dmlt.copyThroughProcess,
+		Sem:                dmlt.throttling.CopySem,
 		TraceFn: func(size int64, cost time.Duration) {
 			dmlt.taskMgr.UpdateBackupTask(dmlt.taskID, taskmgr.IncBackupCollCopiedSize(dmlt.ns, size, cost))
 		},

--- a/core/backup/coll_strategy.go
+++ b/core/backup/coll_strategy.go
@@ -45,11 +45,11 @@ type concurrencyThrottling struct {
 type collTaskArgs struct {
 	TaskID string
 
-	MilvusStorage  storage.Client
-	MilvusRootPath string
-	CrossStorage   bool
-	BackupStorage  storage.Client
-	BackupDir      string
+	MilvusStorage      storage.Client
+	MilvusRootPath     string
+	CopyThroughProcess bool
+	BackupStorage      storage.Client
+	BackupDir          string
 
 	Throttling concurrencyThrottling
 

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -69,7 +69,7 @@ type Task struct {
 	milvusStorage  storage.Client
 	milvusRootPath string
 
-	crossStorage bool
+	copyThroughProcess bool
 
 	backupStorage storage.Client
 	backupDir     string
@@ -107,10 +107,11 @@ func newGCCtrl(taskID string, pauseGC bool, grpc milvus.Grpc, manage milvus.Mana
 func NewTask(args TaskArgs) (*Task, error) {
 	logger := log.L().With(zap.String("task_id", args.TaskID))
 
-	crossStorage := args.Params.Minio.CrossStorage.Val
-	if args.BackupStorage.Config().Provider != args.MilvusStorage.Config().Provider {
-		crossStorage = true
-	}
+	copyThroughProcess := storage.CopyThroughProcess(
+		args.Params.Transfer.Mode.Val,
+		args.MilvusStorage,
+		args.BackupStorage,
+	)
 
 	mb := newMetaBuilder(args.TaskID, args.Option.BackupName)
 	err := args.TaskMgr.AddBackupTask(args.TaskID, args.Option.BackupName)
@@ -119,9 +120,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 	}
 
 	throttling := concurrencyThrottling{
-		CollSem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.BackupCollection.Val)),
-		SegSem:  semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.BackupSegment.Val)),
-		CopySem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.CopyData.Val)),
+		CollSem: semaphore.NewWeighted(int64(args.Params.Backup.Concurrency.Collections.Val)),
+		SegSem:  semaphore.NewWeighted(int64(args.Params.Backup.Concurrency.Segments.Val)),
+		CopySem: semaphore.NewWeighted(int64(args.Params.Transfer.Concurrency.Val)),
 	}
 
 	return &Task{
@@ -134,9 +135,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 		params: args.Params,
 
 		milvusStorage:  args.MilvusStorage,
-		milvusRootPath: args.Params.Minio.RootPath.Val,
+		milvusRootPath: args.Params.Milvus.Storage.RootPath.Val,
 
-		crossStorage: crossStorage,
+		copyThroughProcess: copyThroughProcess,
 
 		backupStorage: args.BackupStorage,
 		backupDir:     args.BackupDir,
@@ -391,18 +392,18 @@ func (t *Task) backupDatabase(ctx context.Context, dbNames []string) error {
 
 func (t *Task) newCollTaskArgs() collTaskArgs {
 	return collTaskArgs{
-		TaskID:         t.taskID,
-		MilvusStorage:  t.milvusStorage,
-		MilvusRootPath: t.milvusRootPath,
-		CrossStorage:   t.crossStorage,
-		BackupStorage:  t.backupStorage,
-		BackupDir:      t.backupDir,
-		Throttling:     t.throttling,
-		MetaBuilder:    t.metaBuilder,
-		TaskMgr:        t.taskMgr,
-		Grpc:           t.grpc,
-		Restful:        t.restful,
-		gcCtrl:         t.gcCtrl,
+		TaskID:             t.taskID,
+		MilvusStorage:      t.milvusStorage,
+		MilvusRootPath:     t.milvusRootPath,
+		CopyThroughProcess: t.copyThroughProcess,
+		BackupStorage:      t.backupStorage,
+		BackupDir:          t.backupDir,
+		Throttling:         t.throttling,
+		MetaBuilder:        t.metaBuilder,
+		TaskMgr:            t.taskMgr,
+		Grpc:               t.grpc,
+		Restful:            t.restful,
+		gcCtrl:             t.gcCtrl,
 	}
 }
 

--- a/core/check/task.go
+++ b/core/check/task.go
@@ -68,12 +68,11 @@ func (t *Task) writeResult(version string, milvusEmpty bool) error {
 	var buff []byte
 
 	buff = append(buff, []byte("\nMilvus version: "+version+"\n")...)
-
 	if milvusEmpty {
 		buff = append(buff, []byte("\n")...)
 		buff = append(buff, []byte("!!! Milvus root path is empty !!! \n")...)
 		buff = append(buff, []byte("If your Milvus instance is expected to have data,\n")...)
-		buff = append(buff, []byte("please check your minio configuration.\n")...)
+		buff = append(buff, []byte("please check your milvus.storage configuration.\n")...)
 		buff = append(buff, []byte("(address / bucket / rootPath).\n")...)
 	} else {
 		buff = append(buff, []byte("\nSuccess!\n")...)
@@ -88,7 +87,7 @@ func (t *Task) writeResult(version string, milvusEmpty bool) error {
 
 func (t *Task) checkMilvusStorage(ctx context.Context) (bool, error) {
 	t.logger.Info("check milvus storage")
-	files, _, err := storage.ListPrefixFlat(ctx, t.milvusStorage, mpath.MilvusRootDir(t.params.Minio.RootPath.Val), true)
+	files, _, err := storage.ListPrefixFlat(ctx, t.milvusStorage, mpath.MilvusRootDir(t.params.Milvus.Storage.RootPath.Val), true)
 	if err != nil {
 		return false, fmt.Errorf("check: list milvus root dir %w", err)
 	}
@@ -104,7 +103,7 @@ func (t *Task) checkMilvusStorage(ctx context.Context) (bool, error) {
 
 func (t *Task) checkBackupStorage(ctx context.Context) error {
 	t.logger.Info("check backup storage")
-	_, _, err := storage.ListPrefixFlat(ctx, t.backupStorage, mpath.BackupRootDir(t.params.Minio.BackupRootPath.Val), false)
+	_, _, err := storage.ListPrefixFlat(ctx, t.backupStorage, mpath.BackupRootDir(t.params.Backup.Storage.RootPath.Val), false)
 	if err != nil {
 		return fmt.Errorf("check: list backup root dir %w", err)
 	}
@@ -114,8 +113,8 @@ func (t *Task) checkBackupStorage(ctx context.Context) error {
 
 func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	t.logger.Info("check write and copy")
-	srcKey := path.Join(t.params.Minio.RootPath.Val, "milvus_backup_check_src_"+uuid.NewString())
-	destKey := path.Join(t.params.Minio.BackupRootPath.Val, "milvus_backup_check_dst_"+uuid.NewString())
+	srcKey := path.Join(t.params.Milvus.Storage.RootPath.Val, "milvus_backup_check_src_"+uuid.NewString())
+	destKey := path.Join(t.params.Backup.Storage.RootPath.Val, "milvus_backup_check_dst_"+uuid.NewString())
 	if err := storage.Write(ctx, t.milvusStorage, srcKey, []byte{1}); err != nil {
 		return fmt.Errorf("check: write to milvus storage %w", err)
 	}
@@ -128,18 +127,19 @@ func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	t.logger.Info("write to milvus storage success", zap.String("key", srcKey))
 
 	t.logger.Info("copy from milvus storage to backup storage")
-	crossStorage := t.params.Minio.CrossStorage.Val
-	if t.backupStorage.Config().Provider != t.milvusStorage.Config().Provider {
-		crossStorage = true
-	}
-	t.logger.Info("try to copy", zap.Bool("cross_storage", crossStorage), zap.String("dest_key", destKey))
+	copyThroughProcess := storage.CopyThroughProcess(
+		t.params.Transfer.Mode.Val,
+		t.milvusStorage,
+		t.backupStorage,
+	)
+	t.logger.Info("try to copy", zap.String("transfer_mode", t.params.Transfer.Mode.Val), zap.Bool("copy_through_process", copyThroughProcess), zap.String("dest_key", destKey))
 	opt := storage.CopyPrefixOpt{
-		Src:          t.milvusStorage,
-		Dest:         t.backupStorage,
-		SrcPrefix:    srcKey,
-		DestPrefix:   destKey,
-		Sem:          semaphore.NewWeighted(1),
-		CopyByServer: crossStorage,
+		Src:                t.milvusStorage,
+		Dest:               t.backupStorage,
+		SrcPrefix:          srcKey,
+		DestPrefix:         destKey,
+		Sem:                semaphore.NewWeighted(1),
+		CopyThroughProcess: copyThroughProcess,
 	}
 	task := storage.NewCopyPrefixTask(opt)
 	if err := task.Execute(ctx); err != nil {

--- a/core/migrate/task.go
+++ b/core/migrate/task.go
@@ -200,11 +200,11 @@ func NewTask(taskID, backupName, clusterID string, params *cfg.Config) (*Task, e
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("migrate: new backup storage %w", err)
 	}
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, backupName)
 
 	return &Task{
 		logger: logger,
@@ -220,7 +220,7 @@ func NewTask(taskID, backupName, clusterID string, params *cfg.Config) (*Task, e
 
 		// use taskID as volume prefix
 		volume:  newVolume(clusterID, taskID, cloudCli),
-		copySem: semaphore.NewWeighted(int64(params.Backup.Parallelism.CopyData.Val)),
+		copySem: semaphore.NewWeighted(int64(params.Transfer.Concurrency.Val)),
 	}, nil
 }
 
@@ -257,7 +257,7 @@ func (t *Task) copyToCloud(ctx context.Context) error {
 			t.taskMgr.UpdateMigrateTask(t.taskID, taskmgr.IncMigrateCopiedSize(size, cost))
 		},
 
-		CopyByServer: true,
+		CopyThroughProcess: true,
 	}
 
 	copyTask := storage.NewCopyPrefixTask(opt)

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -48,7 +48,7 @@ type collTask struct {
 
 	targetNS namespace.NS
 
-	crossStorage  bool
+	transferMode  string
 	keepTempFiles bool
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
@@ -89,7 +89,7 @@ type collTaskArgs struct {
 
 	backupDir     string
 	keepTempFiles bool
-	crossStorage  bool
+	transferMode  string
 
 	backupStorage storage.Client
 	milvusStorage storage.Client
@@ -130,7 +130,7 @@ func newCollTask(args collTaskArgs) *collTask {
 		copySem:       args.copySem,
 		bulkInsertSem: args.bulkInsertSem,
 
-		crossStorage:  args.crossStorage,
+		transferMode:  args.transferMode,
 		keepTempFiles: args.keepTempFiles,
 		backupDir:     args.backupDir,
 
@@ -315,12 +315,12 @@ func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix s
 	ct.logger.Info("milvus and backup store in different bucket, copy the data first", zap.String("temp_dir", tempDir))
 	dest := path.Join(tempDir, strings.Replace(srcPrefix, ct.backupDir, "", 1)) + "/"
 	opt := storage.CopyPrefixOpt{
-		Sem:          ct.copySem,
-		Src:          ct.backupStorage,
-		Dest:         ct.milvusStorage,
-		SrcPrefix:    srcPrefix,
-		DestPrefix:   dest,
-		CopyByServer: true,
+		Sem:                ct.copySem,
+		Src:                ct.backupStorage,
+		Dest:               ct.milvusStorage,
+		SrcPrefix:          srcPrefix,
+		DestPrefix:         dest,
+		CopyThroughProcess: storage.CopyThroughProcess(ct.transferMode, ct.backupStorage, ct.milvusStorage),
 	}
 
 	ct.logger.Info("copy temporary restore file", zap.String("src", srcPrefix), zap.String("dest", dest))
@@ -344,9 +344,9 @@ func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix s
 
 func (ct *collTask) copyAndRewriteDir(ctx context.Context, b batch) (batch, error) {
 	isSameBucket := ct.milvusStorage.Config().Bucket == ct.backupStorage.Config().Bucket
-	isSameStorage := ct.backupStorage.Config().Provider == ct.milvusStorage.Config().Provider
-	// if milvus bucket and backup bucket are not the same, should copy the data first
-	if isSameBucket && isSameStorage && !ct.crossStorage {
+	isSameBackend := storage.SameBackend(ct.backupStorage.Config(), ct.milvusStorage.Config())
+	// Data already in the Milvus bucket can be imported in place.
+	if isSameBucket && isSameBackend {
 		ct.logger.Info("milvus and backup store in the same bucket, no need to copy the data")
 		return b, nil
 	}

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -244,7 +244,7 @@ func (t *Task) runCollTasks(ctx context.Context) error {
 	loadArgs := t.loadTaskArgs()
 
 	g, subCtx := errgroup.WithContext(ctx)
-	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
+	g.SetLimit(t.args.Params.Restore.Concurrency.Collections.Val)
 	for _, coll := range t.args.Backup.GetCollectionBackups() {
 		g.Go(func() error {
 			return t.runCollTask(subCtx, dbNameBackup[coll.GetDbName()], coll, ddlArgs, dmlArgs, loadArgs)

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -167,8 +167,8 @@ func NewTask(args TaskArgs) (*Task, error) {
 	return &Task{
 		args: args,
 
-		copySem:       semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.CopyData.Val)),
-		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.ImportJob.Val)),
+		copySem:       semaphore.NewWeighted(int64(args.Params.Transfer.Concurrency.Val)),
+		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Restore.Concurrency.ImportJobs.Val)),
 
 		logger: logger,
 	}, nil
@@ -267,8 +267,8 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 			collBackup:    collBackup,
 			option:        t.args.Option,
 			collOverride:  t.args.Plan.CollOverrides[targetNS.String()],
-			crossStorage:  t.args.Params.Minio.CrossStorage.Val,
-			keepTempFiles: t.args.Params.Backup.KeepTempFiles.Val,
+			transferMode:  t.args.Params.Transfer.Mode.Val,
+			keepTempFiles: t.args.Params.Restore.KeepTempFiles.Val,
 			backupDir:     t.args.BackupDir,
 			backupStorage: t.args.BackupStorage,
 			milvusStorage: t.args.MilvusStorage,
@@ -509,7 +509,7 @@ func (t *Task) runCollTasks(ctx context.Context, collTasks []*collTask) error {
 	t.logger.Info("start restore collection")
 
 	g, subCtx := errgroup.WithContext(ctx)
-	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
+	g.SetLimit(t.args.Params.Restore.Concurrency.Collections.Val)
 	for _, collTask := range collTasks {
 		g.Go(func() error {
 			if err := collTask.Execute(subCtx); err != nil {

--- a/core/server/check.go
+++ b/core/server/check.go
@@ -28,12 +28,12 @@ func (s *Server) handleCheck(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &s.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, s.params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	backupStorage, err := storage.NewBackupStorage(ctx, &s.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, s.params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -71,13 +71,13 @@ func (h *createBackupHandler) complete() {
 }
 
 func (h *createBackupHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return err
 	}
 	h.backupStorage = backupStorage
 
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &h.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (h *createBackupHandler) toArgs() (backup.TaskArgs, error) {
 		return backup.TaskArgs{}, fmt.Errorf("server: build option: %w", err)
 	}
 
-	backupRoot := h.params.Minio.BackupRootPath.Val
+	backupRoot := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetBackupRootPath() != "" {
 		backupRoot = h.request.GetBackupRootPath()
 		log.Info("use backup root from request", zap.String("backup_root", backupRoot))

--- a/core/server/del.go
+++ b/core/server/del.go
@@ -67,7 +67,7 @@ func (h *delHandler) validate() error {
 }
 
 func (h *delHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create backup storage: %w", err)
 	}
@@ -93,7 +93,7 @@ func (h *delHandler) run(ctx context.Context) *backuppb.DeleteBackupResponse {
 		return resp
 	}
 
-	task := del.NewTask(h.backupStorage, mpath.BackupDir(h.params.Minio.BackupRootPath.Val, h.req.GetBackupName()))
+	task := del.NewTask(h.backupStorage, mpath.BackupDir(h.params.Backup.Storage.RootPath.Val, h.req.GetBackupName()))
 	if err := task.Execute(ctx); err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()

--- a/core/server/get_backup.go
+++ b/core/server/get_backup.go
@@ -76,7 +76,7 @@ func (h *getBackupHandler) validate() error {
 }
 
 func (h *getBackupHandler) initClient(ctx context.Context) error {
-	cli, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	cli, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: init backup storage client %w", err)
 	}
@@ -137,7 +137,7 @@ func (h *getBackupHandler) get(ctx context.Context) *backuppb.BackupInfoResponse
 
 func (h *getBackupHandler) readFromStorage(ctx context.Context, backupName string) (*backuppb.BackupInfo, int64, error) {
 	// get backup meta from storage
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetPath() != "" {
 		backupRootPath = h.request.GetPath()
 	}

--- a/core/server/list.go
+++ b/core/server/list.go
@@ -31,7 +31,7 @@ func (s *Server) handleListBackups(c *gin.Context) {
 		return
 	}
 
-	backupStorage, err := storage.NewBackupStorage(c.Request.Context(), &s.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(c.Request.Context(), s.params)
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
@@ -39,7 +39,7 @@ func (s *Server) handleListBackups(c *gin.Context) {
 		return
 	}
 
-	summaries, err := meta.List(c.Request.Context(), backupStorage, s.params.Minio.BackupRootPath.Val)
+	summaries, err := meta.List(c.Request.Context(), backupStorage, s.params.Backup.Storage.RootPath.Val)
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -133,7 +133,10 @@ func (h *restoreHandler) complete() {
 }
 
 func (h *restoreHandler) initClient(ctx context.Context) error {
-	backupCfg := storage.BackupStorageConfig(&h.params.Minio)
+	backupCfg := storage.BuildConfig(
+		&h.params.Backup.Storage,
+		h.params.Transfer.MultipartCopyThresholdMiB.Val,
+	)
 	if h.request.GetBucketName() != "" {
 		log.Info("use bucket name from request", zap.String("bucketName", h.request.GetBucketName()))
 		backupCfg.Bucket = h.request.GetBucketName()
@@ -146,13 +149,13 @@ func (h *restoreHandler) initClient(ctx context.Context) error {
 		return fmt.Errorf("server: create backup bucket: %w", err)
 	}
 
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetPath() != "" {
 		log.Info("use path from request", zap.String("path", h.request.GetPath()))
 		backupRootPath = h.request.GetPath()
 	}
 
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &h.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create milvus storage: %w", err)
 	}

--- a/core/server/restore_secondary.go
+++ b/core/server/restore_secondary.go
@@ -122,12 +122,12 @@ func (h *restoreSecondaryHandler) run(ctx context.Context) *backuppb.RestoreBack
 }
 
 func (h *restoreSecondaryHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create backup storage: %w", err)
 	}
 
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if len(h.request.GetPath()) != 0 {
 		backupRootPath = h.request.GetPath()
 	}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,11 +46,11 @@ This error usually means the target Milvus cannot read the restored binlog files
 
 **Why does this happen?**
 
-During restore, milvus-backup copies backup data into the bucket specified by `minio.bucketName` in `backup.yaml`, then asks Milvus to import from there via BulkInsert. If that bucket is not the one the target Milvus is actually using, Milvus finds no files and returns `no binlog to import`.
+During restore, milvus-backup copies backup data into the bucket specified by `milvus.storage.bucketName` in `backup.yaml`, then asks Milvus to import from there via BulkInsert. If that bucket is not the one the target Milvus is actually using, Milvus finds no files and returns `no binlog to import`.
 
 **How to fix it?**
 
-Run `./milvus-backup check config` to print the resolved configuration, and make sure `minio.bucketName` matches the bucket that the **target Milvus** is actually using. Run `./milvus-backup check` to verify connectivity.
+Run `./milvus-backup check config` to print the resolved configuration, and make sure `milvus.storage.bucketName` matches the bucket that the **target Milvus** is actually using. Run `./milvus-backup check` to verify connectivity.
 
 **Related issues:** [#1026](https://github.com/zilliztech/milvus-backup/issues/1026), [#1006](https://github.com/zilliztech/milvus-backup/issues/1006), [#923](https://github.com/zilliztech/milvus-backup/issues/923), [#895](https://github.com/zilliztech/milvus-backup/issues/895)
 
@@ -72,7 +72,7 @@ Upgrade the **target** Milvus to **v2.6.12 or newer**. The fix ([milvus-io/milvu
 
 ### Backup fails with `segment xxx has no insert logs`
 
-This error means milvus-backup cannot list any binlog files for the segment under the configured object storage path. It almost always indicates that the `minio` section in `backup.yaml` does not match the storage the source Milvus is actually using.
+This error means milvus-backup cannot list any binlog files for the segment under the configured object storage path. It almost always indicates that the `milvus.storage` section in `backup.yaml` does not match the storage the source Milvus is actually using.
 
 **How to fix it?**
 
@@ -88,6 +88,6 @@ If the output contains:
 !!! Milvus root path is empty !!!
 ```
 
-then at least one of `minio.address` / `minio.bucketName` / `minio.rootPath` in `backup.yaml` disagrees with the source Milvus configuration. `rootPath` is the most frequent culprit — an empty string, `files`, and `/files` all behave differently. Align each field with the source Milvus config and retry.
+then at least one of `milvus.storage.address` / `milvus.storage.bucketName` / `milvus.storage.rootPath` in `backup.yaml` disagrees with the source Milvus configuration. `rootPath` is the most frequent culprit — an empty string, `files`, and `/files` all behave differently. Align each field with the source Milvus config and retry.
 
 **Related issues:** [#1033](https://github.com/zilliztech/milvus-backup/issues/1033), [#441](https://github.com/zilliztech/milvus-backup/issues/441), [#183](https://github.com/zilliztech/milvus-backup/issues/183), [#176](https://github.com/zilliztech/milvus-backup/issues/176)

--- a/docs/user_guide/cross_storage.md
+++ b/docs/user_guide/cross_storage.md
@@ -1,112 +1,100 @@
-# Cross storage backup & restore
+# Storage transfer modes
 
-Previously, Milvus-backup utilized the Copy API of the storage client to back up data.
-This limited the backup capability to the same storage type as the Milvus cluster.
-However, there's a significant demand for cross-storage backups—for instance,
-backup data from Minio to a local disk or backup from in-house storage to cloud storage.
+Milvus Backup can move objects in two different ways:
 
-Starting from version v0.4.21, Milvus-backup now supports cross-storage backups.
-In this process, data is read from the source storage and written to the target storage through the Milvus-backup service.
+- `direct`: call the destination storage provider's native COPY API. This avoids sending object data through the Milvus Backup process, but requires both storage configurations to refer to a compatible backend.
+- `streaming`: download objects from the source and upload them to the destination through the Milvus Backup process. Use this for different providers or different service endpoints.
+- `auto` (default): use direct copy only when the source and destination have the same provider and endpoint; otherwise use streaming.
 
-This feature is currently in Beta. `azure` is not supported. Not all storage types are fully tested.
+Configure the policy with `transfer.mode`. The legacy `minio.crossStorage` key remains supported: `true` maps to `streaming`, while `false` maps to `auto`.
 
-## Usage
+Run `./milvus-backup check` after changing storage settings to verify that the selected transfer path works.
 
-To enable cross-storage backup, you only need to adjust the configurations in backup.yaml.
-
-You can use `./milvus-backup check` first to see if the cross copy is working.
-
-For example
-
-*Back up data from Minio to a local disk*:
+## MinIO to a local directory
 
 ```yaml
-# Related configuration of minio, which is responsible for data persistence for Milvus.
-minio:
-  storageType: "minio"
-  address: localhost
-  port: 9000
-  accessKeyID: minioadmin
-  secretAccessKey: minioadmin
-  bucketName: "a-bucket"
-  rootPath: "files"
+milvus:
+  storage:
+    provider: minio
+    address: localhost
+    port: 9000
+    accessKeyID: minioadmin
+    secretAccessKey: minioadmin
+    bucketName: a-bucket
+    rootPath: files
 
-  backupStorageType: "local"
-  backupRootPath: "/root/backup/"
+backup:
+  storage:
+    provider: local
+    rootPath: /root/backup/
+
+transfer:
+  mode: auto
 ```
 
-*Backup from Minio to S3*
+Because the providers differ, `auto` streams data through Milvus Backup.
+
+## MinIO to S3
 
 ```yaml
-minio:
-  storageType: "minio"
-  address: localhost
-  port: 9000
-  accessKeyID: minioadmin
-  secretAccessKey: minioadmin
-  useSSL: false
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "a-bucket"
-  rootPath: "files"
+milvus:
+  storage:
+    provider: minio
+    address: localhost
+    port: 9000
+    accessKeyID: minioadmin
+    secretAccessKey: minioadmin
+    bucketName: a-bucket
+    rootPath: files
 
-  backupStorageType: "s3"
-  backupAddress: s3Address
-  backupPort: 443
-  backupAccessKeyID: s3AccessKey
-  backupSecretAccessKey: s3SecretAccessKey
-  backupBucketName: "s3-bucket"
-  backupRootPath: "s3-backup-path"
+backup:
+  storage:
+    provider: s3
+    address: s3.example.com
+    port: 443
+    accessKeyID: s3AccessKey
+    secretAccessKey: s3SecretAccessKey
+    bucketName: s3-bucket
+    rootPath: s3-backup-path
+    useSSL: true
+
+transfer:
+  mode: auto
 ```
 
-*Backup from Minio A to Minio B*
+## MinIO service A to MinIO service B
 
-If the two storage locations are of the same type but belong to different services,
-you need to add an additional configuration crossStorage=true to explicitly indicate that it is a cross-storage backup or restore operation.
 ```yaml
-minio:
-  storageType: "minio"
-  address: addressA
-  port: 9000
-  accessKeyID: userA
-  secretAccessKey: passwdB
-  useSSL: false
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "a-bucket"
-  rootPath: "files"
+milvus:
+  storage:
+    provider: minio
+    address: minio-a.example.com
+    port: 9000
+    accessKeyID: userA
+    secretAccessKey: passwordA
+    bucketName: a-bucket
+    rootPath: files
 
-  backupStorageType: "minio"
-  backupAddress: addressB
-  backupPort: 9000
-  backupAccessKeyID: userB
-  backupSecretAccessKey: passwdB
-  backupBucketName: "b-bucket"
-  backupRootPath: "backup"
+backup:
+  storage:
+    provider: minio
+    address: minio-b.example.com
+    port: 9000
+    accessKeyID: userB
+    secretAccessKey: passwordB
+    bucketName: b-bucket
+    rootPath: backup
 
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported. 
-  # Set this option to true to enable data transfer through Milvus Backup.
-  # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
-  # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: "true"
+transfer:
+  mode: auto
 ```
 
-## FAQ
+Although both endpoints use MinIO, their addresses differ, so `auto` selects streaming. Set `mode: direct` only when the destination storage service can perform a native COPY from the configured source.
 
-Q: 
-```
-What is the meaning of the option `crossStorage`. 
+## Choosing a mode
 
-Even if the storageType is the same, does it mean we need to set crossStorage to true when minio.address and backupaddress are different? 
-```
+Use `auto` unless you have a specific reason to override it:
 
-A:
-```
-The crossStorage option determines how data is transferred:
-
-When set to True, data is transferred via read and write operations managed by the milvus-backup process.
-
-When set to False, data is directly copied using the storage system’s COPY API, bypassing the milvus-backup process.
-
-Use crossStorage based on whether the two addresses are accessible to each other through the COPY API.
-```
+- Choose `direct` to require the storage COPY API. The operation fails rather than silently switching to streaming if direct copy is not possible.
+- Choose `streaming` when storage-native COPY is unavailable, credentials are isolated, or traffic must pass through the Milvus Backup host.
+- Choose `auto` for safe endpoint-aware selection.

--- a/docs/user_guide/env_variables.md
+++ b/docs/user_guide/env_variables.md
@@ -21,8 +21,11 @@ $ ./milvus-backup server
 > For the latest list of supported environment variables, refer to `internal/cfg/cfg.go` (search for `EnvKeys`) in the source code.
 
 - [Milvus Connection](#milvus-connection)
-- [MinIO (Object Storage)](#minio-object-storage)
+- [Milvus storage](#milvus-storage)
+- [Backup storage](#backup-storage)
+- [Transfer](#transfer)
 - [Backup](#backup)
+- [Restore](#restore)
 
 ### Milvus Connection
 
@@ -39,47 +42,67 @@ $ ./milvus-backup server
 | milvus.mtlsKeyPath   | MILVUS_MTLS_KEY_PATH| Mutual TLS key path                         |
 | milvus.rpcChannelName| MILVUS_RPC_CHANNEL_NAME | Replicate msg channel name               |
 
-### MinIO (Object Storage)
+### Milvus storage
 
-| Config Key                  | Env Variable          | Description                                  |
-|-----------------------------|-----------------------|----------------------------------------------|
-| minio.address               | MINIO_ADDRESS         | MinIO server address                         |
-| minio.port                  | MINIO_PORT            | MinIO server port                            |
-| minio.region                | MINIO_REGION          | Region                                       |
-| minio.accessKeyID           | MINIO_ACCESS_KEY      | MinIO access key ID                          |
-| minio.secretAccessKey       | MINIO_SECRET_KEY      | MinIO secret access key                      |
-| minio.token                 | MINIO_TOKEN           | Session token                                |
-| minio.rootPath              | MINIO_ROOT_PATH       | Root path                                    |
-| minio.useSSL                | MINIO_USE_SSL         | Use SSL for MinIO                            |
-| minio.useIAM                | MINIO_USE_IAM         | Use IAM credentials                          |
-| minio.iamEndpoint           | MINIO_IAM_ENDPOINT    | IAM endpoint                                 |
-| minio.bucketName            | MINIO_BUCKET_NAME     | MinIO bucket name                            |
-| minio.gcpCredentialJSON     | GCP_KEY_JSON          | Path to GCP credentials JSON for MinIO       |
+| Config Key                         | Env Variable                       | Description                     |
+|------------------------------------|------------------------------------|---------------------------------|
+| milvus.storage.provider            | MILVUS_STORAGE_PROVIDER            | Storage provider                |
+| milvus.storage.address             | MILVUS_STORAGE_ADDRESS             | Storage endpoint address        |
+| milvus.storage.port                | MILVUS_STORAGE_PORT                | Storage endpoint port           |
+| milvus.storage.region              | MILVUS_STORAGE_REGION              | Region                          |
+| milvus.storage.accessKeyID         | MILVUS_STORAGE_ACCESS_KEY          | Access key ID                   |
+| milvus.storage.secretAccessKey     | MILVUS_STORAGE_SECRET_KEY          | Secret access key               |
+| milvus.storage.token               | MILVUS_STORAGE_TOKEN               | Session token                   |
+| milvus.storage.rootPath            | MILVUS_STORAGE_ROOT_PATH           | Root path                       |
+| milvus.storage.useSSL              | MILVUS_STORAGE_USE_SSL             | Use SSL                         |
+| milvus.storage.useIAM              | MILVUS_STORAGE_USE_IAM             | Use IAM credentials             |
+| milvus.storage.iamEndpoint         | MILVUS_STORAGE_IAM_ENDPOINT        | IAM endpoint                    |
+| milvus.storage.bucketName          | MILVUS_STORAGE_BUCKET_NAME         | Bucket name                     |
+| milvus.storage.gcpCredentialJSON   | MILVUS_STORAGE_GCP_KEY_JSON        | GCP credentials JSON            |
 
-#### Backup-specific MinIO Variables
+### Backup storage
 
-| Config Key                        | Env Variable                  | Description                                  |
-|-----------------------------------|-------------------------------|----------------------------------------------|
-| minio.backupBucketName            | MINIO_BACKUP_BUCKET_NAME      | Backup bucket name                           |
-| minio.backupAddress               | MINIO_BACKUP_ADDRESS          | Backup MinIO server address                  |
-| minio.backupRegion                | MINIO_BACKUP_REGION           | Backup region                                |
-| minio.backupPort                  | MINIO_BACKUP_PORT             | Backup MinIO server port                     |
-| minio.backupAccessKeyID           | MINIO_BACKUP_ACCESS_KEY       | Backup MinIO access key ID                   |
-| minio.backupSecretAccessKey       | MINIO_BACKUP_SECRET_KEY       | Backup MinIO secret access key               |
-| minio.backupToken                 | MINIO_BACKUP_TOKEN            | Backup session token                         |
-| minio.backupRootPath              | MINIO_BACKUP_ROOT_PATH        | Backup root path                             |
-| minio.backupUseSSL                | MINIO_BACKUP_USE_SSL          | Use SSL for backup MinIO                     |
-| minio.backupUseIAM                | MINIO_BACKUP_USE_IAM          | Use IAM for backup storage                   |
-| minio.backupIamEndpoint           | MINIO_BACKUP_IAM_ENDPOINT     | Backup IAM endpoint                          |
-| minio.backupGcpCredentialJSON     | BACKUP_GCP_KEY_JSON           | Path to GCP credentials JSON for backup      |
+| Config Key                                | Env Variable                                | Description                              |
+|-------------------------------------------|---------------------------------------------|------------------------------------------|
+| backup.storage.provider                   | BACKUP_STORAGE_PROVIDER                     | Backup storage provider                  |
+| backup.storage.address                    | BACKUP_STORAGE_ADDRESS                      | Backup storage endpoint address          |
+| backup.storage.region                     | BACKUP_STORAGE_REGION                       | Backup storage region                    |
+| backup.storage.port                       | BACKUP_STORAGE_PORT                         | Backup storage endpoint port             |
+| backup.storage.accessKeyID                | BACKUP_STORAGE_ACCESS_KEY                   | Backup storage access key ID             |
+| backup.storage.secretAccessKey            | BACKUP_STORAGE_SECRET_KEY                   | Backup storage secret access key         |
+| backup.storage.token                      | BACKUP_STORAGE_TOKEN                        | Backup storage session token             |
+| backup.storage.rootPath                   | BACKUP_STORAGE_ROOT_PATH                    | Backup root path                         |
+| backup.storage.useSSL                     | BACKUP_STORAGE_USE_SSL                      | Use SSL                                  |
+| backup.storage.useIAM                     | BACKUP_STORAGE_USE_IAM                      | Use IAM                                  |
+| backup.storage.iamEndpoint                | BACKUP_STORAGE_IAM_ENDPOINT                 | IAM endpoint                             |
+| backup.storage.bucketName                 | BACKUP_STORAGE_BUCKET_NAME                  | Backup bucket name                       |
+| backup.storage.gcpCredentialJSON          | BACKUP_STORAGE_GCP_KEY_JSON                 | GCP credentials JSON                     |
+
+The historical `MINIO_*`, `MINIO_BACKUP_*`, `GCP_KEY_JSON`, and `BACKUP_GCP_KEY_JSON` variables remain supported as compatibility aliases. The new variables take precedence when both forms are set.
+
+### Transfer
+
+| Config Key                        | Env Variable                         | Description                                      |
+|-----------------------------------|--------------------------------------|--------------------------------------------------|
+| transfer.mode                     | TRANSFER_MODE                        | `auto`, `direct`, or `streaming`                 |
+| transfer.concurrency              | TRANSFER_CONCURRENCY                 | Maximum concurrently transferred objects         |
+| transfer.multipartCopyThresholdMiB| TRANSFER_MULTIPART_COPY_THRESHOLD_MIB| Multipart direct-copy threshold in MiB           |
 
 ### Backup
 
-| Config Key                  | Env Variable                  | Description                                   |
-|-----------------------------|-------------------------------|-----------------------------------------------|
-| backup.parallelism.backupCollection | BACKUP_PARALLELISM_BACKUP_COLLECTION | Backup collection parallelism         |
-| backup.parallelism.copydata | BACKUP_PARALLELISM_COPYDATA   | Copy data parallelism                         |
-| backup.parallelism.restoreCollection | BACKUP_PARALLELISM_RESTORE_COLLECTION | Restore collection parallelism     |
-| backup.keepTempFiles        | BACKUP_KEEP_TEMP_FILES         | Keep temporary files after backup             |
-| backup.gcPause.enable       | BACKUP_GC_PAUSE_ENABLE         | Pause GC during backup                        |
-| backup.gcPause.address      | BACKUP_GC_PAUSE_ADDRESS        | GC pause service address                      |
+| Config Key                     | Env Variable                    | Description                                   |
+|--------------------------------|---------------------------------|-----------------------------------------------|
+| backup.concurrency.collections | BACKUP_CONCURRENCY_COLLECTIONS  | Concurrent backup collection tasks            |
+| backup.concurrency.segments    | BACKUP_CONCURRENCY_SEGMENTS     | Concurrent backup segment tasks               |
+| backup.gcPause.enable          | BACKUP_GC_PAUSE_ENABLE          | Pause GC during backup                        |
+| backup.gcPause.address         | BACKUP_GC_PAUSE_ADDRESS         | GC pause service address                      |
+
+### Restore
+
+| Config Key                     | Env Variable                    | Description                                   |
+|--------------------------------|---------------------------------|-----------------------------------------------|
+| restore.concurrency.collections| RESTORE_CONCURRENCY_COLLECTIONS | Concurrent restore collection tasks           |
+| restore.concurrency.importJobs | RESTORE_CONCURRENCY_IMPORT_JOBS | Concurrent Milvus import jobs                 |
+| restore.keepTempFiles          | RESTORE_KEEP_TEMP_FILES         | Keep temporary restore files                  |
+
+The historical `BACKUP_PARALLELISM_*` and `BACKUP_KEEP_TEMP_FILES` variables remain supported as compatibility aliases.

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -23,27 +23,33 @@ func resolve(s *source, rs ...Resolver) error {
 }
 
 type Config struct {
-	Log    LogConfig
-	HTTP   HTTPConfig
-	Cloud  CloudConfig
-	Milvus MilvusConfig
-	Minio  MinioConfig
-	Backup BackupConfig
+	Log      LogConfig
+	HTTP     HTTPConfig
+	Cloud    CloudConfig
+	Milvus   MilvusConfig
+	Transfer TransferConfig
+	Backup   BackupConfig
+	Restore  RestoreConfig
 }
 
 func New() *Config {
 	return &Config{
-		Log:    newLogConfig(),
-		HTTP:   newHTTPConfig(),
-		Cloud:  newCloudConfig(),
-		Milvus: newMilvusConfig(),
-		Minio:  newMinioConfig(),
-		Backup: newBackupConfig(),
+		Log:      newLogConfig(),
+		HTTP:     newHTTPConfig(),
+		Cloud:    newCloudConfig(),
+		Milvus:   newMilvusConfig(),
+		Transfer: newTransferConfig(),
+		Backup:   newBackupConfig(),
+		Restore:  newRestoreConfig(),
 	}
 }
 
 func (c *Config) Resolve(s *source) error {
-	return resolve(s, &c.Log, &c.HTTP, &c.Cloud, &c.Milvus, &c.Minio, &c.Backup)
+	if err := resolve(s, &c.Log, &c.HTTP, &c.Cloud, &c.Milvus); err != nil {
+		return err
+	}
+	c.Backup.Storage.inherit(&c.Milvus.Storage)
+	return resolve(s, &c.Transfer, &c.Backup, &c.Restore)
 }
 
 func (c *Config) Entries() []Entry {
@@ -85,10 +91,14 @@ func (c *Config) WriteTable(w io.Writer) error {
 	// only error-returning I/O is the single write and flush to the underlying
 	// writer below.
 	var sb strings.Builder
-	fmt.Fprintln(&sb, "PARAMETER\tVALUE\tSOURCE\tSOURCE_KEY")
-	fmt.Fprintln(&sb, "---------\t-----\t------\t----------")
+	fmt.Fprintln(&sb, "PARAMETER\tVALUE\tSOURCE\tSOURCE_KEY\tSTATUS")
+	fmt.Fprintln(&sb, "---------\t-----\t------\t----------\t------")
 	for _, e := range c.Entries() {
-		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\n", e.Name, e.Value, e.Source, e.SourceKey)
+		status := ""
+		if e.Deprecated {
+			status = "deprecated; use " + e.Replacement
+		}
+		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\t%s\n", e.Name, e.Value, e.Source, e.SourceKey, status)
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -188,7 +198,8 @@ type MilvusConfig struct {
 
 	RPCChannelName Value[string]
 
-	Etcd EtcdConfig
+	Etcd    EtcdConfig
+	Storage StorageConfig
 }
 
 func newMilvusConfig() MilvusConfig {
@@ -213,6 +224,7 @@ func newMilvusConfig() MilvusConfig {
 			Endpoints: Value[string]{Default: "localhost:2379", Keys: []string{"milvus.etcd.endpoints"}},
 			RootPath:  Value[string]{Default: "by-dev", Keys: []string{"milvus.etcd.rootPath"}},
 		},
+		Storage: newMilvusStorageConfig(),
 	}
 }
 
@@ -224,15 +236,17 @@ func (c *MilvusConfig) Resolve(s *source) error {
 		&c.MTLSCertPath, &c.MTLSKeyPath,
 		&c.RPCChannelName,
 		&c.Etcd.Endpoints, &c.Etcd.RootPath,
+		&c.Storage,
 	)
 }
 
-type MinioConfig struct {
-	StorageType Value[string]
-
-	Address Value[string]
-	Port    Value[int]
-	Region  Value[string]
+// StorageConfig describes one storage endpoint. It is shared by the Milvus
+// source storage and the backup destination storage.
+type StorageConfig struct {
+	Provider Value[string]
+	Address  Value[string]
+	Port     Value[int]
+	Region   Value[string]
 
 	AccessKeyID       Value[string]
 	SecretAccessKey   Value[string]
@@ -244,110 +258,151 @@ type MinioConfig struct {
 	RootPath    Value[string]
 	UseIAM      Value[bool]
 	IAMEndpoint Value[string]
-
-	BackupStorageType Value[string]
-	BackupAddress     Value[string]
-	BackupPort        Value[int]
-	BackupRegion      Value[string]
-
-	BackupAccessKeyID       Value[string]
-	BackupSecretAccessKey   Value[string]
-	BackupToken             Value[string]
-	BackupGcpCredentialJSON Value[string]
-	BackupUseSSL            Value[bool]
-	BackupBucketName        Value[string]
-	BackupRootPath          Value[string]
-	BackupUseIAM            Value[bool]
-	BackupIAMEndpoint       Value[string]
-
-	CrossStorage Value[bool]
-
-	// MultipartCopyThresholdMiB is the file size threshold above which multipart copy is used.
-	// Default is 500 MiB. GCP does not support multipart copy and will always use single copy.
-	MultipartCopyThresholdMiB Value[int64]
 }
 
-func newMinioConfig() MinioConfig {
-	// Defaults align with configs/backup.yaml and old paramtable constants.
-	return MinioConfig{
-		StorageType: Value[string]{Default: "minio", Keys: []string{"storage.storageType", "minio.storageType", "minio.cloudProvider"}},
+func newMilvusStorageConfig() StorageConfig {
+	return StorageConfig{
+		Provider: Value[string]{Default: "minio", Keys: []string{"milvus.storage.provider", "storage.storageType", "minio.storageType", "minio.cloudProvider"}, EnvKeys: []string{"MILVUS_STORAGE_PROVIDER"}},
+		Address:  Value[string]{Default: "localhost", Keys: []string{"milvus.storage.address", "minio.address"}, EnvKeys: []string{"MILVUS_STORAGE_ADDRESS", "MINIO_ADDRESS"}},
+		Port:     Value[int]{Default: 9000, Keys: []string{"milvus.storage.port", "minio.port"}, EnvKeys: []string{"MILVUS_STORAGE_PORT", "MINIO_PORT"}},
+		Region:   Value[string]{Default: "", Keys: []string{"milvus.storage.region", "minio.region"}, EnvKeys: []string{"MILVUS_STORAGE_REGION", "MINIO_REGION"}},
 
-		Address: Value[string]{Default: "localhost", Keys: []string{"minio.address"}, EnvKeys: []string{"MINIO_ADDRESS"}},
-		Port:    Value[int]{Default: 9000, Keys: []string{"minio.port"}, EnvKeys: []string{"MINIO_PORT"}},
-		Region:  Value[string]{Default: "", Keys: []string{"minio.region"}, EnvKeys: []string{"MINIO_REGION"}},
+		AccessKeyID:       Value[string]{Default: "minioadmin", Keys: []string{"milvus.storage.accessKeyID", "minio.accessKeyID"}, EnvKeys: []string{"MILVUS_STORAGE_ACCESS_KEY", "MINIO_ACCESS_KEY"}},
+		SecretAccessKey:   Value[string]{Default: "minioadmin", Keys: []string{"milvus.storage.secretAccessKey", "minio.secretAccessKey"}, EnvKeys: []string{"MILVUS_STORAGE_SECRET_KEY", "MINIO_SECRET_KEY"}, Opts: SecretValue},
+		Token:             Value[string]{Default: "", Keys: []string{"milvus.storage.token", "minio.token"}, EnvKeys: []string{"MILVUS_STORAGE_TOKEN", "MINIO_TOKEN"}, Opts: SecretValue},
+		GcpCredentialJSON: Value[string]{Default: "", Keys: []string{"milvus.storage.gcpCredentialJSON", "minio.gcpCredentialJSON"}, EnvKeys: []string{"MILVUS_STORAGE_GCP_KEY_JSON", "GCP_KEY_JSON"}, Opts: SecretValue},
 
-		AccessKeyID:       Value[string]{Default: "minioadmin", Keys: []string{"minio.accessKeyID"}, EnvKeys: []string{"MINIO_ACCESS_KEY"}},
-		SecretAccessKey:   Value[string]{Default: "minioadmin", Keys: []string{"minio.secretAccessKey"}, EnvKeys: []string{"MINIO_SECRET_KEY"}, Opts: SecretValue},
-		Token:             Value[string]{Default: "", Keys: []string{"minio.token"}, EnvKeys: []string{"MINIO_TOKEN"}, Opts: SecretValue},
-		GcpCredentialJSON: Value[string]{Default: "", Keys: []string{"minio.gcpCredentialJSON"}, EnvKeys: []string{"GCP_KEY_JSON"}, Opts: SecretValue},
-
-		UseSSL:      Value[bool]{Default: false, Keys: []string{"minio.useSSL"}, EnvKeys: []string{"MINIO_USE_SSL"}},
-		BucketName:  Value[string]{Default: "a-bucket", Keys: []string{"minio.bucketName"}, EnvKeys: []string{"MINIO_BUCKET_NAME"}},
-		RootPath:    Value[string]{Default: "files", Keys: []string{"minio.rootPath"}, EnvKeys: []string{"MINIO_ROOT_PATH"}},
-		UseIAM:      Value[bool]{Default: false, Keys: []string{"minio.useIAM"}, EnvKeys: []string{"MINIO_USE_IAM"}},
-		IAMEndpoint: Value[string]{Default: "", Keys: []string{"minio.iamEndpoint"}, EnvKeys: []string{"MINIO_IAM_ENDPOINT"}},
-
-		// Backup fields default to corresponding "milvus storage" values at resolve time.
-		BackupStorageType: Value[string]{Default: "", Keys: []string{"storage.backupStorageType", "minio.backupStorageType"}},
-		BackupAddress:     Value[string]{Default: "", Keys: []string{"minio.backupAddress"}, EnvKeys: []string{"MINIO_BACKUP_ADDRESS"}},
-		BackupPort:        Value[int]{Default: 0, Keys: []string{"minio.backupPort"}, EnvKeys: []string{"MINIO_BACKUP_PORT"}},
-		BackupRegion:      Value[string]{Default: "", Keys: []string{"minio.backupRegion"}, EnvKeys: []string{"MINIO_BACKUP_REGION"}},
-
-		BackupAccessKeyID:       Value[string]{Default: "", Keys: []string{"minio.backupAccessKeyID"}, EnvKeys: []string{"MINIO_BACKUP_ACCESS_KEY"}},
-		BackupSecretAccessKey:   Value[string]{Default: "", Keys: []string{"minio.backupSecretAccessKey"}, EnvKeys: []string{"MINIO_BACKUP_SECRET_KEY"}, Opts: SecretValue},
-		BackupToken:             Value[string]{Default: "", Keys: []string{"minio.backupToken"}, EnvKeys: []string{"MINIO_BACKUP_TOKEN"}, Opts: SecretValue},
-		BackupGcpCredentialJSON: Value[string]{Default: "", Keys: []string{"minio.backupGcpCredentialJSON"}, EnvKeys: []string{"BACKUP_GCP_KEY_JSON"}, Opts: SecretValue},
-		BackupUseSSL:            Value[bool]{Default: false, Keys: []string{"minio.backupUseSSL"}, EnvKeys: []string{"MINIO_BACKUP_USE_SSL"}},
-		BackupBucketName:        Value[string]{Default: "", Keys: []string{"minio.backupBucketName"}, EnvKeys: []string{"MINIO_BACKUP_BUCKET_NAME"}},
-		BackupRootPath:          Value[string]{Default: "", Keys: []string{"minio.backupRootPath"}, EnvKeys: []string{"MINIO_BACKUP_ROOT_PATH"}},
-		BackupUseIAM:            Value[bool]{Default: false, Keys: []string{"minio.backupUseIAM"}, EnvKeys: []string{"MINIO_BACKUP_USE_IAM"}},
-		BackupIAMEndpoint:       Value[string]{Default: "", Keys: []string{"minio.backupIamEndpoint"}, EnvKeys: []string{"MINIO_BACKUP_IAM_ENDPOINT"}},
-
-		CrossStorage: Value[bool]{Default: false, Keys: []string{"minio.crossStorage"}},
-
-		MultipartCopyThresholdMiB: Value[int64]{Default: 500, Keys: []string{"minio.multipartCopyThresholdMiB"}},
+		UseSSL:      Value[bool]{Default: false, Keys: []string{"milvus.storage.useSSL", "minio.useSSL"}, EnvKeys: []string{"MILVUS_STORAGE_USE_SSL", "MINIO_USE_SSL"}},
+		BucketName:  Value[string]{Default: "a-bucket", Keys: []string{"milvus.storage.bucketName", "minio.bucketName"}, EnvKeys: []string{"MILVUS_STORAGE_BUCKET_NAME", "MINIO_BUCKET_NAME"}},
+		RootPath:    Value[string]{Default: "files", Keys: []string{"milvus.storage.rootPath", "minio.rootPath"}, EnvKeys: []string{"MILVUS_STORAGE_ROOT_PATH", "MINIO_ROOT_PATH"}},
+		UseIAM:      Value[bool]{Default: false, Keys: []string{"milvus.storage.useIAM", "minio.useIAM"}, EnvKeys: []string{"MILVUS_STORAGE_USE_IAM", "MINIO_USE_IAM"}},
+		IAMEndpoint: Value[string]{Default: "", Keys: []string{"milvus.storage.iamEndpoint", "minio.iamEndpoint"}, EnvKeys: []string{"MILVUS_STORAGE_IAM_ENDPOINT", "MINIO_IAM_ENDPOINT"}},
 	}
 }
 
-func (c *MinioConfig) Resolve(s *source) error {
-	// Resolve "milvus storage" fields first.
-	if err := resolve(s,
-		&c.StorageType, &c.Address, &c.Port, &c.Region,
+func newBackupStorageConfig() StorageConfig {
+	return StorageConfig{
+		Provider: Value[string]{Keys: []string{"backup.storage.provider", "storage.backupStorageType", "minio.backupStorageType"}, EnvKeys: []string{"BACKUP_STORAGE_PROVIDER"}},
+		Address:  Value[string]{Keys: []string{"backup.storage.address", "minio.backupAddress"}, EnvKeys: []string{"BACKUP_STORAGE_ADDRESS", "MINIO_BACKUP_ADDRESS"}},
+		Port:     Value[int]{Keys: []string{"backup.storage.port", "minio.backupPort"}, EnvKeys: []string{"BACKUP_STORAGE_PORT", "MINIO_BACKUP_PORT"}},
+		Region:   Value[string]{Keys: []string{"backup.storage.region", "minio.backupRegion"}, EnvKeys: []string{"BACKUP_STORAGE_REGION", "MINIO_BACKUP_REGION"}},
+
+		AccessKeyID:       Value[string]{Keys: []string{"backup.storage.accessKeyID", "minio.backupAccessKeyID"}, EnvKeys: []string{"BACKUP_STORAGE_ACCESS_KEY", "MINIO_BACKUP_ACCESS_KEY"}},
+		SecretAccessKey:   Value[string]{Keys: []string{"backup.storage.secretAccessKey", "minio.backupSecretAccessKey"}, EnvKeys: []string{"BACKUP_STORAGE_SECRET_KEY", "MINIO_BACKUP_SECRET_KEY"}, Opts: SecretValue},
+		Token:             Value[string]{Keys: []string{"backup.storage.token", "minio.backupToken"}, EnvKeys: []string{"BACKUP_STORAGE_TOKEN", "MINIO_BACKUP_TOKEN"}, Opts: SecretValue},
+		GcpCredentialJSON: Value[string]{Keys: []string{"backup.storage.gcpCredentialJSON", "minio.backupGcpCredentialJSON"}, EnvKeys: []string{"BACKUP_STORAGE_GCP_KEY_JSON", "BACKUP_GCP_KEY_JSON"}, Opts: SecretValue},
+
+		UseSSL:      Value[bool]{Keys: []string{"backup.storage.useSSL", "minio.backupUseSSL"}, EnvKeys: []string{"BACKUP_STORAGE_USE_SSL", "MINIO_BACKUP_USE_SSL"}},
+		BucketName:  Value[string]{Keys: []string{"backup.storage.bucketName", "minio.backupBucketName"}, EnvKeys: []string{"BACKUP_STORAGE_BUCKET_NAME", "MINIO_BACKUP_BUCKET_NAME"}},
+		RootPath:    Value[string]{Keys: []string{"backup.storage.rootPath", "minio.backupRootPath"}, EnvKeys: []string{"BACKUP_STORAGE_ROOT_PATH", "MINIO_BACKUP_ROOT_PATH"}},
+		UseIAM:      Value[bool]{Keys: []string{"backup.storage.useIAM", "minio.backupUseIAM"}, EnvKeys: []string{"BACKUP_STORAGE_USE_IAM", "MINIO_BACKUP_USE_IAM"}},
+		IAMEndpoint: Value[string]{Keys: []string{"backup.storage.iamEndpoint", "minio.backupIamEndpoint"}, EnvKeys: []string{"BACKUP_STORAGE_IAM_ENDPOINT", "MINIO_BACKUP_IAM_ENDPOINT"}},
+	}
+}
+
+func (c *StorageConfig) inherit(source *StorageConfig) {
+	c.Provider.Default = source.Provider.Val
+	c.Address.Default = source.Address.Val
+	c.Port.Default = source.Port.Val
+	c.Region.Default = source.Region.Val
+	c.AccessKeyID.Default = source.AccessKeyID.Val
+	c.SecretAccessKey.Default = source.SecretAccessKey.Val
+	c.Token.Default = source.Token.Val
+	c.GcpCredentialJSON.Default = source.GcpCredentialJSON.Val
+	c.UseSSL.Default = source.UseSSL.Val
+	c.BucketName.Default = source.BucketName.Val
+	c.RootPath.Default = cmp.Or(source.RootPath.Val, "backup")
+	c.UseIAM.Default = source.UseIAM.Val
+	c.IAMEndpoint.Default = source.IAMEndpoint.Val
+}
+
+func (c *StorageConfig) Resolve(s *source) error {
+	return resolve(s,
+		&c.Provider, &c.Address, &c.Port, &c.Region,
 		&c.AccessKeyID, &c.SecretAccessKey, &c.Token, &c.GcpCredentialJSON,
 		&c.UseSSL, &c.BucketName, &c.RootPath, &c.UseIAM, &c.IAMEndpoint,
-	); err != nil {
-		return err
-	}
-
-	// Backward-compatible defaults: if backup configs are not provided, inherit from primary configs.
-	c.BackupStorageType.Default = cmp.Or(c.BackupStorageType.Default, c.StorageType.Val)
-	c.BackupAddress.Default = cmp.Or(c.BackupAddress.Default, c.Address.Val)
-	c.BackupPort.Default = cmp.Or(c.BackupPort.Default, c.Port.Val)
-	c.BackupRegion.Default = cmp.Or(c.BackupRegion.Default, c.Region.Val)
-	c.BackupAccessKeyID.Default = cmp.Or(c.BackupAccessKeyID.Default, c.AccessKeyID.Val)
-	c.BackupSecretAccessKey.Default = cmp.Or(c.BackupSecretAccessKey.Default, c.SecretAccessKey.Val)
-	c.BackupToken.Default = cmp.Or(c.BackupToken.Default, c.Token.Val)
-	c.BackupUseSSL.Default = c.BackupUseSSL.Default || c.UseSSL.Val
-	c.BackupBucketName.Default = cmp.Or(c.BackupBucketName.Default, c.BucketName.Val)
-	c.BackupRootPath.Default = cmp.Or(c.BackupRootPath.Default, c.RootPath.Val, "backup")
-	c.BackupUseIAM.Default = c.BackupUseIAM.Default || c.UseIAM.Val
-	c.BackupIAMEndpoint.Default = cmp.Or(c.BackupIAMEndpoint.Default, c.IAMEndpoint.Val)
-
-	return resolve(s,
-		&c.BackupStorageType, &c.BackupAddress, &c.BackupPort, &c.BackupRegion,
-		&c.BackupAccessKeyID, &c.BackupSecretAccessKey, &c.BackupToken, &c.BackupGcpCredentialJSON,
-		&c.BackupUseSSL, &c.BackupBucketName, &c.BackupRootPath, &c.BackupUseIAM, &c.BackupIAMEndpoint,
-		&c.CrossStorage,
-		&c.MultipartCopyThresholdMiB,
 	)
 }
 
-type BackupParallelismConfig struct {
-	CopyData          Value[int]
-	BackupCollection  Value[int]
-	BackupSegment     Value[int]
-	RestoreCollection Value[int]
-	ImportJob         Value[int]
+const (
+	TransferModeAuto      = "auto"
+	TransferModeDirect    = "direct"
+	TransferModeStreaming = "streaming"
+)
+
+type TransferConfig struct {
+	// Mode controls how objects move between the two storage endpoints:
+	// auto chooses conservatively, direct uses the storage COPY API, and
+	// streaming downloads and uploads through the milvus-backup process.
+	Mode Value[string]
+
+	// Concurrency limits the number of objects being copied at the same time.
+	Concurrency Value[int]
+
+	// MultipartCopyThresholdMiB is the file size threshold above which multipart copy is used.
+	MultipartCopyThresholdMiB Value[int64]
+}
+
+func newTransferConfig() TransferConfig {
+	return TransferConfig{
+		Mode: Value[string]{Default: TransferModeAuto, Keys: []string{"transfer.mode", "backup.transfer.mode"}, EnvKeys: []string{"TRANSFER_MODE", "BACKUP_TRANSFER_MODE"}},
+		Concurrency: Value[int]{
+			Default: 128,
+			Keys:    []string{"transfer.concurrency", "backup.parallelism.copydata"},
+			EnvKeys: []string{"TRANSFER_CONCURRENCY", "BACKUP_PARALLELISM_COPYDATA"},
+		},
+		MultipartCopyThresholdMiB: Value[int64]{
+			Default: 500,
+			Keys:    []string{"transfer.multipartCopyThresholdMiB", "backup.transfer.multipartCopyThresholdMiB", "minio.multipartCopyThresholdMiB"},
+			EnvKeys: []string{"TRANSFER_MULTIPART_COPY_THRESHOLD_MIB", "BACKUP_TRANSFER_MULTIPART_COPY_THRESHOLD_MIB"},
+		},
+	}
+}
+
+func (c *TransferConfig) Resolve(s *source) error {
+	// Resolve the canonical mode first. The legacy crossStorage boolean maps to
+	// streaming=true and auto=false, matching the historical automatic fallback
+	// when providers differ.
+	canonical := c.Mode
+	canonical.Default = ""
+	if err := canonical.Resolve(s); err != nil {
+		return err
+	}
+	if canonical.Used.Kind != SourceDefault {
+		c.Mode = canonical
+	} else {
+		legacy := Value[bool]{Default: false, Keys: []string{"minio.crossStorage"}}
+		if err := legacy.Resolve(s); err != nil {
+			return err
+		}
+		c.Mode.Val = TransferModeAuto
+		c.Mode.Used = Used{Kind: SourceDefault}
+		if legacy.Used.Kind != SourceDefault {
+			c.Mode.Used = legacy.Used
+			if legacy.Val {
+				c.Mode.Val = TransferModeStreaming
+			}
+		}
+	}
+
+	switch c.Mode.Val {
+	case TransferModeAuto, TransferModeDirect, TransferModeStreaming:
+	default:
+		return fmt.Errorf("cfg: unsupported transfer.mode %q (want auto, direct, or streaming)", c.Mode.Val)
+	}
+
+	if err := resolve(s, &c.Concurrency, &c.MultipartCopyThresholdMiB); err != nil {
+		return err
+	}
+	if c.Concurrency.Val <= 0 {
+		return fmt.Errorf("cfg: transfer.concurrency must be greater than zero")
+	}
+	return nil
+}
+
+type BackupConcurrencyConfig struct {
+	Collections Value[int]
+	Segments    Value[int]
 }
 
 type BackupGCPauseConfig struct {
@@ -356,21 +411,18 @@ type BackupGCPauseConfig struct {
 }
 
 type BackupConfig struct {
-	Parallelism   BackupParallelismConfig
-	KeepTempFiles Value[bool]
-	GCPause       BackupGCPauseConfig
+	Storage     StorageConfig
+	Concurrency BackupConcurrencyConfig
+	GCPause     BackupGCPauseConfig
 }
 
 func newBackupConfig() BackupConfig {
 	return BackupConfig{
-		Parallelism: BackupParallelismConfig{
-			CopyData:          Value[int]{Default: 128, Keys: []string{"backup.parallelism.copydata"}, EnvKeys: []string{"BACKUP_PARALLELISM_COPYDATA"}},
-			BackupCollection:  Value[int]{Default: 4, Keys: []string{"backup.parallelism.backupCollection"}, EnvKeys: []string{"BACKUP_PARALLELISM_BACKUP_COLLECTION"}},
-			BackupSegment:     Value[int]{Default: 1024, Keys: []string{"backup.parallelism.backupSegment"}},
-			RestoreCollection: Value[int]{Default: 2, Keys: []string{"backup.parallelism.restoreCollection"}, EnvKeys: []string{"BACKUP_PARALLELISM_RESTORE_COLLECTION"}},
-			ImportJob:         Value[int]{Default: 768, Keys: []string{"backup.parallelism.importJob"}},
+		Storage: newBackupStorageConfig(),
+		Concurrency: BackupConcurrencyConfig{
+			Collections: Value[int]{Default: 4, Keys: []string{"backup.concurrency.collections", "backup.parallelism.backupCollection"}, EnvKeys: []string{"BACKUP_CONCURRENCY_COLLECTIONS", "BACKUP_PARALLELISM_BACKUP_COLLECTION"}},
+			Segments:    Value[int]{Default: 1024, Keys: []string{"backup.concurrency.segments", "backup.parallelism.backupSegment"}, EnvKeys: []string{"BACKUP_CONCURRENCY_SEGMENTS"}},
 		},
-		KeepTempFiles: Value[bool]{Default: false, Keys: []string{"backup.keepTempFiles"}, EnvKeys: []string{"BACKUP_KEEP_TEMP_FILES"}},
 		GCPause: BackupGCPauseConfig{
 			Enable:  Value[bool]{Default: true, Keys: []string{"backup.gcPause.enable"}, EnvKeys: []string{"BACKUP_GC_PAUSE_ENABLE"}},
 			Address: Value[string]{Default: "http://localhost:9091", Keys: []string{"backup.gcPause.address"}, EnvKeys: []string{"BACKUP_GC_PAUSE_ADDRESS"}},
@@ -379,10 +431,48 @@ func newBackupConfig() BackupConfig {
 }
 
 func (c *BackupConfig) Resolve(s *source) error {
-	return resolve(s,
-		&c.Parallelism.CopyData, &c.Parallelism.BackupCollection, &c.Parallelism.BackupSegment,
-		&c.Parallelism.RestoreCollection, &c.Parallelism.ImportJob,
-		&c.KeepTempFiles,
+	if err := resolve(s,
+		&c.Storage,
+		&c.Concurrency.Collections, &c.Concurrency.Segments,
 		&c.GCPause.Enable, &c.GCPause.Address,
-	)
+	); err != nil {
+		return err
+	}
+	if c.Concurrency.Collections.Val <= 0 || c.Concurrency.Segments.Val <= 0 {
+		return fmt.Errorf("cfg: backup concurrency values must be greater than zero")
+	}
+	return nil
+}
+
+type RestoreConcurrencyConfig struct {
+	Collections Value[int]
+	ImportJobs  Value[int]
+}
+
+type RestoreConfig struct {
+	Concurrency   RestoreConcurrencyConfig
+	KeepTempFiles Value[bool]
+}
+
+func newRestoreConfig() RestoreConfig {
+	return RestoreConfig{
+		Concurrency: RestoreConcurrencyConfig{
+			Collections: Value[int]{Default: 2, Keys: []string{"restore.concurrency.collections", "backup.parallelism.restoreCollection"}, EnvKeys: []string{"RESTORE_CONCURRENCY_COLLECTIONS", "BACKUP_PARALLELISM_RESTORE_COLLECTION"}},
+			ImportJobs:  Value[int]{Default: 768, Keys: []string{"restore.concurrency.importJobs", "backup.parallelism.importJob"}, EnvKeys: []string{"RESTORE_CONCURRENCY_IMPORT_JOBS"}},
+		},
+		KeepTempFiles: Value[bool]{Default: false, Keys: []string{"restore.keepTempFiles", "backup.keepTempFiles"}, EnvKeys: []string{"RESTORE_KEEP_TEMP_FILES", "BACKUP_KEEP_TEMP_FILES"}},
+	}
+}
+
+func (c *RestoreConfig) Resolve(s *source) error {
+	if err := resolve(s,
+		&c.Concurrency.Collections, &c.Concurrency.ImportJobs,
+		&c.KeepTempFiles,
+	); err != nil {
+		return err
+	}
+	if c.Concurrency.Collections.Val <= 0 || c.Concurrency.ImportJobs.Val <= 0 {
+		return fmt.Errorf("cfg: restore concurrency values must be greater than zero")
+	}
+	return nil
 }

--- a/internal/cfg/load_test.go
+++ b/internal/cfg/load_test.go
@@ -65,22 +65,241 @@ milvus:
 	})
 }
 
-func TestLoad_FlattenNestedKeys(t *testing.T) {
+func TestLoad_LegacyConcurrencyKeys(t *testing.T) {
 	p := writeTempYAML(t, `
 backup:
   parallelism:
     copydata: 99
     backupCollection: 7
+    backupSegment: 55
+    restoreCollection: 6
+    importJob: 44
+  keepTempFiles: true
 `)
 
 	c, err := Load(p, nil)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := c.Backup.Parallelism.CopyData.Val; got != 99 {
-		t.Fatalf("backup.parallelism.copydata = %d, want %d", got, 99)
+	if got := c.Transfer.Concurrency.Val; got != 99 {
+		t.Fatalf("transfer.concurrency = %d, want %d", got, 99)
 	}
-	if got := c.Backup.Parallelism.BackupCollection.Val; got != 7 {
-		t.Fatalf("backup.parallelism.backupCollection = %d, want %d", got, 7)
+	if got := c.Backup.Concurrency.Collections.Val; got != 7 {
+		t.Fatalf("backup.concurrency.collections = %d, want %d", got, 7)
 	}
+	if got := c.Backup.Concurrency.Segments.Val; got != 55 {
+		t.Fatalf("backup.concurrency.segments = %d, want %d", got, 55)
+	}
+	if got := c.Restore.Concurrency.Collections.Val; got != 6 {
+		t.Fatalf("restore.concurrency.collections = %d, want %d", got, 6)
+	}
+	if got := c.Restore.Concurrency.ImportJobs.Val; got != 44 {
+		t.Fatalf("restore.concurrency.importJobs = %d, want %d", got, 44)
+	}
+	if !c.Restore.KeepTempFiles.Val {
+		t.Fatal("restore.keepTempFiles did not load legacy backup.keepTempFiles")
+	}
+}
+
+func TestLoad_ConcurrencyStructure(t *testing.T) {
+	p := writeTempYAML(t, `
+transfer:
+  concurrency: 32
+backup:
+  concurrency:
+    collections: 3
+    segments: 64
+restore:
+  concurrency:
+    collections: 5
+    importJobs: 20
+`)
+
+	c, err := Load(p, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := c.Transfer.Concurrency.Val; got != 32 {
+		t.Fatalf("transfer.concurrency = %d", got)
+	}
+	if got := c.Backup.Concurrency.Collections.Val; got != 3 {
+		t.Fatalf("backup.concurrency.collections = %d", got)
+	}
+	if got := c.Backup.Concurrency.Segments.Val; got != 64 {
+		t.Fatalf("backup.concurrency.segments = %d", got)
+	}
+	if got := c.Restore.Concurrency.Collections.Val; got != 5 {
+		t.Fatalf("restore.concurrency.collections = %d", got)
+	}
+	if got := c.Restore.Concurrency.ImportJobs.Val; got != 20 {
+		t.Fatalf("restore.concurrency.importJobs = %d", got)
+	}
+}
+
+func TestLoad_RejectsNonPositiveConcurrency(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{name: "transfer", yaml: "transfer:\n  concurrency: 0\n"},
+		{name: "backup collections", yaml: "backup:\n  concurrency:\n    collections: 0\n"},
+		{name: "restore import jobs", yaml: "restore:\n  concurrency:\n    importJobs: -1\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := writeTempYAML(t, tt.yaml)
+			if _, err := Load(p, nil); err == nil {
+				t.Fatal("expected concurrency validation error")
+			}
+		})
+	}
+}
+
+func TestLoad_StorageConfig(t *testing.T) {
+	t.Run("canonical_structure", func(t *testing.T) {
+		p := writeTempYAML(t, `
+milvus:
+  storage:
+    provider: minio
+    address: source.example.com
+    port: 9000
+    bucketName: source-bucket
+    rootPath: files
+backup:
+  storage:
+    provider: s3
+    address: dest.example.com
+    port: 443
+    bucketName: backup-bucket
+    rootPath: backups
+transfer:
+  mode: streaming
+`)
+
+		c, err := Load(p, nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Milvus.Storage.Address.Val; got != "source.example.com" {
+			t.Fatalf("milvus.storage.address = %q", got)
+		}
+		if got := c.Backup.Storage.Provider.Val; got != S3 {
+			t.Fatalf("backup.storage.provider = %q", got)
+		}
+		if got := c.Transfer.Mode.Val; got != TransferModeStreaming {
+			t.Fatalf("transfer.mode = %q", got)
+		}
+	})
+
+	t.Run("legacy_structure", func(t *testing.T) {
+		p := writeTempYAML(t, `
+minio:
+  storageType: minio
+  address: source.example.com
+  bucketName: source-bucket
+  backupStorageType: s3
+  backupAddress: dest.example.com
+  backupBucketName: backup-bucket
+  crossStorage: true
+`)
+
+		c, err := Load(p, nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Milvus.Storage.Address.Val; got != "source.example.com" {
+			t.Fatalf("milvus.storage.address = %q", got)
+		}
+		if got := c.Backup.Storage.Provider.Val; got != S3 {
+			t.Fatalf("backup.storage.provider = %q", got)
+		}
+		if got := c.Transfer.Mode.Val; got != TransferModeStreaming {
+			t.Fatalf("legacy crossStorage mapped to %q", got)
+		}
+		if got := c.Transfer.Mode.Used.Key; got != "minio.crossstorage" {
+			t.Fatalf("transfer mode source key = %q", got)
+		}
+	})
+
+	t.Run("canonical_keys_win", func(t *testing.T) {
+		p := writeTempYAML(t, `
+milvus:
+  storage:
+    address: canonical.example.com
+minio:
+  address: legacy.example.com
+backup:
+  transfer:
+    mode: direct
+`)
+
+		c, err := Load(p, nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Milvus.Storage.Address.Val; got != "canonical.example.com" {
+			t.Fatalf("milvus.storage.address = %q", got)
+		}
+		if got := c.Milvus.Storage.Address.Used.Key; got != "milvus.storage.address" {
+			t.Fatalf("storage address source key = %q", got)
+		}
+	})
+
+	t.Run("backup_storage_inherits_milvus_storage", func(t *testing.T) {
+		p := writeTempYAML(t, `
+milvus:
+  storage:
+    provider: gcpnative
+    address: storage.example.com
+    useSSL: true
+    useIAM: true
+    gcpCredentialJSON: credentials.json
+`)
+
+		c, err := Load(p, nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Backup.Storage.Provider.Val; got != CloudProviderGCPNative {
+			t.Fatalf("backup.storage.provider = %q", got)
+		}
+		if !c.Backup.Storage.UseSSL.Val || !c.Backup.Storage.UseIAM.Val {
+			t.Fatal("backup storage did not inherit boolean settings")
+		}
+		if got := c.Backup.Storage.GcpCredentialJSON.Val; got != "credentials.json" {
+			t.Fatalf("backup GCP credential = %q", got)
+		}
+	})
+}
+
+func TestLoad_TransferMode(t *testing.T) {
+	t.Run("default_auto", func(t *testing.T) {
+		c, err := Load("", nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Transfer.Mode.Val; got != TransferModeAuto {
+			t.Fatalf("transfer.mode = %q", got)
+		}
+	})
+
+	t.Run("legacy_false_maps_to_auto", func(t *testing.T) {
+		p := writeTempYAML(t, "minio:\n  crossStorage: false\n")
+		c, err := Load(p, nil)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := c.Transfer.Mode.Val; got != TransferModeAuto {
+			t.Fatalf("transfer.mode = %q", got)
+		}
+	})
+
+	t.Run("reject_invalid_mode", func(t *testing.T) {
+		p := writeTempYAML(t, "transfer:\n  mode: magic\n")
+		_, err := Load(p, nil)
+		if err == nil {
+			t.Fatal("expected invalid transfer mode error")
+		}
+	})
 }

--- a/internal/cfg/value.go
+++ b/internal/cfg/value.go
@@ -47,10 +47,12 @@ type Value[T primitive] struct {
 }
 
 type Entry struct {
-	Name      string
-	Value     string
-	Source    SourceKind
-	SourceKey string
+	Name        string
+	Value       string
+	Source      SourceKind
+	SourceKey   string
+	Deprecated  bool
+	Replacement string
 }
 
 type Displayer interface {
@@ -62,12 +64,40 @@ func (val *Value[T]) Display(name string) Entry {
 	if val.IsSecret() {
 		value = maskSecret(value)
 	}
-	return Entry{
+	entry := Entry{
 		Name:      name,
 		Value:     value,
 		Source:    val.Used.Kind,
 		SourceKey: val.Used.Key,
 	}
+
+	if val.Used.Kind == SourceDefault || val.Used.Key == "" {
+		return entry
+	}
+
+	usedKey := strings.ToLower(val.Used.Key)
+	canonicalKey := ""
+	for _, key := range val.EnvKeys {
+		if strings.EqualFold(key, usedKey) {
+			canonicalKey = firstKey(val.EnvKeys)
+			break
+		}
+	}
+	if canonicalKey == "" {
+		canonicalKey = firstKey(val.Keys)
+	}
+	if canonicalKey != "" && !strings.EqualFold(canonicalKey, usedKey) {
+		entry.Deprecated = true
+		entry.Replacement = canonicalKey
+	}
+	return entry
+}
+
+func firstKey(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
 }
 
 func maskSecret(s string) string {

--- a/internal/cfg/value_test.go
+++ b/internal/cfg/value_test.go
@@ -48,6 +48,18 @@ func TestValueDisplay(t *testing.T) {
 		// fixed-length masking: "su" + "****" + "et"
 		assert.Equal(t, "su****et", entry.Value)
 	})
+
+	t.Run("DeprecatedAliasShowsReplacement", func(t *testing.T) {
+		v := Value[string]{
+			Keys: []string{"milvus.storage.address", "minio.address"},
+			Val:  "localhost",
+			Used: Used{Kind: SourceConfigFile, Key: "minio.address"},
+		}
+		entry := v.Display("Milvus.Storage.Address")
+
+		assert.True(t, entry.Deprecated)
+		assert.Equal(t, "milvus.storage.address", entry.Replacement)
+	})
 }
 
 func TestConfigEntries(t *testing.T) {
@@ -67,8 +79,13 @@ func TestConfigEntries(t *testing.T) {
 		"Log.Console",
 		"Milvus.Address",
 		"Milvus.Port",
-		"Minio.BucketName",
-		"Backup.KeepTempFiles",
+		"Milvus.Storage.BucketName",
+		"Backup.Storage.BucketName",
+		"Transfer.Mode",
+		"Transfer.Concurrency",
+		"Backup.Concurrency.Collections",
+		"Restore.Concurrency.Collections",
+		"Restore.KeepTempFiles",
 	}
 
 	for _, field := range expectedFields {

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/internal/cfg"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/retry"
 )
@@ -47,8 +48,8 @@ type copier interface {
 	copy(ctx context.Context, copyAttr CopyAttr) error
 }
 
-// remoteCopier copy data from src to dest by calling dest.CopyObject
-type remoteCopier struct {
+// directCopier copies data with the destination storage's native COPY API.
+type directCopier struct {
 	src  Client
 	dest Client
 
@@ -57,7 +58,7 @@ type remoteCopier struct {
 	logger *zap.Logger
 }
 
-func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
+func (rp *directCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	rp.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
 
 	start := time.Now()
@@ -65,7 +66,7 @@ func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 		i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
 		if err := rp.dest.CopyObject(ctx, i); err != nil {
-			return fmt.Errorf("storage: remote copier copy object %w", err)
+			return fmt.Errorf("storage: direct copier copy object %w", err)
 		}
 
 		return nil
@@ -78,8 +79,9 @@ func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	return err
 }
 
-// serverCopier copy data from src to dest by backup server
-type serverCopier struct {
+// streamingCopier downloads from the source and uploads to the destination
+// through the milvus-backup process.
+type streamingCopier struct {
 	src  Client
 	dest Client
 
@@ -88,13 +90,13 @@ type serverCopier struct {
 	logger *zap.Logger
 }
 
-func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
+func (sc *streamingCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	sc.logger.Debug("copy object", zap.String("src_key", copyAttr.Src.Key), zap.String("dest_key", copyAttr.DestKey))
 
 	return retry.Do(ctx, func() error {
 		obj, err := sc.src.GetObject(ctx, copyAttr.Src.Key)
 		if err != nil {
-			return fmt.Errorf("storage: server copier get object %w", err)
+			return fmt.Errorf("storage: streaming copier get object %w", err)
 		}
 		defer obj.Body.Close()
 
@@ -105,22 +107,41 @@ func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 
 		i := UploadObjectInput{Body: body, Key: copyAttr.DestKey, Size: copyAttr.Src.Length}
 		if err := sc.dest.UploadObject(ctx, i); err != nil {
-			return fmt.Errorf("storage: server copier upload object %w", err)
+			return fmt.Errorf("storage: streaming copier upload object %w", err)
 		}
 
 		return nil
 	})
 }
 
-func newCopier(src, dest Client, copyByServer bool, opt copierOpt) copier {
+func SameBackend(left, right Config) bool {
+	return left.Provider == right.Provider &&
+		left.Endpoint == right.Endpoint &&
+		left.UseSSL == right.UseSSL &&
+		left.Region == right.Region &&
+		left.Credential.AzureAccountName == right.Credential.AzureAccountName
+}
+
+func CopyThroughProcess(mode string, src, dest Client) bool {
+	switch mode {
+	case cfg.TransferModeDirect:
+		return false
+	case cfg.TransferModeStreaming:
+		return true
+	default:
+		return !SameBackend(src.Config(), dest.Config())
+	}
+}
+
+func newCopier(src, dest Client, copyThroughProcess bool, opt copierOpt) copier {
 	logger := log.L().With(
 		zap.String("src", src.Config().Bucket),
 		zap.String("dest", dest.Config().Bucket),
 	)
 
-	if copyByServer {
-		return &serverCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "server"))}
+	if copyThroughProcess {
+		return &streamingCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "streaming"))}
 	}
 
-	return &remoteCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "remote"))}
+	return &directCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "direct"))}
 }

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg"
 )
 
 func TestTrackReader_Read(t *testing.T) {
@@ -37,11 +39,11 @@ func TestTrackReader_Read(t *testing.T) {
 	})
 }
 
-func TestRemoteCopier_Copy(t *testing.T) {
+func TestDirectCopier_Copy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
@@ -54,7 +56,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	t.Run("CopyObjectError", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
@@ -71,7 +73,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	t.Run("RetryThenSuccess", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
@@ -87,7 +89,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		src := NewMockClient(t)
 
 		var traced bool
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
 			traceFn: func(size int64, cost time.Duration) {
 				traced = true
 				assert.Equal(t, int64(5), size)
@@ -108,7 +110,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		src := NewMockClient(t)
 
 		var traced bool
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
 			traceFn: func(size int64, cost time.Duration) {
 				traced = true
 			},
@@ -127,11 +129,11 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	})
 }
 
-func TestServerCopier_Copy(t *testing.T) {
+func TestStreamingCopier_Copy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
+		sp := &streamingCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		body := io.NopCloser(bytes.NewReader([]byte("hello")))
 		obj := &Object{Body: body, Length: 5}
@@ -143,5 +145,53 @@ func TestServerCopier_Copy(t *testing.T) {
 		attr := CopyAttr{Src: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		err := sp.copy(context.Background(), attr)
 		assert.NoError(t, err)
+	})
+}
+
+func TestCopyThroughProcess(t *testing.T) {
+	newClients := func(srcCfg, destCfg Config) (Client, Client) {
+		src := NewMockClient(t)
+		dest := NewMockClient(t)
+		src.EXPECT().Config().Return(srcCfg).Maybe()
+		dest.EXPECT().Config().Return(destCfg).Maybe()
+		return src, dest
+	}
+
+	t.Run("explicit_modes", func(t *testing.T) {
+		src, dest := newClients(Config{}, Config{})
+		assert.False(t, CopyThroughProcess(cfg.TransferModeDirect, src, dest))
+		assert.True(t, CopyThroughProcess(cfg.TransferModeStreaming, src, dest))
+	})
+
+	t.Run("auto_direct_for_same_backend", func(t *testing.T) {
+		src, dest := newClients(
+			Config{Provider: cfg.Minio, Endpoint: "minio:9000"},
+			Config{Provider: cfg.Minio, Endpoint: "minio:9000"},
+		)
+		assert.False(t, CopyThroughProcess(cfg.TransferModeAuto, src, dest))
+	})
+
+	t.Run("auto_streams_for_different_endpoint", func(t *testing.T) {
+		src, dest := newClients(
+			Config{Provider: cfg.Minio, Endpoint: "minio-a:9000"},
+			Config{Provider: cfg.Minio, Endpoint: "minio-b:9000"},
+		)
+		assert.True(t, CopyThroughProcess(cfg.TransferModeAuto, src, dest))
+	})
+
+	t.Run("auto_streams_for_different_provider", func(t *testing.T) {
+		src, dest := newClients(
+			Config{Provider: cfg.Minio, Endpoint: "storage:9000"},
+			Config{Provider: cfg.S3, Endpoint: "storage:9000"},
+		)
+		assert.True(t, CopyThroughProcess(cfg.TransferModeAuto, src, dest))
+	})
+
+	t.Run("auto_streams_for_different_azure_account", func(t *testing.T) {
+		src, dest := newClients(
+			Config{Provider: cfg.CloudProviderAzure, Endpoint: "core.windows.net:443", UseSSL: true, Credential: Credential{AzureAccountName: "account-a"}},
+			Config{Provider: cfg.CloudProviderAzure, Endpoint: "core.windows.net:443", UseSSL: true, Credential: Credential{AzureAccountName: "account-b"}},
+		)
+		assert.True(t, CopyThroughProcess(cfg.TransferModeAuto, src, dest))
 	})
 }

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -24,7 +24,7 @@ type CopyPrefixOpt struct {
 
 	TraceFn TraceFn
 
-	CopyByServer bool
+	CopyThroughProcess bool
 }
 
 type CopyPrefixTask struct {
@@ -39,7 +39,7 @@ func NewCopyPrefixTask(opt CopyPrefixOpt) *CopyPrefixTask {
 	return &CopyPrefixTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyThroughProcess, copierOpt{traceFn: opt.TraceFn}),
 
 		logger: log.L().With(zap.String("src", opt.SrcPrefix), zap.String("dest", opt.DestPrefix)),
 	}
@@ -104,7 +104,7 @@ type CopyObjectsOpt struct {
 
 	TraceFn TraceFn
 
-	CopyByServer bool
+	CopyThroughProcess bool
 }
 
 type CopyObjectsTask struct {
@@ -117,7 +117,7 @@ func NewCopyObjectsTask(opt CopyObjectsOpt) *CopyObjectsTask {
 	return &CopyObjectsTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.CopyThroughProcess, copierOpt{traceFn: opt.TraceFn}),
 	}
 }
 

--- a/internal/storage/copy_task_test.go
+++ b/internal/storage/copy_task_test.go
@@ -85,7 +85,7 @@ func TestCopyObjectsTask_Execute(t *testing.T) {
 		assert.NoError(t, task.Execute(context.Background()))
 	})
 
-	t.Run("CopyByServerUploadsAll", func(t *testing.T) {
+	t.Run("CopyThroughProcessUploadsAll", func(t *testing.T) {
 		src := NewMockClient(t)
 		dest := NewMockClient(t)
 		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
@@ -96,7 +96,7 @@ func TestCopyObjectsTask_Execute(t *testing.T) {
 		dest.EXPECT().UploadObject(mock.Anything, UploadObjectInput{Body: body, Key: "x", Size: 2}).Return(nil).Once()
 
 		attrs := []CopyAttr{{Src: ObjectAttr{Key: "a", Length: 2}, DestKey: "x"}}
-		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1), CopyByServer: true})
+		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1), CopyThroughProcess: true})
 		assert.NoError(t, task.Execute(context.Background()))
 	})
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -12,67 +12,9 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/log"
 )
 
-func newBackupCredential(params *cfg.MinioConfig) Credential {
+func newCredential(params *cfg.StorageConfig) Credential {
 	var cred Credential
-	if params.BackupStorageType.Val == cfg.CloudProviderAzure {
-		cred.AzureAccountName = params.BackupAccessKeyID.Val
-	}
-
-	if params.BackupUseIAM.Val {
-		cred.Type = IAM
-		cred.IAMEndpoint = params.BackupIAMEndpoint.Val
-		return cred
-	}
-
-	if params.BackupStorageType.Val == cfg.CloudProviderGCPNative &&
-		params.BackupGcpCredentialJSON.Val != "" {
-		cred.Type = GCPCredJSON
-		cred.GCPCredJSON = params.BackupGcpCredentialJSON.Val
-		return cred
-	}
-
-	cred.Type = Static
-	cred.AK = params.BackupAccessKeyID.Val
-	cred.SK = params.BackupSecretAccessKey.Val
-	cred.Token = params.BackupToken.Val
-	return cred
-}
-
-func BackupStorageConfig(params *cfg.MinioConfig) Config {
-	ep := net.JoinHostPort(params.BackupAddress.Val, strconv.Itoa(params.BackupPort.Val))
-	return Config{
-		Provider:                  params.BackupStorageType.Val,
-		Endpoint:                  ep,
-		UseSSL:                    params.BackupUseSSL.Val,
-		Bucket:                    params.BackupBucketName.Val,
-		Credential:                newBackupCredential(params),
-		Region:                    params.BackupRegion.Val,
-		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
-	}
-}
-
-func NewBackupStorage(ctx context.Context, params *cfg.MinioConfig) (Client, error) {
-	ep := net.JoinHostPort(params.BackupAddress.Val, strconv.Itoa(params.BackupPort.Val))
-	log.Info("create backup storage client",
-		zap.String("endpoint", ep),
-		zap.String("bucket", params.BackupBucketName.Val))
-
-	cfg := BackupStorageConfig(params)
-
-	cli, err := NewClient(ctx, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("create backup storage client: %w", err)
-	}
-	if err := CreateBucketIfNotExist(ctx, cli, ""); err != nil {
-		return nil, fmt.Errorf("create backup storage client: %w", err)
-	}
-
-	return cli, nil
-}
-
-func newMilvusCredential(params *cfg.MinioConfig) Credential {
-	var cred Credential
-	if params.StorageType.Val == cfg.CloudProviderAzure {
+	if params.Provider.Val == cfg.CloudProviderAzure {
 		cred.AzureAccountName = params.AccessKeyID.Val
 	}
 
@@ -82,7 +24,7 @@ func newMilvusCredential(params *cfg.MinioConfig) Credential {
 		return cred
 	}
 
-	if params.StorageType.Val == cfg.CloudProviderGCPNative &&
+	if params.Provider.Val == cfg.CloudProviderGCPNative &&
 		params.GcpCredentialJSON.Val != "" {
 		cred.Type = GCPCredJSON
 		cred.GCPCredJSON = params.GcpCredentialJSON.Val
@@ -96,28 +38,49 @@ func newMilvusCredential(params *cfg.MinioConfig) Credential {
 	return cred
 }
 
-func MilvusStorageConfig(params *cfg.MinioConfig) Config {
+func BuildConfig(params *cfg.StorageConfig, multipartCopyThresholdMiB int64) Config {
 	ep := net.JoinHostPort(params.Address.Val, strconv.Itoa(params.Port.Val))
 	return Config{
-		Provider:                  params.StorageType.Val,
+		Provider:                  params.Provider.Val,
 		Endpoint:                  ep,
 		UseSSL:                    params.UseSSL.Val,
-		Credential:                newMilvusCredential(params),
 		Bucket:                    params.BucketName.Val,
+		Credential:                newCredential(params),
 		Region:                    params.Region.Val,
-		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
+		MultipartCopyThresholdMiB: multipartCopyThresholdMiB,
 	}
 }
 
-func NewMilvusStorage(ctx context.Context, params *cfg.MinioConfig) (Client, error) {
-	ep := net.JoinHostPort(params.Address.Val, strconv.Itoa(params.Port.Val))
+func NewBackupStorage(ctx context.Context, params *cfg.Config) (Client, error) {
+	storageParams := &params.Backup.Storage
+	ep := net.JoinHostPort(storageParams.Address.Val, strconv.Itoa(storageParams.Port.Val))
+	log.Info("create backup storage client",
+		zap.String("endpoint", ep),
+		zap.String("bucket", storageParams.BucketName.Val))
+
+	conf := BuildConfig(storageParams, params.Transfer.MultipartCopyThresholdMiB.Val)
+
+	cli, err := NewClient(ctx, conf)
+	if err != nil {
+		return nil, fmt.Errorf("create backup storage client: %w", err)
+	}
+	if err := CreateBucketIfNotExist(ctx, cli, ""); err != nil {
+		return nil, fmt.Errorf("create backup storage client: %w", err)
+	}
+
+	return cli, nil
+}
+
+func NewMilvusStorage(ctx context.Context, params *cfg.Config) (Client, error) {
+	storageParams := &params.Milvus.Storage
+	ep := net.JoinHostPort(storageParams.Address.Val, strconv.Itoa(storageParams.Port.Val))
 	log.Info("create milvus storage client",
 		zap.String("endpoint", ep),
-		zap.String("bucket", params.BucketName.Val))
+		zap.String("bucket", storageParams.BucketName.Val))
 
-	cfg := MilvusStorageConfig(params)
+	conf := BuildConfig(storageParams, params.Transfer.MultipartCopyThresholdMiB.Val)
 
-	return NewClient(ctx, cfg)
+	return NewClient(ctx, conf)
 }
 
 func NewClient(ctx context.Context, conf Config) (Client, error) {

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -8,91 +8,45 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/cfg"
 )
 
-func TestNewBackupCredential(t *testing.T) {
+func TestNewCredential(t *testing.T) {
 	t.Run("Azure", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupStorageType: cfg.Value[string]{Val: cfg.CloudProviderAzure},
-			BackupAccessKeyID: cfg.Value[string]{Val: "accountName"},
-			BackupUseIAM:      cfg.Value[bool]{Val: true},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "accountName", cred.AzureAccountName)
-	})
-
-	t.Run("IAM", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupUseIAM:      cfg.Value[bool]{Val: true},
-			BackupIAMEndpoint: cfg.Value[string]{Val: "iamEndpoint"},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "iamEndpoint", cred.IAMEndpoint)
-	})
-
-	t.Run("GCPCredJSON", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupStorageType:       cfg.Value[string]{Val: cfg.CloudProviderGCPNative},
-			BackupGcpCredentialJSON: cfg.Value[string]{Val: "path/to/json"},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, GCPCredJSON, cred.Type)
-		assert.Equal(t, "path/to/json", cred.GCPCredJSON)
-	})
-
-	t.Run("Static", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupAccessKeyID:     cfg.Value[string]{Val: "ak"},
-			BackupSecretAccessKey: cfg.Value[string]{Val: "sk"},
-			BackupToken:           cfg.Value[string]{Val: "token"},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, Static, cred.Type)
-		assert.Equal(t, "ak", cred.AK)
-		assert.Equal(t, "sk", cred.SK)
-		assert.Equal(t, "token", cred.Token)
-	})
-}
-
-func TestNewMilvusCredential(t *testing.T) {
-	t.Run("Azure", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			StorageType: cfg.Value[string]{Val: cfg.CloudProviderAzure},
+		params := &cfg.StorageConfig{
+			Provider:    cfg.Value[string]{Val: cfg.CloudProviderAzure},
 			AccessKeyID: cfg.Value[string]{Val: "accountName"},
 			UseIAM:      cfg.Value[bool]{Val: true},
 		}
-		cred := newMilvusCredential(params)
+		cred := newCredential(params)
 		assert.Equal(t, IAM, cred.Type)
 		assert.Equal(t, "accountName", cred.AzureAccountName)
 	})
 
 	t.Run("IAM", func(t *testing.T) {
-		params := &cfg.MinioConfig{
+		params := &cfg.StorageConfig{
 			UseIAM:      cfg.Value[bool]{Val: true},
 			IAMEndpoint: cfg.Value[string]{Val: "iamEndpoint"},
 		}
-		cred := newMilvusCredential(params)
+		cred := newCredential(params)
 		assert.Equal(t, IAM, cred.Type)
 		assert.Equal(t, "iamEndpoint", cred.IAMEndpoint)
 	})
 
 	t.Run("GCPCredJSON", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			StorageType:       cfg.Value[string]{Val: cfg.CloudProviderGCPNative},
+		params := &cfg.StorageConfig{
+			Provider:          cfg.Value[string]{Val: cfg.CloudProviderGCPNative},
 			GcpCredentialJSON: cfg.Value[string]{Val: "path/to/json"},
 		}
-		cred := newMilvusCredential(params)
+		cred := newCredential(params)
 		assert.Equal(t, GCPCredJSON, cred.Type)
 		assert.Equal(t, "path/to/json", cred.GCPCredJSON)
 	})
 
 	t.Run("Static", func(t *testing.T) {
-		params := &cfg.MinioConfig{
+		params := &cfg.StorageConfig{
 			AccessKeyID:     cfg.Value[string]{Val: "ak"},
 			SecretAccessKey: cfg.Value[string]{Val: "sk"},
 			Token:           cfg.Value[string]{Val: "token"},
 		}
-		cred := newMilvusCredential(params)
+		cred := newCredential(params)
 		assert.Equal(t, Static, cred.Type)
 		assert.Equal(t, "ak", cred.AK)
 		assert.Equal(t, "sk", cred.SK)


### PR DESCRIPTION
Refactors the MinIO-centric configuration into explicit milvus.storage, backup.storage, transfer, backup concurrency, and restore concurrency sections. Replaces crossStorage with transfer.mode (auto/direct/streaming), applies one endpoint-aware transfer policy to backup and restore, and keeps legacy YAML keys and environment variables as deprecated aliases. Updates sample configs and documentation. Testing: go test ./... and git diff --check. Closes #1005.