### PR TITLE
storage: abort multipart upload on a detached context

### DIFF
--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -30,6 +31,11 @@ const (
 	_maxParts         int64 = 10000
 
 	_maxCopyPartParallelism = 10
+
+	// aborting an unfinished multipart upload runs on a context detached from the
+	// caller's, so it needs its own bound to avoid hanging the copy path
+	_abortTimeout  = 30 * time.Second
+	_abortAttempts = 3
 )
 
 var _ Client = (*MinioClient)(nil)
@@ -162,6 +168,30 @@ func (m *MinioClient) copyPart(ctx context.Context, i copyPartInput) (minio.Comp
 	return output, err
 }
 
+// abortMultipartUpload cleans up an unfinished multipart upload.
+//
+// The caller reaches here precisely when something went wrong, and the most common
+// reason is that ctx was canceled -- the user canceled the backup, or a sibling copy
+// failed and tore down the shared context. Aborting with that ctx would fail
+// immediately and leave the already uploaded parts behind, billed until a bucket
+// lifecycle rule reaps them. So detach from the caller's cancellation and give the
+// abort its own deadline instead.
+func (m *MinioClient) abortMultipartUpload(ctx context.Context, destKey, uploadID string) {
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), _abortTimeout)
+	defer cancel()
+
+	err := retry.Do(abortCtx, func() error {
+		if err := m.core.AbortMultipartUpload(abortCtx, m.cfg.Bucket, destKey, uploadID); err != nil {
+			return fmt.Errorf("storage: %s abort multipart upload %w", m.cfg.Provider, err)
+		}
+		return nil
+	}, retry.Attempts(_abortAttempts))
+	if err != nil {
+		m.logger.Error("abort multipart upload failed", zap.Error(err),
+			zap.String("dest_key", destKey), zap.String("upload_id", uploadID))
+	}
+}
+
 type sortableCompletedParts []minio.CompletePart
 
 func (a sortableCompletedParts) Len() int           { return len(a) }
@@ -183,10 +213,7 @@ func (m *MinioClient) multiPartCopy(ctx context.Context, srcCli *MinioClient, i 
 	defer func() {
 		if err != nil {
 			m.logger.Error("multi part copy failed, abort multipart upload", zap.Error(err), zap.String("upload_id", uploadID))
-
-			if err := m.core.AbortMultipartUpload(ctx, m.cfg.Bucket, i.DestKey, uploadID); err != nil {
-				m.logger.Error("abort multipart upload failed", zap.Error(err))
-			}
+			m.abortMultipartUpload(ctx, i.DestKey, uploadID)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

The deferred cleanup in `multiPartCopy` aborted the multipart upload with the
caller's `ctx`. But the most common reason we reach that cleanup is that `ctx` was
already canceled — the user canceled the backup, or one part failed and the
errgroup tore down the shared context. The abort request then fails before it is
even sent, and the already uploaded parts stay in the bucket, taking up space
until a lifecycle rule reaps them.

Run the abort on a context detached from the caller's cancellation, bounded by
its own 30s timeout so the cleanup path cannot hang, and retry it a few times.
`context.WithoutCancel` keeps the ctx values (logging/trace context) and drops
only the cancellation and deadline, which is exactly what a cleanup path wants.

## Changes
- add `MinioClient.abortMultipartUpload`, which aborts on `context.WithoutCancel(ctx)`
  with a 30s timeout and 3 attempts
- call it from the `multiPartCopy` deferred cleanup

/kind improvement