### PR TITLE
cfg: warn on unknown v2 config keys instead of failing

### DIFF
--- a/internal/cfg/v2/load.go
+++ b/internal/cfg/v2/load.go
@@ -1,17 +1,18 @@
 package v2
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	"github.com/zilliztech/milvus-backup/internal/log"
 )
 
 // Load loads a v2 configuration from yaml + overrides + env.
 //
 // precedence: overrides (--set) > env > config file > default, among the names
-// the v2 schema defines. v1 names are rejected, not aliased.
+// the v2 schema defines. v1 names are not aliased; they are warned about and
+// ignored.
 func Load(configPath string, overrides map[string]string) (*Config, error) {
 	src, err := param.NewSource(configPath, overrides)
 	if err != nil {
@@ -29,10 +30,11 @@ func LoadFrom(src *param.Source) (*Config, error) {
 	if err := checkVersion(src); err != nil {
 		return nil, err
 	}
-	// Reject unknown names before resolving, so a typo is reported as a typo
-	// rather than as whatever the default silently did instead.
-	if err := checkKeys(cfg, src); err != nil {
-		return nil, err
+	// Unknown names are warned about and ignored, not rejected: a stray or
+	// misspelled key should not stop a backup. They are never applied either
+	// way, so resolving proceeds from the declared keys alone.
+	for _, w := range checkKeys(cfg, src) {
+		log.Warn(w)
 	}
 	if err := cfg.Resolve(src); err != nil {
 		return nil, err
@@ -66,17 +68,17 @@ func checkVersion(src *param.Source) error {
 	return nil
 }
 
-// checkKeys rejects every config file key and --set path the v2 schema does
-// not declare, so misspellings and v1 leftovers fail instead of falling back
-// to a default.
-func checkKeys(cfg *Config, src *param.Source) error {
+// checkKeys returns a warning for every config file key and --set path the v2
+// schema does not declare. Unknown names are ignored rather than applied, so a
+// misspelling or v1 leftover is surfaced without stopping the load.
+func checkKeys(cfg *Config, src *param.Source) []string {
 	configKeys, envNames := param.DeclaredKeys(cfg)
 	configKeys[strings.ToLower(VersionKey)] = struct{}{}
 
-	var errs []error
+	var warnings []string
 	for _, key := range src.ConfigFileKeys() {
 		if _, ok := configKeys[key]; !ok {
-			errs = append(errs, unknownKeyErr("config file key", key))
+			warnings = append(warnings, unknownKeyWarning("config file key", key))
 		}
 	}
 
@@ -86,21 +88,21 @@ func checkKeys(cfg *Config, src *param.Source) error {
 		_, isConfigKey := configKeys[strings.ToLower(key)]
 		_, isEnvName := envNames[strings.ToLower(key)]
 		if !isConfigKey && !isEnvName {
-			errs = append(errs, unknownKeyErr("--set key", key))
+			warnings = append(warnings, unknownKeyWarning("--set key", key))
 		}
 	}
 
-	return errors.Join(errs...)
+	return warnings
 }
 
-func unknownKeyErr(kind, key string) error {
+func unknownKeyWarning(kind, key string) string {
 	to, isLegacy := Migration(key)
 	switch {
 	case isLegacy && to == "":
-		return fmt.Errorf("cfg: v1 %s %q was removed in v2", kind, key)
+		return fmt.Sprintf("cfg: v1 %s %q was removed in v2, ignoring it", kind, key)
 	case isLegacy:
-		return fmt.Errorf("cfg: v1 %s %q is not accepted by a v2 config, use %s instead", kind, key, to)
+		return fmt.Sprintf("cfg: v1 %s %q is not accepted by a v2 config, ignoring it; use %s instead", kind, key, to)
 	default:
-		return fmt.Errorf("cfg: unknown v2 %s %q", kind, key)
+		return fmt.Sprintf("cfg: unknown v2 %s %q, ignoring it", kind, key)
 	}
 }

--- a/internal/cfg/v2/load_test.go
+++ b/internal/cfg/v2/load_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
 )
 
 // writeYAML writes content to a temp file and returns its path. header is
@@ -117,44 +119,78 @@ func TestLoad_Version(t *testing.T) {
 	})
 }
 
-func TestLoad_RejectsUnknownKeys(t *testing.T) {
+// checkKeys warns about every unknown key but never fails the load, so the
+// warnings are asserted on its return value rather than on an error.
+func TestCheckKeys(t *testing.T) {
+	cfg := New()
+
+	warningsFor := func(t *testing.T, yaml string, overrides map[string]string) []string {
+		t.Helper()
+
+		var path string
+		if yaml != "" {
+			path = writeYAML(t, yaml)
+		}
+		src, err := param.NewSource(path, overrides)
+		require.NoError(t, err)
+
+		return checkKeys(cfg, src)
+	}
+
 	t.Run("Misspelled", func(t *testing.T) {
-		_, err := Load(writeYAML(t, "milvus:\n  grpc:\n    adress: localhost\n"), nil) //nolint:misspell // the typo is what is under test
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), `unknown v2 config file key "milvus.grpc.adress"`)
+		w := warningsFor(t, "milvus:\n  grpc:\n    adress: localhost\n", nil) //nolint:misspell // the typo is what is under test
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], `unknown v2 config file key "milvus.grpc.adress"`)
+		assert.Contains(t, w[0], "ignoring it")
 	})
 
 	t.Run("V1Key", func(t *testing.T) {
-		_, err := Load(writeYAML(t, "milvus:\n  address: localhost\n"), nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), `v1 config file key "milvus.address"`)
-		assert.Contains(t, err.Error(), "milvus.grpc.address")
+		w := warningsFor(t, "milvus:\n  address: localhost\n", nil)
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], `v1 config file key "milvus.address"`)
+		assert.Contains(t, w[0], "milvus.grpc.address")
 	})
 
 	t.Run("RemovedV1Key", func(t *testing.T) {
-		_, err := Load(writeYAML(t, "http:\n  enabled: true\n"), nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), `"http.enabled" was removed in v2`)
+		w := warningsFor(t, "http:\n  enabled: true\n", nil)
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], `"http.enabled" was removed in v2`)
 	})
 
 	t.Run("EveryUnknownKeyIsReported", func(t *testing.T) {
-		_, err := Load(writeYAML(t, "minio:\n  address: localhost\n  port: 9000\n"), nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "milvus.storage.address")
-		assert.Contains(t, err.Error(), "milvus.storage.port")
+		w := warningsFor(t, "minio:\n  address: localhost\n  port: 9000\n", nil)
+		joined := strings.Join(w, "\n")
+		assert.Contains(t, joined, "milvus.storage.address")
+		assert.Contains(t, joined, "milvus.storage.port")
 	})
 
 	t.Run("V1Override", func(t *testing.T) {
-		_, err := Load("", map[string]string{"MILVUS_ADDRESS": "localhost"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), `v1 --set key "MILVUS_ADDRESS"`)
-		assert.Contains(t, err.Error(), "MILVUS_GRPC_ADDRESS")
+		w := warningsFor(t, "", map[string]string{"MILVUS_ADDRESS": "localhost"})
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], `v1 --set key "MILVUS_ADDRESS"`)
+		assert.Contains(t, w[0], "MILVUS_GRPC_ADDRESS")
 	})
 
 	t.Run("UnknownOverride", func(t *testing.T) {
-		_, err := Load("", map[string]string{"milvus.grpc.hostname": "localhost"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), `unknown v2 --set key "milvus.grpc.hostname"`)
+		w := warningsFor(t, "", map[string]string{"milvus.grpc.hostname": "localhost"})
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], `unknown v2 --set key "milvus.grpc.hostname"`)
+	})
+}
+
+// An unknown key is warned about and then ignored, so loading succeeds and the
+// affected field keeps its default rather than the stray value.
+func TestLoad_UnknownKeysAreIgnored(t *testing.T) {
+	t.Run("MisspelledConfigKey", func(t *testing.T) {
+		c, err := Load(writeYAML(t, "milvus:\n  grpc:\n    adress: 10.0.0.1\n"), nil) //nolint:misspell // the typo is what is under test
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", c.Milvus.Grpc.Address.Val)
+	})
+
+	t.Run("V1Override", func(t *testing.T) {
+		c, err := Load("", map[string]string{"MILVUS_ADDRESS": "10.0.0.1"})
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", c.Milvus.Grpc.Address.Val)
 	})
 }
 


### PR DESCRIPTION
## Summary

The v2 config loader rejected the whole file when it carried an unknown key —
a misspelling, a leftover v1 name, or an extra field. That makes an otherwise
valid config unloadable over a single stray line, which is heavier than the
mistake warrants: unknown keys are never applied anyway, since resolving only
reads declared keys.

This relaxes the unknown-key check from a hard error to a warning. Each unknown
config-file key and `--set` path is logged via `log.Warn` and then ignored, and
loading proceeds. The warning still names the key and, for v1 leftovers, the v2
key to use instead, so the diagnostic is unchanged — only its severity is.

Version detection (`configVersion`) and value validation (port ranges, provider
enums, required credentials, ...) stay hard errors: the former drives v1/v2
dispatch, and the latter would otherwise let an invalid value flow through to a
confusing runtime failure.

## Changes

- `LoadFrom`: log unknown-key warnings and continue instead of aborting the load
- `checkKeys` now returns `[]string` warnings; `unknownKeyErr` becomes
  `unknownKeyWarning` and its messages note the key is being ignored
- Tests: assert the warnings on `checkKeys`'s return value, and add a case that
  an unknown key is ignored so the affected field keeps its default

/kind improvement
