### PR TITLE
cfg: add config migrate command to translate v1 config to v2

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/zilliztech/milvus-backup/cmd/check"
+	"github.com/zilliztech/milvus-backup/cmd/config"
 	"github.com/zilliztech/milvus-backup/cmd/create"
 	"github.com/zilliztech/milvus-backup/cmd/del"
 	"github.com/zilliztech/milvus-backup/cmd/get"
@@ -22,6 +23,7 @@ func Execute() {
 	cmd := root.NewCmd(&opt)
 
 	cmd.AddCommand(check.NewCmd(&opt))
+	cmd.AddCommand(config.NewCmd(&opt))
 	cmd.AddCommand(create.NewCmd(&opt))
 	cmd.AddCommand(del.NewCmd(&opt))
 	cmd.AddCommand(get.NewCmd(&opt))
@@ -34,7 +36,9 @@ func Execute() {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	cmd.Println(fmt.Sprintf("config: %s", opt.Config))
+	// This is a diagnostic, not output: keep it off stdout so a command such as
+	// "config migrate" can write a clean document there.
+	cmd.PrintErrln(fmt.Sprintf("config: %s", opt.Config))
 
 	if err := cmd.Execute(); err != nil {
 		cmd.PrintErrln(err)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+)
+
+// NewCmd builds the "config" command group, which inspects and migrates
+// milvus-backup configuration files.
+func NewCmd(opt *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "inspect and migrate milvus-backup configuration",
+	}
+
+	cmd.AddCommand(newMigrateCmd(opt))
+
+	return cmd
+}

--- a/cmd/config/migrate.go
+++ b/cmd/config/migrate.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/migrate"
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+type migrateOptions struct {
+	output string
+	force  bool
+	strict bool
+}
+
+func (o *migrateOptions) run(cmd *cobra.Command, opt *root.Options) error {
+	if err := ensureNotV2(opt.Config); err != nil {
+		return err
+	}
+
+	// Load the v1 config directly rather than through root.InitGlobalVars,
+	// which also initializes logging and panics on error. Overrides are not
+	// applied: --set paths are v1-scoped runtime overrides, not part of the
+	// file being migrated.
+	src, err := cfg.Load(opt.Config, nil)
+	if err != nil {
+		return fmt.Errorf("load v1 config %s: %w", opt.Config, err)
+	}
+
+	out, report := migrate.Migrate(src)
+
+	data, err := v2.Render(out, report.Comments)
+	if err != nil {
+		return err
+	}
+
+	// The report goes to stderr so stdout stays a clean YAML document that can
+	// be redirected straight into a file.
+	report.WriteTo(cmd.ErrOrStderr(), opt.Config)
+
+	if o.strict {
+		if err := report.Err(); err != nil {
+			return fmt.Errorf("migrated config is not valid v2 (--strict): %w", err)
+		}
+	}
+
+	return o.write(cmd, data)
+}
+
+func (o *migrateOptions) write(cmd *cobra.Command, data []byte) error {
+	if o.output == "" || o.output == "-" {
+		_, err := cmd.OutOrStdout().Write(data)
+		return err
+	}
+
+	if !o.force {
+		if _, err := os.Stat(o.output); err == nil {
+			return fmt.Errorf("output file %s already exists, use --force to overwrite", o.output)
+		}
+	}
+	if err := os.WriteFile(o.output, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", o.output, err)
+	}
+	cmd.PrintErrf("wrote v2 config to %s\n", o.output)
+
+	return nil
+}
+
+// ensureNotV2 rejects a config file that already declares configVersion: v2, so
+// a mistaken re-run does not silently reload a v2 file with the v1 loader.
+func ensureNotV2(configPath string) error {
+	src, err := param.NewSource(configPath, nil)
+	if err != nil {
+		return err
+	}
+	if raw, ok := src.ConfigFileValue(v2.VersionKey); ok {
+		if s, _ := raw.(string); strings.EqualFold(s, v2.Version) {
+			return fmt.Errorf("%s is already a v2 config", configPath)
+		}
+	}
+
+	return nil
+}
+
+func newMigrateCmd(opt *root.Options) *cobra.Command {
+	var o migrateOptions
+
+	cmd := &cobra.Command{
+		Use:           "migrate",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "translate a v1 config file into a complete v2 config file",
+		Long: "Translate the v1 configuration named by --config into a complete v2 " +
+			"configuration file.\n\n" +
+			"Keys and environment variables are renamed, not relocated: a secret kept " +
+			"in a v1 environment variable is left out of the file and reported with the " +
+			"v2 variable to set instead. The migration report is written to stderr; the " +
+			"v2 file to stdout, or to --output.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return o.run(cmd, opt)
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "write the v2 config here (default: stdout)")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite the output file if it already exists")
+	cmd.Flags().BoolVar(&o.strict, "strict", false, "fail if the migrated config is not valid v2")
+
+	return cmd
+}

--- a/cmd/config/migrate_test.go
+++ b/cmd/config/migrate_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+)
+
+// runMigrate wires the migrate command against configPath and captures stdout
+// and stderr separately.
+func runMigrate(t *testing.T, configPath string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	opt := &root.Options{Config: configPath}
+	cmd := newMigrateCmd(opt)
+
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	return out.String(), errBuf.String(), err
+}
+
+func writeV1(t *testing.T, content string) string {
+	t.Helper()
+
+	p := filepath.Join(t.TempDir(), "backup.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+
+	return p
+}
+
+// stdout is a clean v2 document: the report and diagnostics stay on stderr.
+func TestMigrate_StdoutIsCleanDocument(t *testing.T) {
+	stdout, _, err := runMigrate(t, writeV1(t, "milvus:\n  address: milvus-proxy\n"))
+	require.NoError(t, err)
+
+	assert.True(t, len(stdout) > 0)
+	assert.Equal(t, "configVersion: v2", stdout[:len("configVersion: v2")])
+	assert.Contains(t, stdout, "address: milvus-proxy")
+}
+
+func TestMigrate_Output(t *testing.T) {
+	src := writeV1(t, "milvus:\n  address: milvus-proxy\n")
+	out := filepath.Join(t.TempDir(), "v2.yaml")
+
+	t.Run("WritesFile", func(t *testing.T) {
+		stdout, stderr, err := runMigrate(t, src, "--output", out)
+		require.NoError(t, err)
+
+		assert.Empty(t, stdout)
+		assert.Contains(t, stderr, "wrote v2 config to")
+
+		data, err := os.ReadFile(out)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "configVersion: v2")
+	})
+
+	t.Run("RefusesToOverwriteWithoutForce", func(t *testing.T) {
+		_, _, err := runMigrate(t, src, "--output", out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("ForceOverwrites", func(t *testing.T) {
+		_, _, err := runMigrate(t, src, "--output", out, "--force")
+		require.NoError(t, err)
+	})
+}
+
+// Migrating a file that is already v2 is a mistake, not a no-op reload.
+func TestMigrate_RejectsV2Input(t *testing.T) {
+	src := writeV1(t, "configVersion: v2\nmilvus:\n  grpc:\n    address: milvus-proxy\n")
+
+	_, _, err := runMigrate(t, src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already a v2 config")
+}
+
+// --strict turns a config that cannot be expressed as valid v2 into a failure
+// and writes nothing.
+func TestMigrate_Strict(t *testing.T) {
+	// Azure with explicitly empty credentials (as the shipped azure sample has)
+	// resolves to an invalid v2 config: no account name or key.
+	src := writeV1(t, "minio:\n  storageType: azure\n  accessKeyID: \"\"\n  secretAccessKey: \"\"\n")
+	out := filepath.Join(t.TempDir(), "v2.yaml")
+
+	_, _, err := runMigrate(t, src, "--strict", "--output", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--strict")
+
+	_, statErr := os.Stat(out)
+	assert.True(t, os.IsNotExist(statErr), "no file should be written on a strict failure")
+}

--- a/internal/cfg/migrate/migrate.go
+++ b/internal/cfg/migrate/migrate.go
@@ -1,0 +1,354 @@
+// Package migrate translates a resolved v1 configuration into a v2
+// configuration plus a report of everything that needs a human's attention.
+//
+// Migration renames configuration keys and environment variables; it does not
+// relocate values between mechanisms. A value the operator keeps in an
+// environment variable stays there: the v2 file records the v2 variable name to
+// set rather than baking the secret into the file.
+package migrate
+
+import (
+	"os"
+	"strings"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+// Migrate maps a resolved v1 configuration into a complete v2 configuration and
+// a report. The returned config always renders; the report carries the
+// warnings, the embedded comments, the environment renames, and any validation
+// problems (via Report.Err) that --strict promotes to a failure.
+func Migrate(src *cfg.Config) (*v2.Config, *Report) {
+	out := v2.New()
+	// Start from a fully defaulted baseline so the fields with no v1 source
+	// report as defaulted, which the v2 validator relies on to tell an
+	// inapplicable credential from one left unset.
+	param.Defaults(out)
+	r := newReport()
+
+	migrateLog(src, out)
+	migrateServer(src, out, r)
+	migrateMilvus(src, out, r)
+	migrateStorage(&src.Minio, out, r)
+	migrateConcurrency(src, out)
+	migrateTransfer(src, out, r)
+	migrateCloud(src, out, r)
+
+	scanLegacyEnv(src, r)
+	r.recordValidation(out.Validate())
+
+	return out, r
+}
+
+func migrateLog(src *cfg.Config, out *v2.Config) {
+	out.Log.Level.Val = src.Log.Level.Val
+	out.Log.Console.Val = src.Log.Console.Val
+	out.Log.File.Path.Val = src.Log.File.Filename.Val
+	out.Log.File.MaxSizeMiB.Val = src.Log.File.MaxSize.Val
+	out.Log.File.MaxDays.Val = src.Log.File.MaxDays.Val
+	out.Log.File.MaxBackups.Val = src.Log.File.MaxBackups.Val
+}
+
+func migrateServer(src *cfg.Config, out *v2.Config, r *Report) {
+	out.Server.DebugMode.Val = src.HTTP.DebugMode.Val
+	out.Server.SwaggerBasePath.Val = src.HTTP.SwaggerBasePath.Val
+
+	// http.enabled has no v2 replacement: the API server is always available.
+	if !src.HTTP.Enabled.Val {
+		r.warnf("http.enabled=false was dropped in v2; the API server is always enabled")
+	}
+}
+
+func migrateMilvus(src *cfg.Config, out *v2.Config, r *Report) {
+	m := &src.Milvus
+
+	out.Milvus.User.Val = m.User.Val
+	mapSecret(&out.Milvus.Password, &m.Password, "MILVUS_PASSWORD", r)
+
+	out.Milvus.Grpc.Address.Val = m.Address.Val
+	out.Milvus.Grpc.Port.Val = m.Port.Val
+	out.Milvus.Grpc.TLSMode.Val = tlsMode(m, r)
+	out.Milvus.Grpc.CACertPath.Val = m.CACertPath.Val
+	out.Milvus.Grpc.ServerName.Val = m.ServerName.Val
+	out.Milvus.Grpc.MTLSCertPath.Val = m.MTLSCertPath.Val
+	out.Milvus.Grpc.MTLSKeyPath.Val = m.MTLSKeyPath.Val
+
+	// There is no v1 REST endpoint: v1 derived it from the gRPC connection.
+	out.Milvus.Rest.Endpoint.Val = out.Milvus.Rest.Endpoint.Default
+
+	out.Milvus.Management.Endpoint.Val = src.Backup.GCPause.Address.Val
+	out.Milvus.Replicate.RPCChannelName.Val = m.RPCChannelName.Val
+
+	out.Milvus.Etcd.Endpoints.Val = splitList(m.Etcd.Endpoints.Val)
+	out.Milvus.Etcd.RootPath.Val = m.Etcd.RootPath.Val
+}
+
+// tlsMode maps the v1 integer TLS mode to its v2 name. v1 silently downgraded
+// mutual TLS to server TLS when no client key pair was configured; v2 rejects
+// it, so the downgrade is settled here to keep the output loadable.
+func tlsMode(m *cfg.MilvusConfig, r *Report) string {
+	switch m.TLSMode.Val {
+	case 0:
+		return v2.TLSDisabled
+	case 1:
+		return v2.TLSServer
+	case 2:
+		if m.MTLSCertPath.Val == "" || m.MTLSKeyPath.Val == "" {
+			r.warnf("milvus.tlsMode=2 (mutual) but no client certificate/key is set; v1 used server TLS, migrated as %q", v2.TLSServer)
+			r.commentKey("milvus.grpc.tlsMode", "v1 tlsMode 2 without an mTLS key pair; downgraded to server (v1 behavior)")
+			return v2.TLSServer
+		}
+		return v2.TLSMutual
+	default:
+		r.warnf("milvus.tlsMode=%d is not a valid v1 TLS mode; migrated as %q", m.TLSMode.Val, v2.TLSDisabled)
+		return v2.TLSDisabled
+	}
+}
+
+// storageV1 gathers one v1 storage side (the Milvus deployment storage or the
+// backup destination) into the shape migrateStorageSide maps from. The
+// credential fields are pointers so their source (file, env, default) can be
+// inspected.
+type storageV1 struct {
+	provider string
+	address  string
+	port     int
+	region   string
+	useSSL   bool
+	bucket   string
+	rootPath string
+
+	accessKeyID       string
+	secretAccessKey   *cfg.Value[string]
+	sessionToken      *cfg.Value[string]
+	gcpCredentialJSON *cfg.Value[string]
+	useIAM            bool
+	iamEndpoint       string
+}
+
+func migrateStorage(m *cfg.MinioConfig, out *v2.Config, r *Report) {
+	migrateStorageSide(&out.Milvus.Storage, storageV1{
+		provider:          m.StorageType.Val,
+		address:           m.Address.Val,
+		port:              m.Port.Val,
+		region:            m.Region.Val,
+		useSSL:            m.UseSSL.Val,
+		bucket:            m.BucketName.Val,
+		rootPath:          m.RootPath.Val,
+		accessKeyID:       m.AccessKeyID.Val,
+		secretAccessKey:   &m.SecretAccessKey,
+		sessionToken:      &m.Token,
+		gcpCredentialJSON: &m.GcpCredentialJSON,
+		useIAM:            m.UseIAM.Val,
+		iamEndpoint:       m.IAMEndpoint.Val,
+	}, "milvus", r)
+
+	migrateStorageSide(&out.Backup.Storage, storageV1{
+		provider:    m.BackupStorageType.Val,
+		address:     m.BackupAddress.Val,
+		port:        m.BackupPort.Val,
+		region:      m.BackupRegion.Val,
+		useSSL:      m.BackupUseSSL.Val,
+		bucket:      m.BackupBucketName.Val,
+		rootPath:    m.BackupRootPath.Val,
+		accessKeyID: m.BackupAccessKeyID.Val,
+		// An unset backup secret inherits the primary storage secret in v1, so
+		// its true origin — including "came from an environment variable" — is
+		// the primary's. gcpCredentialJSON is not inherited, so it stays direct.
+		secretAccessKey:   effective(&m.BackupSecretAccessKey, &m.SecretAccessKey),
+		sessionToken:      effective(&m.BackupToken, &m.Token),
+		gcpCredentialJSON: &m.BackupGcpCredentialJSON,
+		useIAM:            m.BackupUseIAM.Val,
+		iamEndpoint:       m.BackupIAMEndpoint.Val,
+	}, "backup", r)
+
+	// v1 let an unset backup root path inherit a customized Milvus storage root
+	// path, putting backup data under the Milvus root. v2 keeps them
+	// independent; the migration preserves the v1 location by writing it out
+	// explicitly, and flags the case an operator is most likely to be surprised
+	// by: a custom milvus root path silently adopted for backups.
+	if m.BackupRootPath.Used.Kind == param.SourceDefault && m.RootPath.Used.Kind != param.SourceDefault {
+		r.warnf("backup root path %q was inherited from the milvus storage root path in v1; v2 keeps them independent and now sets it explicitly", m.BackupRootPath.Val)
+	}
+}
+
+func migrateStorageSide(out *v2.StorageConfig, in storageV1, side string, r *Report) {
+	provider := canonicalProvider(in.provider)
+	out.Provider.Val = provider
+	out.Address.Val = in.address
+	out.Port.Val = in.port
+	out.Region.Val = in.region
+	out.UseSSL.Val = in.useSSL
+	out.BucketName.Val = in.bucket
+	out.RootPath.Val = in.rootPath
+
+	switch {
+	case provider == v2.ProviderLocal:
+		// Local storage is a directory: no endpoint, no credentials.
+	case provider == v2.ProviderAzure:
+		// v1 overloaded the access key ID as the Azure account name.
+		out.AccountName.Val = in.accessKeyID
+		out.Auth.Type.Val = v2.AuthSharedKey
+		mapSecret(&out.Auth.AccountKey, in.secretAccessKey, storageEnv(side, "AUTH_ACCOUNT_KEY"), r)
+	case provider == v2.ProviderGCPNative:
+		out.Auth.Type.Val = v2.AuthServiceAccount
+		mapSecret(&out.Auth.CredentialsFile, in.gcpCredentialJSON, storageEnv(side, "AUTH_CREDENTIALS_FILE"), r)
+		r.warnf("%s.auth.credentialsFile expects a path to the service account JSON file; verify it is not inline JSON", storagePrefix(side))
+	case in.useIAM:
+		out.Auth.Type.Val = v2.AuthIAM
+		out.Auth.Endpoint.Val = in.iamEndpoint
+	default:
+		out.Auth.Type.Val = v2.AuthStatic
+		out.Auth.AccessKeyID.Val = in.accessKeyID
+		mapSecret(&out.Auth.SecretAccessKey, in.secretAccessKey, storageEnv(side, "AUTH_SECRET_ACCESS_KEY"), r)
+		mapSecret(&out.Auth.SessionToken, in.sessionToken, storageEnv(side, "AUTH_SESSION_TOKEN"), r)
+	}
+}
+
+func migrateConcurrency(src *cfg.Config, out *v2.Config) {
+	p := &src.Backup.Parallelism
+	out.Backup.Concurrency.Collections.Val = p.BackupCollection.Val
+	out.Backup.Concurrency.Segments.Val = p.BackupSegment.Val
+	out.Backup.PauseGC.Val = src.Backup.GCPause.Enable.Val
+
+	out.Restore.Concurrency.Collections.Val = p.RestoreCollection.Val
+	out.Restore.Concurrency.ImportJobs.Val = p.ImportJob.Val
+	out.Restore.KeepTempFiles.Val = src.Backup.KeepTempFiles.Val
+}
+
+func migrateTransfer(src *cfg.Config, out *v2.Config, r *Report) {
+	if src.Minio.CrossStorage.Val {
+		out.Transfer.Mode.Val = v2.TransferStreaming
+	} else {
+		out.Transfer.Mode.Val = v2.TransferAuto
+		r.commentKey("transfer.mode", "v1 minio.crossStorage=false mapped to auto")
+		// auto only diverges from v1 when the two backends differ: for the same
+		// backend both do a storage-side copy, so warning then would be noise.
+		if !sameBackend(&out.Milvus.Storage, &out.Backup.Storage) {
+			r.warnf("minio.crossStorage=false mapped to transfer.mode=auto, but milvus and backup storage differ; auto streams between them where v1 could attempt direct copy — verify this is intended")
+		}
+	}
+
+	out.Transfer.Concurrency.Val = src.Backup.Parallelism.CopyData.Val
+	out.Transfer.MultipartCopyThresholdMiB.Val = src.Minio.MultipartCopyThresholdMiB.Val
+}
+
+// sameBackend reports whether two storage configs name the same backend, i.e.
+// the same provider reached at the same endpoint. Buckets and root paths may
+// differ within one backend.
+func sameBackend(a, b *v2.StorageConfig) bool {
+	return a.Provider.Val == b.Provider.Val &&
+		a.Address.Val == b.Address.Val &&
+		a.Port.Val == b.Port.Val &&
+		a.Region.Val == b.Region.Val &&
+		a.UseSSL.Val == b.UseSSL.Val &&
+		a.AccountName.Val == b.AccountName.Val
+}
+
+func migrateCloud(src *cfg.Config, out *v2.Config, r *Report) {
+	out.Cloud.Endpoint.Val = src.Cloud.Address.Val
+	mapSecret(&out.Cloud.APIKey, &src.Cloud.APIKey, "ZILLIZ_CLOUD_API_KEY", r)
+}
+
+// effective returns the field whose source decides how a v1 backup secret is
+// migrated. An unset backup secret inherits the primary storage secret in v1,
+// so a secret that reached the backup side only by inheriting an env-supplied
+// primary is still treated as env-supplied, not written into the file.
+func effective(field, primary *cfg.Value[string]) *cfg.Value[string] {
+	if field.Used.Kind == param.SourceDefault {
+		return primary
+	}
+
+	return field
+}
+
+// mapSecret copies a v1 secret into a v2 field, unless the v1 value came from an
+// environment variable: then it leaves the v2 field at its default and records
+// that the secret must be supplied through the v2 variable instead of being
+// written into the file.
+func mapSecret(out, in *cfg.Value[string], v2env string, r *Report) {
+	if in.Used.Kind == param.SourceEnv {
+		r.comment(out, "set via env "+v2env)
+		r.deferToEnv(out)
+		r.warnf("%s is supplied via environment variable %s in v1; set %s in your v2 deployment (its value was not written to the file)",
+			configKey(out), strings.ToUpper(in.Used.Key), v2env)
+		return
+	}
+	out.Val = in.Val
+}
+
+// scanLegacyEnv reports the v1 environment variables that are set in the current
+// environment and were renamed in v2, so a deployment carrying them over does
+// not silently lose the value (the v2 loader does not read v1 variables).
+func scanLegacyEnv(src *cfg.Config, r *Report) {
+	seen := make(map[string]bool)
+	param.Walk(src, func(_ string, f param.Field) {
+		for _, env := range f.EnvNames() {
+			if seen[env] {
+				continue
+			}
+			seen[env] = true
+			if _, ok := os.LookupEnv(env); !ok {
+				continue
+			}
+			if to, legacy := v2.Migration(env); legacy {
+				r.EnvRenames = append(r.EnvRenames, EnvRename{From: env, To: to})
+			}
+		}
+	})
+}
+
+// canonicalProvider folds the v1 provider spelling aliases into the single v2
+// name for each provider.
+func canonicalProvider(p string) string {
+	switch strings.ToLower(p) {
+	case cfg.CloudProviderAli, cfg.CloudProviderAlibaba, cfg.CloudProviderAliCloud, cfg.CloudProviderAliyun:
+		return v2.ProviderAliyun
+	case cfg.CloudProviderTencentShort, cfg.CloudProviderTencent:
+		return v2.ProviderTencent
+	default:
+		return strings.ToLower(p)
+	}
+}
+
+// splitList turns the v1 comma-separated endpoint string into the v2 list form,
+// dropping blanks so "a, b," yields [a b].
+func splitList(s string) []string {
+	items := make([]string, 0, strings.Count(s, ",")+1)
+	for item := range strings.SplitSeq(s, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+
+	return items
+}
+
+// storagePrefix is the v2 config key prefix of one storage side.
+func storagePrefix(side string) string {
+	if side == "backup" {
+		return "backup.storage"
+	}
+
+	return "milvus.storage"
+}
+
+// storageEnv builds the v2 environment variable name for a storage credential,
+// e.g. MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY or BACKUP_STORAGE_AUTH_ACCOUNT_KEY.
+func storageEnv(side, suffix string) string {
+	if side == "backup" {
+		return "BACKUP_STORAGE_" + suffix
+	}
+
+	return "MILVUS_STORAGE_" + suffix
+}
+
+func configKey(f param.Field) string {
+	if keys := f.ConfigKeys(); len(keys) > 0 {
+		return keys[0]
+	}
+
+	return ""
+}

--- a/internal/cfg/migrate/migrate_test.go
+++ b/internal/cfg/migrate/migrate_test.go
@@ -1,0 +1,310 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+// loadV1 writes content to a temp file and resolves it with the v1 loader, so a
+// test starts from the same resolved config the application would.
+func loadV1(t *testing.T, content string) *cfg.Config {
+	t.Helper()
+
+	p := filepath.Join(t.TempDir(), "backup.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+
+	c, err := cfg.Load(p, nil)
+	require.NoError(t, err)
+
+	return c
+}
+
+func TestMigrate_RenamedKeys(t *testing.T) {
+	src := loadV1(t, `
+milvus:
+  address: milvus-proxy
+  port: 19531
+  user: root
+  rpcChannelName: my-replicate
+  etcd:
+    endpoints: etcd-0:2379,etcd-1:2379
+    rootPath: my-root
+http:
+  debugMode: true
+  swaggerBasePath: /backup
+cloud:
+  address: https://api.example.com
+log:
+  file:
+    filename: /var/log/backup.log
+    maxSize: 100
+backup:
+  gcPause:
+    enable: false
+    address: http://datacoord:9091
+  parallelism:
+    backupCollection: 8
+    backupSegment: 512
+    restoreCollection: 3
+    importJob: 64
+    copydata: 32
+`)
+
+	out, _ := Migrate(src)
+
+	assert.Equal(t, "milvus-proxy", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
+	assert.Equal(t, "root", out.Milvus.User.Val)
+	assert.Equal(t, "my-replicate", out.Milvus.Replicate.RPCChannelName.Val)
+	assert.Equal(t, []string{"etcd-0:2379", "etcd-1:2379"}, out.Milvus.Etcd.Endpoints.Val)
+	assert.Equal(t, "my-root", out.Milvus.Etcd.RootPath.Val)
+
+	assert.True(t, out.Server.DebugMode.Val)
+	assert.Equal(t, "/backup", out.Server.SwaggerBasePath.Val)
+	assert.Equal(t, "https://api.example.com", out.Cloud.Endpoint.Val)
+	assert.Equal(t, "/var/log/backup.log", out.Log.File.Path.Val)
+	assert.Equal(t, 100, out.Log.File.MaxSizeMiB.Val)
+
+	// backup.gcPause.address is a management endpoint, not a GC-only knob.
+	assert.Equal(t, "http://datacoord:9091", out.Milvus.Management.Endpoint.Val)
+	assert.False(t, out.Backup.PauseGC.Val)
+
+	assert.Equal(t, 8, out.Backup.Concurrency.Collections.Val)
+	assert.Equal(t, 512, out.Backup.Concurrency.Segments.Val)
+	assert.Equal(t, 3, out.Restore.Concurrency.Collections.Val)
+	assert.Equal(t, 64, out.Restore.Concurrency.ImportJobs.Val)
+	assert.Equal(t, 32, out.Transfer.Concurrency.Val)
+}
+
+func TestMigrate_TLSMode(t *testing.T) {
+	t.Run("Disabled", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "milvus:\n  tlsMode: 0\n"))
+		assert.Equal(t, v2.TLSDisabled, out.Milvus.Grpc.TLSMode.Val)
+	})
+
+	t.Run("Server", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "milvus:\n  tlsMode: 1\n"))
+		assert.Equal(t, v2.TLSServer, out.Milvus.Grpc.TLSMode.Val)
+	})
+
+	t.Run("Mutual", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "milvus:\n  tlsMode: 2\n  mtlsCertPath: /c.pem\n  mtlsKeyPath: /c.key\n"))
+		assert.Equal(t, v2.TLSMutual, out.Milvus.Grpc.TLSMode.Val)
+	})
+
+	// v1 silently downgraded mutual TLS to server TLS without a key pair. v2
+	// rejects it, so the migrator settles the downgrade and warns.
+	t.Run("MutualWithoutKeyPairDowngrades", func(t *testing.T) {
+		out, report := Migrate(loadV1(t, "milvus:\n  tlsMode: 2\n"))
+		assert.Equal(t, v2.TLSServer, out.Milvus.Grpc.TLSMode.Val)
+		assert.NoError(t, report.Err())
+		require.Len(t, report.Warnings, 1)
+		assert.Contains(t, report.Warnings[0], "mutual")
+	})
+}
+
+func TestMigrate_StorageProviderAlias(t *testing.T) {
+	t.Run("Aliyun", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "minio:\n  storageType: ali\n"))
+		assert.Equal(t, v2.ProviderAliyun, out.Milvus.Storage.Provider.Val)
+	})
+
+	t.Run("Tencent", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "minio:\n  storageType: tc\n"))
+		assert.Equal(t, v2.ProviderTencent, out.Milvus.Storage.Provider.Val)
+	})
+}
+
+func TestMigrate_StorageAuth(t *testing.T) {
+	t.Run("Static", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: s3
+  accessKeyID: ak
+  secretAccessKey: sk
+  token: tok
+`))
+		s := out.Milvus.Storage
+		assert.Equal(t, v2.AuthStatic, s.Auth.Type.Val)
+		assert.Equal(t, "ak", s.Auth.AccessKeyID.Val)
+		assert.Equal(t, "sk", s.Auth.SecretAccessKey.Val)
+		assert.Equal(t, "tok", s.Auth.SessionToken.Val)
+	})
+
+	// v1 overloaded accessKeyID as the Azure account name and secretAccessKey
+	// as the account key.
+	t.Run("Azure", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: azure
+  accessKeyID: myaccount
+  secretAccessKey: mykey
+  bucketName: mycontainer
+`))
+		s := out.Milvus.Storage
+		assert.Equal(t, v2.ProviderAzure, s.Provider.Val)
+		assert.Equal(t, "myaccount", s.AccountName.Val)
+		assert.Equal(t, "mycontainer", s.BucketName.Val)
+		assert.Equal(t, v2.AuthSharedKey, s.Auth.Type.Val)
+		assert.Equal(t, "mykey", s.Auth.AccountKey.Val)
+	})
+
+	t.Run("GCPNative", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: gcpnative
+  gcpCredentialJSON: /creds.json
+`))
+		s := out.Milvus.Storage
+		assert.Equal(t, v2.AuthServiceAccount, s.Auth.Type.Val)
+		assert.Equal(t, "/creds.json", s.Auth.CredentialsFile.Val)
+	})
+
+	t.Run("IAM", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: aws
+  useIAM: true
+  iamEndpoint: http://iam.local
+`))
+		s := out.Milvus.Storage
+		assert.Equal(t, v2.AuthIAM, s.Auth.Type.Val)
+		assert.Equal(t, "http://iam.local", s.Auth.Endpoint.Val)
+	})
+}
+
+// A backup destination that only names what differs still describes a complete
+// backend, since v1 inherited the rest from the Milvus storage.
+func TestMigrate_BackupStorageInheritance(t *testing.T) {
+	out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: s3
+  address: s3.amazonaws.com
+  port: 443
+  useSSL: true
+  accessKeyID: ak
+  secretAccessKey: sk
+  backupBucketName: backup-bucket
+`))
+
+	assert.Equal(t, v2.ProviderS3, out.Backup.Storage.Provider.Val)
+	assert.Equal(t, "s3.amazonaws.com", out.Backup.Storage.Address.Val)
+	assert.True(t, out.Backup.Storage.UseSSL.Val)
+	assert.Equal(t, "ak", out.Backup.Storage.Auth.AccessKeyID.Val)
+	assert.Equal(t, "backup-bucket", out.Backup.Storage.BucketName.Val)
+}
+
+func TestMigrate_CrossStorage(t *testing.T) {
+	t.Run("TrueStreams", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "minio:\n  crossStorage: true\n"))
+		assert.Equal(t, v2.TransferStreaming, out.Transfer.Mode.Val)
+	})
+
+	t.Run("FalseAuto", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, "minio:\n  crossStorage: false\n"))
+		assert.Equal(t, v2.TransferAuto, out.Transfer.Mode.Val)
+	})
+
+	// The behavior change only matters when the two backends differ.
+	t.Run("WarnsOnlyWhenBackendsDiffer", func(t *testing.T) {
+		same, report := Migrate(loadV1(t, "minio:\n  crossStorage: false\n"))
+		assert.Empty(t, report.Warnings)
+		assert.Equal(t, v2.TransferAuto, same.Transfer.Mode.Val)
+
+		_, report = Migrate(loadV1(t, `
+minio:
+  crossStorage: false
+  address: milvus-minio
+  backupAddress: backup-s3
+`))
+		require.Len(t, report.Warnings, 1)
+		assert.Contains(t, report.Warnings[0], "crossStorage")
+	})
+}
+
+func TestMigrate_DroppedHTTPEnabled(t *testing.T) {
+	_, report := Migrate(loadV1(t, "http:\n  enabled: false\n"))
+	require.Len(t, report.Warnings, 1)
+	assert.Contains(t, report.Warnings[0], "http.enabled")
+}
+
+// A secret kept in a v1 environment variable is not written into the file: the
+// v2 field stays at its default and the report names the v2 variable to set.
+func TestMigrate_EnvSecretDeferred(t *testing.T) {
+	t.Setenv("MINIO_SECRET_KEY", "supersecret")
+
+	out, report := Migrate(loadV1(t, "minio:\n  storageType: s3\n  accessKeyID: ak\n"))
+
+	assert.NotEqual(t, "supersecret", out.Milvus.Storage.Auth.SecretAccessKey.Val)
+	assert.Contains(t, report.Comments["milvus.storage.auth.secretaccesskey"], "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY")
+	assert.NoError(t, report.Err()) // the empty required secret is expected, not an error
+
+	var warned bool
+	for _, w := range report.Warnings {
+		if strings.Contains(w, "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY") {
+			warned = true
+		}
+	}
+	assert.True(t, warned, "expected a warning naming the v2 env var")
+}
+
+// The backup storage secret inherits the primary secret in v1. When the primary
+// came from an environment variable, the inherited backup secret must not be
+// written into the file either.
+func TestMigrate_InheritedEnvSecretNotLeaked(t *testing.T) {
+	t.Setenv("MINIO_SECRET_KEY", "supersecret")
+
+	out, report := Migrate(loadV1(t, `
+minio:
+  storageType: s3
+  accessKeyID: ak
+  backupBucketName: backups
+`))
+
+	assert.NotEqual(t, "supersecret", out.Milvus.Storage.Auth.SecretAccessKey.Val)
+	assert.NotEqual(t, "supersecret", out.Backup.Storage.Auth.SecretAccessKey.Val)
+	assert.Contains(t, report.Comments["backup.storage.auth.secretaccesskey"], "BACKUP_STORAGE_AUTH_SECRET_ACCESS_KEY")
+}
+
+func TestMigrate_LegacyEnvReport(t *testing.T) {
+	t.Setenv("MILVUS_ADDRESS", "milvus-proxy")
+
+	_, report := Migrate(loadV1(t, "milvus:\n  user: root\n"))
+
+	require.Len(t, report.EnvRenames, 1)
+	assert.Equal(t, "MILVUS_ADDRESS", report.EnvRenames[0].From)
+	assert.Contains(t, report.EnvRenames[0].To, "MILVUS_GRPC_ADDRESS")
+}
+
+// Migrating then rendering must produce a file the v2 loader accepts.
+func TestMigrate_RendersLoadableV2(t *testing.T) {
+	out, report := Migrate(loadV1(t, `
+minio:
+  storageType: s3
+  address: s3.amazonaws.com
+  port: 443
+  useSSL: true
+  accessKeyID: ak
+  secretAccessKey: sk
+`))
+	require.NoError(t, report.Err())
+
+	data, err := v2.Render(out, report.Comments)
+	require.NoError(t, err)
+
+	p := filepath.Join(t.TempDir(), "v2.yaml")
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+
+	loaded, err := v2.Load(p, nil)
+	require.NoError(t, err)
+	assert.Equal(t, v2.ProviderS3, loaded.Milvus.Storage.Provider.Val)
+	assert.Equal(t, "ak", loaded.Milvus.Storage.Auth.AccessKeyID.Val)
+}

--- a/internal/cfg/migrate/report.go
+++ b/internal/cfg/migrate/report.go
@@ -1,0 +1,126 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// Report collects everything about a migration a human should see: warnings
+// about values that changed meaning, the per-field comments embedded in the
+// output file, the validation problems the migrated config still has, and the
+// v1 environment variables that need renaming.
+type Report struct {
+	// Comments maps a lower-cased v2 config key to the head comment Render
+	// writes above it.
+	Comments map[string]string
+
+	Warnings    []string
+	EnvRenames  []EnvRename
+	validations []error
+
+	// deferred is the set of lower-cased config keys whose value was left in an
+	// environment variable, so validation must not treat their emptiness in the
+	// file as a mistake.
+	deferred map[string]bool
+}
+
+// EnvRename names a v1 environment variable found set in the environment and
+// the v2 variable that replaces it. To may name more than one option when the
+// replacement depends on the storage provider.
+type EnvRename struct {
+	From string
+	To   string
+}
+
+func newReport() *Report {
+	return &Report{Comments: map[string]string{}, deferred: map[string]bool{}}
+}
+
+func (r *Report) warnf(format string, args ...any) {
+	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
+}
+
+// comment records a head comment for a v2 field, keyed by its config key.
+func (r *Report) comment(f param.Field, text string) {
+	if keys := f.ConfigKeys(); len(keys) > 0 {
+		r.Comments[strings.ToLower(keys[0])] = text
+	}
+}
+
+// commentKey records a head comment for a v2 field named directly by its
+// config key, for callers that do not hold the field.
+func (r *Report) commentKey(key, text string) {
+	r.Comments[strings.ToLower(key)] = text
+}
+
+// deferToEnv marks a field as supplied through an environment variable, so its
+// empty value in the file is expected rather than a validation error.
+func (r *Report) deferToEnv(f param.Field) {
+	if keys := f.ConfigKeys(); len(keys) > 0 {
+		r.deferred[strings.ToLower(keys[0])] = true
+	}
+}
+
+// recordValidation runs the v2 validator over the migrated config and keeps
+// every problem except those on fields whose value the operator deliberately
+// left in an environment variable, which are empty in the file on purpose.
+func (r *Report) recordValidation(err error) {
+	if err == nil {
+		return
+	}
+
+	var joined interface{ Unwrap() []error }
+	if !errors.As(err, &joined) {
+		if !r.isEnvDeferred(err) {
+			r.validations = append(r.validations, err)
+		}
+		return
+	}
+	for _, e := range joined.Unwrap() {
+		r.recordValidation(e)
+	}
+}
+
+// isEnvDeferred reports whether a validation error is about a field the
+// migration moved to an environment variable, which is expected to be empty.
+func (r *Report) isEnvDeferred(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for key := range r.deferred {
+		if strings.Contains(msg, key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Err returns the migrated config's validation problems joined together, or nil
+// when it is valid v2. --strict turns this into a hard failure.
+func (r *Report) Err() error { return errors.Join(r.validations...) }
+
+// WriteTo prints the report to w. srcPath names the file that was migrated. It
+// writes nothing when there is nothing to say.
+func (r *Report) WriteTo(w io.Writer, srcPath string) {
+	if len(r.Warnings) == 0 && len(r.validations) == 0 && len(r.EnvRenames) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "# migration report for %s\n", srcPath)
+	for _, warn := range r.Warnings {
+		fmt.Fprintf(w, "warning: %s\n", warn)
+	}
+	for _, e := range r.validations {
+		fmt.Fprintf(w, "warning: migrated config is not valid v2: %s\n", e)
+	}
+
+	if len(r.EnvRenames) > 0 {
+		fmt.Fprintln(w, "v1 environment variables are set but inert under a v2 config, rename them:")
+		for _, er := range r.EnvRenames {
+			fmt.Fprintf(w, "  %s -> %s\n", er.From, er.To)
+		}
+	}
+}

--- a/internal/cfg/param/entry.go
+++ b/internal/cfg/param/entry.go
@@ -39,6 +39,15 @@ type Field interface {
 	Display(name string) Entry
 	ConfigKeys() []string
 	EnvNames() []string
+
+	// YAMLValue returns the resolved value as a Go value ready to be marshaled
+	// back to a YAML config file. Unlike Display it never masks secrets, since
+	// the rendered file must hold the value that actually resolves.
+	YAMLValue() any
+
+	// UseDefault sets the value to its declared default with a default source,
+	// without consulting any external source.
+	UseDefault()
 }
 
 func maskSecret(s string) string {
@@ -86,6 +95,14 @@ func Entries(cfg any) []Entry {
 	Walk(cfg, func(name string, field Field) { entries = append(entries, field.Display(name)) })
 
 	return entries
+}
+
+// Defaults sets every parameter of cfg to its declared default, without
+// consulting any external source. A caller that then populates only some fields
+// (such as a config migration) still starts from a fully resolved baseline, so
+// the fields it leaves alone report as defaulted rather than as unset.
+func Defaults(cfg any) {
+	Walk(cfg, func(_ string, field Field) { field.UseDefault() })
 }
 
 // DeclaredKeys returns every config file key and environment variable name the

--- a/internal/cfg/param/list.go
+++ b/internal/cfg/param/list.go
@@ -34,6 +34,12 @@ func (l *List) Display(name string) Entry {
 
 func (l *List) ConfigKeys() []string { return l.Keys }
 func (l *List) EnvNames() []string   { return l.EnvKeys }
+func (l *List) YAMLValue() any       { return l.Val }
+
+func (l *List) UseDefault() {
+	l.Val = slices.Clone(l.Default)
+	l.Used = Used{Kind: SourceDefault}
+}
 
 func (l *List) IsDefault() bool { return l.Used.Kind == SourceDefault }
 

--- a/internal/cfg/param/value.go
+++ b/internal/cfg/param/value.go
@@ -66,6 +66,12 @@ func (val *Value[T]) Display(name string) Entry {
 
 func (val *Value[T]) ConfigKeys() []string { return val.Keys }
 func (val *Value[T]) EnvNames() []string   { return val.EnvKeys }
+func (val *Value[T]) YAMLValue() any       { return val.Val }
+
+func (val *Value[T]) UseDefault() {
+	val.Val = val.Default
+	val.Used = Used{Kind: SourceDefault}
+}
 
 // IsDefault reports whether the value fell back to its default, i.e. no source
 // set it explicitly. Validation uses it to reject fields that do not belong to

--- a/internal/cfg/v2/legacy.go
+++ b/internal/cfg/v2/legacy.go
@@ -120,9 +120,10 @@ var legacyEnvKeys = map[string]string{
 	"backup_gc_pause_address":               "MILVUS_MANAGEMENT_ENDPOINT",
 }
 
-// migration returns what replaced key in v2, and whether key is a known v1
-// name at all. An empty replacement means the key was removed outright.
-func migration(key string) (string, bool) {
+// Migration returns what replaced key in v2, and whether key is a known v1
+// name at all. An empty replacement means the key was removed outright. key is
+// a v1 config file key or environment variable name, matched case-insensitively.
+func Migration(key string) (string, bool) {
 	key = strings.ToLower(key)
 	if to, ok := legacyKeys[key]; ok {
 		return to, true

--- a/internal/cfg/v2/load.go
+++ b/internal/cfg/v2/load.go
@@ -94,7 +94,7 @@ func checkKeys(cfg *Config, src *param.Source) error {
 }
 
 func unknownKeyErr(kind, key string) error {
-	to, isLegacy := migration(key)
+	to, isLegacy := Migration(key)
 	switch {
 	case isLegacy && to == "":
 		return fmt.Errorf("cfg: v1 %s %q was removed in v2", kind, key)

--- a/internal/cfg/v2/render.go
+++ b/internal/cfg/v2/render.go
@@ -1,0 +1,151 @@
+package v2
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// Render serializes a resolved configuration back into a complete v2 YAML file:
+// the configVersion header followed by every parameter written with its
+// resolved value. Secrets are written in the clear, since the output is a
+// working config file rather than a display.
+//
+// comments attaches a head comment to the parameter named by its lower-cased
+// config key (for example "milvus.storage.auth.secretAccessKey"); a nil map
+// writes no comments. Keys are emitted in schema declaration order, so the
+// output reads like the hand-written sample.
+//
+// Render is the inverse of Load over resolved values: loading the output yields
+// a configuration whose values equal the input's.
+func Render(c *Config, comments map[string]string) ([]byte, error) {
+	skip := skippableKeys(c)
+
+	root := &yaml.Node{Kind: yaml.MappingNode}
+	insert(root, []string{VersionKey}, Version, "")
+
+	param.Walk(c, func(_ string, f param.Field) {
+		keys := f.ConfigKeys()
+		if len(keys) == 0 {
+			return
+		}
+		key := strings.ToLower(keys[0])
+		if _, ok := skip[key]; ok {
+			return
+		}
+		insert(root, strings.Split(keys[0], "."), f.YAMLValue(), comments[key])
+	})
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("cfg: render v2 config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("cfg: render v2 config: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// skippableKeys returns the lower-cased config keys Render must omit because
+// the v2 loader would reject them: storage credential fields that do not apply
+// to the selected provider or authentication type. Emitting them, even empty,
+// would fail validation on reload, since a key present in a file resolves as
+// explicitly set rather than defaulted.
+func skippableKeys(c *Config) map[string]struct{} {
+	skip := map[string]struct{}{}
+	for _, s := range []*StorageConfig{&c.Milvus.Storage, &c.Backup.Storage} {
+		for _, key := range s.inapplicableKeys() {
+			skip[strings.ToLower(key)] = struct{}{}
+		}
+	}
+
+	return skip
+}
+
+// inapplicableKeys lists the config keys of this storage config's identity and
+// credential fields that do not apply to its provider and authentication type,
+// mirroring the compatibility rules validate.go enforces.
+func (c *StorageConfig) inapplicableKeys() []string {
+	applies := map[string]bool{}
+	if c.Provider.Val != ProviderLocal {
+		switch c.Auth.Type.Val {
+		case AuthStatic:
+			markKeys(applies, &c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken)
+		case AuthSharedKey:
+			markKeys(applies, &c.Auth.AccountKey)
+		case AuthServiceAccount:
+			markKeys(applies, &c.Auth.CredentialsFile)
+		case AuthIAM:
+			markKeys(applies, &c.Auth.Endpoint)
+		}
+	}
+
+	var skip []string
+	// accountName belongs to the Azure storage identity and nothing else.
+	if c.Provider.Val != ProviderAzure {
+		skip = append(skip, c.AccountName.Keys...)
+	}
+	for _, cred := range []*param.Value[string]{
+		&c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken,
+		&c.Auth.AccountKey, &c.Auth.CredentialsFile, &c.Auth.Endpoint,
+	} {
+		if len(cred.Keys) > 0 && !applies[cred.Keys[0]] {
+			skip = append(skip, cred.Keys[0])
+		}
+	}
+
+	return skip
+}
+
+func markKeys(applies map[string]bool, fields ...*param.Value[string]) {
+	for _, f := range fields {
+		if len(f.Keys) > 0 {
+			applies[f.Keys[0]] = true
+		}
+	}
+}
+
+// insert writes value at the dotted path under root, creating intermediate
+// mapping nodes as needed and preserving the order keys are first seen in.
+func insert(root *yaml.Node, path []string, value any, comment string) {
+	m := root
+	for _, key := range path[:len(path)-1] {
+		m = child(m, key)
+	}
+
+	valNode := &yaml.Node{}
+	if err := valNode.Encode(value); err != nil {
+		// Encoding a scalar or []string never fails in practice; fall back to a
+		// string so a value can never silently vanish from the output.
+		valNode.SetString(fmt.Sprint(value))
+	}
+
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: path[len(path)-1]}
+	if comment != "" {
+		keyNode.HeadComment = comment
+	}
+	m.Content = append(m.Content, keyNode, valNode)
+}
+
+// child returns the mapping node stored under key in m, creating an empty one
+// if it does not exist yet.
+func child(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	valNode := &yaml.Node{Kind: yaml.MappingNode}
+	m.Content = append(m.Content, keyNode, valNode)
+
+	return valNode
+}

--- a/internal/cfg/v2/render_test.go
+++ b/internal/cfg/v2/render_test.go
@@ -1,0 +1,87 @@
+package v2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// values maps each parameter to its displayed value, ignoring the source. A
+// round trip changes the source (an emitted default reloads as coming from the
+// config file), but the value must be preserved.
+func values(c *Config) map[string]string {
+	m := make(map[string]string)
+	for _, e := range c.Entries() {
+		m[e.Name] = e.Value
+	}
+
+	return m
+}
+
+// roundTrip renders c, loads the result back, and returns the reloaded config.
+func roundTrip(t *testing.T, c *Config) *Config {
+	t.Helper()
+
+	data, err := Render(c, nil)
+	require.NoError(t, err)
+
+	p := filepath.Join(t.TempDir(), "rendered.yaml")
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+
+	out, err := Load(p, nil)
+	require.NoError(t, err)
+
+	return out
+}
+
+// Rendering a resolved config and loading the result back must reproduce every
+// value: Render is the inverse of Load over resolved values.
+func TestRender_RoundTrip(t *testing.T) {
+	in, err := Load(filepath.Join("testdata", "complete.yaml"), nil)
+	require.NoError(t, err)
+
+	data, err := Render(in, nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "configVersion: v2")
+
+	p := filepath.Join(t.TempDir(), "rendered.yaml")
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+	out, err := Load(p, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, values(in), values(out))
+}
+
+// Defaults round-trip too: an env-only config renders and loads back to the
+// same values.
+func TestRender_Defaults(t *testing.T) {
+	in, err := Load("", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, values(in), values(roundTrip(t, in)))
+}
+
+func TestRender_Comment(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	data, err := Render(c, map[string]string{"transfer.mode": "note about the mode"})
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "# note about the mode")
+}
+
+// The etcd endpoints render as a YAML list, not the v1 comma-separated string.
+func TestRender_EtcdList(t *testing.T) {
+	c, err := Load(filepath.Join("testdata", "complete.yaml"), nil)
+	require.NoError(t, err)
+
+	data, err := Render(c, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "- etcd-0:2379")
+	assert.Contains(t, string(data), "- etcd-1:2379")
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 )
 
@@ -16,6 +17,8 @@ func String() string {
 	return fmt.Sprintf("%s (Built on %s from Git SHA %s by %s)", Version, Date, Commit, GoVersion)
 }
 
+// Print writes the version banner to stderr. It is a diagnostic, so it stays
+// off stdout where a command may write a machine-consumable document.
 func Print() {
-	fmt.Println(String())
+	fmt.Fprintln(os.Stderr, String())
 }


### PR DESCRIPTION
## Summary

Adds `milvus-backup config migrate`, which reads a v1 configuration file and writes a complete v2 file (the migration step of #1089). Migration renames keys and environment variables rather than relocating values: a secret an operator keeps in a v1 environment variable is left out of the file and reported with the v2 variable to set instead, so nothing secret is written to disk.

The v2 loader added in #1095 already rejects v1 keys with the v2 name that replaced them; this command performs that rewrite automatically, including the value transforms a flat key rename cannot express.

```
$ milvus-backup config migrate --config backup.yaml -o backup-v2.yaml
# the v2 file goes to -o (or stdout); the migration report goes to stderr
```

## Changes

- `cmd/config`: new `config` command group with `migrate`. Reads the v1 file via `--config`, writes v2 to stdout or `--output`; `--force` guards overwrite, `--strict` fails when the result is not valid v2. The report (warnings + env renames) is written to stderr so stdout stays a clean document.
- `internal/cfg/migrate`: maps a resolved v1 config to a v2 config plus a report. Handles the value transforms — `tlsMode` `0/1/2` → `disabled/server/mutual` (mutual without an mTLS pair downgrades to server, as v1 did silently), provider aliases (`ali`/`tc` → `aliyun`/`tencent`), the provider-aware auth reshape (Azure account name/key, GCP service account, IAM), `crossStorage` → `transfer.mode`, and the `http.enabled` drop.
- Secrets in v1 environment variables are deferred, not written: the field keeps a placeholder with an inline comment naming the v2 variable, and the report lists every v1 variable that needs renaming. An unset backup secret that only inherited an env-supplied primary secret is deferred too, so it does not leak into the file.
- `internal/cfg/v2/render.go`: serializes a resolved v2 config back to an ordered YAML file, omitting credential fields that do not apply to the selected provider or auth type so the output loads.
- `internal/cfg/param`: adds `YAMLValue` and `UseDefault`/`Defaults`, used by the renderer and the migration baseline; exports `v2.Migration` for the env rename report.
- Routes the startup version banner and the `config:` line to stderr, so a data-producing command such as `config migrate` keeps stdout a clean document.

## Notes

- Nothing dispatches on `configVersion` yet, so this does not change how the application loads configuration; it only produces v2 files. Version dispatch, `check config`, and the shipped v2 sample are follow-ups.
- `minio.crossStorage: false` maps to `transfer.mode: auto`, which is not behaviour-identical to v1 when the milvus and backup storage differ; the migration warns in that case (per #1089).

Part of #1089

/kind improvement