### PR TITLE
storage: rename copiers to direct and streaming

### DIFF
--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -526,11 +526,11 @@ func (dmlt *collDMLTask) backupSegmentData(ctx context.Context, seg *backuppb.Se
 	attrs = append(attrs, insertAttrs...)
 	attrs = append(attrs, deltaAttrs...)
 	opt := storage.CopyObjectsOpt{
-		Src:          dmlt.milvusStorage,
-		Dest:         dmlt.backupStorage,
-		Attrs:        attrs,
-		CopyByServer: dmlt.crossStorage,
-		Sem:          dmlt.throttling.CopySem,
+		Src:       dmlt.milvusStorage,
+		Dest:      dmlt.backupStorage,
+		Attrs:     attrs,
+		Streaming: dmlt.crossStorage,
+		Sem:       dmlt.throttling.CopySem,
 		TraceFn: func(size int64, cost time.Duration) {
 			dmlt.taskMgr.UpdateBackupTask(dmlt.taskID, taskmgr.IncBackupCollCopiedSize(dmlt.ns, size, cost))
 		},

--- a/core/check/task.go
+++ b/core/check/task.go
@@ -134,12 +134,12 @@ func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	}
 	t.logger.Info("try to copy", zap.Bool("cross_storage", crossStorage), zap.String("dest_key", destKey))
 	opt := storage.CopyPrefixOpt{
-		Src:          t.milvusStorage,
-		Dest:         t.backupStorage,
-		SrcPrefix:    srcKey,
-		DestPrefix:   destKey,
-		Sem:          semaphore.NewWeighted(1),
-		CopyByServer: crossStorage,
+		Src:        t.milvusStorage,
+		Dest:       t.backupStorage,
+		SrcPrefix:  srcKey,
+		DestPrefix: destKey,
+		Sem:        semaphore.NewWeighted(1),
+		Streaming:  crossStorage,
 	}
 	task := storage.NewCopyPrefixTask(opt)
 	if err := task.Execute(ctx); err != nil {

--- a/core/migrate/task.go
+++ b/core/migrate/task.go
@@ -257,7 +257,7 @@ func (t *Task) copyToCloud(ctx context.Context) error {
 			t.taskMgr.UpdateMigrateTask(t.taskID, taskmgr.IncMigrateCopiedSize(size, cost))
 		},
 
-		CopyByServer: true,
+		Streaming: true,
 	}
 
 	copyTask := storage.NewCopyPrefixTask(opt)

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -315,12 +315,12 @@ func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix s
 	ct.logger.Info("milvus and backup store in different bucket, copy the data first", zap.String("temp_dir", tempDir))
 	dest := path.Join(tempDir, strings.Replace(srcPrefix, ct.backupDir, "", 1)) + "/"
 	opt := storage.CopyPrefixOpt{
-		Sem:          ct.copySem,
-		Src:          ct.backupStorage,
-		Dest:         ct.milvusStorage,
-		SrcPrefix:    srcPrefix,
-		DestPrefix:   dest,
-		CopyByServer: true,
+		Sem:        ct.copySem,
+		Src:        ct.backupStorage,
+		Dest:       ct.milvusStorage,
+		SrcPrefix:  srcPrefix,
+		DestPrefix: dest,
+		Streaming:  true,
 	}
 
 	ct.logger.Info("copy temporary restore file", zap.String("src", srcPrefix), zap.String("dest", dest))

--- a/internal/storage/copier.go
+++ b/internal/storage/copier.go
@@ -47,8 +47,9 @@ type copier interface {
 	copy(ctx context.Context, copyAttr CopyAttr) error
 }
 
-// remoteCopier copy data from src to dest by calling dest.CopyObject
-type remoteCopier struct {
+// directCopier copies data with the destination storage's native COPY API,
+// so the object never passes through this process.
+type directCopier struct {
 	src  Client
 	dest Client
 
@@ -57,29 +58,30 @@ type remoteCopier struct {
 	logger *zap.Logger
 }
 
-func (rp *remoteCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
-	rp.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
+func (dc *directCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
+	dc.logger.Debug("copy object", zap.String("src", copyAttr.Src.Key), zap.String("dest", copyAttr.DestKey))
 
 	start := time.Now()
 	err := retry.Do(ctx, func() error {
-		i := CopyObjectInput{SrcCli: rp.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
+		i := CopyObjectInput{SrcCli: dc.src, SrcAttr: copyAttr.Src, DestKey: copyAttr.DestKey}
 
-		if err := rp.dest.CopyObject(ctx, i); err != nil {
-			return fmt.Errorf("storage: remote copier copy object %w", err)
+		if err := dc.dest.CopyObject(ctx, i); err != nil {
+			return fmt.Errorf("storage: direct copier copy object %w", err)
 		}
 
 		return nil
 	})
 
-	if err == nil && rp.opt.traceFn != nil {
-		rp.opt.traceFn(copyAttr.Src.Length, time.Since(start))
+	if err == nil && dc.opt.traceFn != nil {
+		dc.opt.traceFn(copyAttr.Src.Length, time.Since(start))
 	}
 
 	return err
 }
 
-// serverCopier copy data from src to dest by backup server
-type serverCopier struct {
+// streamingCopier downloads from src and uploads to dest, so the object is
+// streamed through this process.
+type streamingCopier struct {
 	src  Client
 	dest Client
 
@@ -88,13 +90,13 @@ type serverCopier struct {
 	logger *zap.Logger
 }
 
-func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
+func (sc *streamingCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 	sc.logger.Debug("copy object", zap.String("src_key", copyAttr.Src.Key), zap.String("dest_key", copyAttr.DestKey))
 
 	return retry.Do(ctx, func() error {
 		obj, err := sc.src.GetObject(ctx, copyAttr.Src.Key)
 		if err != nil {
-			return fmt.Errorf("storage: server copier get object %w", err)
+			return fmt.Errorf("storage: streaming copier get object %w", err)
 		}
 		defer obj.Body.Close()
 
@@ -105,22 +107,22 @@ func (sc *serverCopier) copy(ctx context.Context, copyAttr CopyAttr) error {
 
 		i := UploadObjectInput{Body: body, Key: copyAttr.DestKey, Size: copyAttr.Src.Length}
 		if err := sc.dest.UploadObject(ctx, i); err != nil {
-			return fmt.Errorf("storage: server copier upload object %w", err)
+			return fmt.Errorf("storage: streaming copier upload object %w", err)
 		}
 
 		return nil
 	})
 }
 
-func newCopier(src, dest Client, copyByServer bool, opt copierOpt) copier {
+func newCopier(src, dest Client, streaming bool, opt copierOpt) copier {
 	logger := log.L().With(
 		zap.String("src", src.Config().Bucket),
 		zap.String("dest", dest.Config().Bucket),
 	)
 
-	if copyByServer {
-		return &serverCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "server"))}
+	if streaming {
+		return &streamingCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "streaming"))}
 	}
 
-	return &remoteCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "remote"))}
+	return &directCopier{src: src, dest: dest, opt: opt, logger: logger.With(zap.String("copier", "direct"))}
 }

--- a/internal/storage/copier_test.go
+++ b/internal/storage/copier_test.go
@@ -37,11 +37,11 @@ func TestTrackReader_Read(t *testing.T) {
 	})
 }
 
-func TestRemoteCopier_Copy(t *testing.T) {
+func TestDirectCopier_Copy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(nil).Once()
@@ -54,7 +54,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	t.Run("CopyObjectError", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
@@ -71,7 +71,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	t.Run("RetryThenSuccess", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop()}
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		in := CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "a/b", Length: 5}, DestKey: "c/d"}
 		dest.EXPECT().CopyObject(mock.Anything, in).Return(assert.AnError).Once()
@@ -87,7 +87,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		src := NewMockClient(t)
 
 		var traced bool
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
 			traceFn: func(size int64, cost time.Duration) {
 				traced = true
 				assert.Equal(t, int64(5), size)
@@ -108,7 +108,7 @@ func TestRemoteCopier_Copy(t *testing.T) {
 		src := NewMockClient(t)
 
 		var traced bool
-		rp := &remoteCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
+		rp := &directCopier{src: src, dest: dest, logger: zap.NewNop(), opt: copierOpt{
 			traceFn: func(size int64, cost time.Duration) {
 				traced = true
 			},
@@ -127,11 +127,11 @@ func TestRemoteCopier_Copy(t *testing.T) {
 	})
 }
 
-func TestServerCopier_Copy(t *testing.T) {
+func TestStreamingCopier_Copy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dest := NewMockClient(t)
 		src := NewMockClient(t)
-		sp := &serverCopier{src: src, dest: dest, logger: zap.NewNop()}
+		sp := &streamingCopier{src: src, dest: dest, logger: zap.NewNop()}
 
 		body := io.NopCloser(bytes.NewReader([]byte("hello")))
 		obj := &Object{Body: body, Length: 5}

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -24,7 +24,7 @@ type CopyPrefixOpt struct {
 
 	TraceFn TraceFn
 
-	CopyByServer bool
+	Streaming bool
 }
 
 type CopyPrefixTask struct {
@@ -39,7 +39,7 @@ func NewCopyPrefixTask(opt CopyPrefixOpt) *CopyPrefixTask {
 	return &CopyPrefixTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.Streaming, copierOpt{traceFn: opt.TraceFn}),
 
 		logger: log.L().With(zap.String("src", opt.SrcPrefix), zap.String("dest", opt.DestPrefix)),
 	}
@@ -104,7 +104,7 @@ type CopyObjectsOpt struct {
 
 	TraceFn TraceFn
 
-	CopyByServer bool
+	Streaming bool
 }
 
 type CopyObjectsTask struct {
@@ -117,7 +117,7 @@ func NewCopyObjectsTask(opt CopyObjectsOpt) *CopyObjectsTask {
 	return &CopyObjectsTask{
 		opt: opt,
 
-		copier: newCopier(opt.Src, opt.Dest, opt.CopyByServer, copierOpt{traceFn: opt.TraceFn}),
+		copier: newCopier(opt.Src, opt.Dest, opt.Streaming, copierOpt{traceFn: opt.TraceFn}),
 	}
 }
 

--- a/internal/storage/copy_task_test.go
+++ b/internal/storage/copy_task_test.go
@@ -85,7 +85,7 @@ func TestCopyObjectsTask_Execute(t *testing.T) {
 		assert.NoError(t, task.Execute(context.Background()))
 	})
 
-	t.Run("CopyByServerUploadsAll", func(t *testing.T) {
+	t.Run("StreamingUploadsAll", func(t *testing.T) {
 		src := NewMockClient(t)
 		dest := NewMockClient(t)
 		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
@@ -96,7 +96,7 @@ func TestCopyObjectsTask_Execute(t *testing.T) {
 		dest.EXPECT().UploadObject(mock.Anything, UploadObjectInput{Body: body, Key: "x", Size: 2}).Return(nil).Once()
 
 		attrs := []CopyAttr{{Src: ObjectAttr{Key: "a", Length: 2}, DestKey: "x"}}
-		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1), CopyByServer: true})
+		task := NewCopyObjectsTask(CopyObjectsOpt{Src: src, Dest: dest, Attrs: attrs, Sem: semaphore.NewWeighted(1), Streaming: true})
 		assert.NoError(t, task.Execute(context.Background()))
 	})
 


### PR DESCRIPTION
## Summary

`serverCopier` and `remoteCopier` describe the wrong thing. In object storage vocabulary a *server-side copy* is the one the storage service performs itself — which is exactly what `remoteCopier` does. So `serverCopier`, whose "server" means the milvus-backup process, points readers at the other implementation.

This renames both to match what they do, using the same vocabulary as the `transfer.mode` values proposed in #1089 (`direct` / `streaming`), so the types, the log field, and the future config value all read the same.

Pure rename — no behavior change. Split out of #1083 so that PR is left with the configuration structure and endpoint-aware `auto` detection.

## Changes

- `remoteCopier` → `directCopier`: uses the destination storage's native COPY API
- `serverCopier` → `streamingCopier`: streams the object through this process
- `CopyObjectsOpt.CopyByServer` / `CopyPrefixOpt.CopyByServer` → `Streaming`
- log field `copier=remote|server` → `copier=direct|streaming`
- doc comments now say which side moves the bytes

Part of #1089

/kind improvement