### PR TITLE
docs: add etcd-style commit title rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,27 @@ assert.Len(t, got.GetCollectionBackups(), 1)         // the actual check
 
 Use PascalCase for sub-test names in `t.Run()`, e.g. `t.Run("SecretValueIsMasked", ...)`.
 See `internal/cfg/value_test.go` for a table-driven test in the intended style.
+
+## Commit titles
+
+Use etcd-style subjects — `scope: short description in lowercase`:
+
+```
+backup: scope index extra etcd scan to backed-up collections
+restore: add support for partial collection restore
+storage: replace per-file copy verification with batched prefix verify
+ci: skip workflow runs for non-code path changes
+```
+
+- **scope** is the component or area touched: `backup`, `restore`, `storage`, `milvus`,
+  `stream`, `migrate`, `cfg`, `client`, `ci`, `docs`, `test`, ...
+- description starts lowercase, imperative mood ("add", not "added"), no trailing period
+- keep the subject under 72 characters
+
+Do not use Conventional Commits (`feat:`, `fix(storage):`). A few exist in history, but etcd
+style is the convention here by a wide margin. `build(deps):` commits are dependabot's and are
+exempt — they are generated, not written.
+
+**PRs are squash-merged, so the PR title is what lands in git history — not your local commit
+subjects.** A 21-commit PR merges as one commit whose subject is the PR title with ` (#NNNN)`
+appended by GitHub. Apply this rule to the PR title above all, and leave room for the suffix.


### PR DESCRIPTION
## Summary

Record the commit title convention in `AGENTS.md`, following #1085.

Use etcd style — `scope: short description in lowercase` — not Conventional Commits. This matches what the repo already does: of the last 100 non-dependabot commits, 64 use etcd style (`ci:`, `docs:`, `restore:`, `backup:`, `storage:`, ...) against 5 using Conventional Commits (`fix(storage):`, `feat:`). Dependabot's `build(deps):` commits are noted as exempt since they are generated.

The section also records something easy to get wrong: this repo squash-merges, so the **PR title** is what lands in git history, not local commit subjects. #1074 merged 21 commits under a single subject taken from its PR title. An agent that carefully styles its commit subjects but not the PR title has styled the wrong thing.

## Changes

- add a "Commit titles" section to `AGENTS.md` with the etcd-style format, scope list, and examples drawn from real history
- note that Conventional Commits are not used here, and that dependabot commits are exempt
- note that the PR title becomes the squashed commit subject, with ` (#NNNN)` appended

/kind improvement