### PR TITLE
config: add config show and deprecate check config

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -64,7 +64,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newConfigCmd(opt))
+	cmd.AddCommand(newConfigCmd())
 
 	return cmd
 }

--- a/cmd/check/config.go
+++ b/cmd/check/config.go
@@ -2,23 +2,20 @@ package check
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/zilliztech/milvus-backup/cmd/root"
 )
 
-func newConfigCmd(opt *root.Options) *cobra.Command {
+// newConfigCmd is the deprecated predecessor of "config show". It stays only to
+// redirect existing callers to the new command and prints nothing else; cobra
+// emits the deprecation notice and hides it from the help listing.
+//
+// TODO: remove this alias in a release after 0.6.0.
+func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Print all configuration parameters with their values and sources",
-		Long: `Print all configuration parameters in a table format showing:
-- Parameter name (config file key)
-- Current value (secrets are masked)
-- Source: where the value came from (override, env, config, default)
-- Source key: the specific key used to set the value`,
-
+		Use:        "config",
+		Short:      `Deprecated: use "config show" instead`,
+		Deprecated: `use "config show" instead; this alias will be removed in a release after 0.6.0`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			params := opt.InitGlobalVars()
-			return params.WriteTable(cmd.OutOrStdout())
+			return nil
 		},
 	}
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -14,6 +14,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 		Short: "inspect and migrate milvus-backup configuration",
 	}
 
+	cmd.AddCommand(newShowCmd(opt))
 	cmd.AddCommand(newMigrateCmd(opt))
 
 	return cmd

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+)
+
+func newShowCmd(opt *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Print all configuration parameters with their values and sources",
+		Long: `Print all configuration parameters in a table format showing:
+- Parameter name (config file key)
+- Current value (secrets are masked)
+- Source: where the value came from (override, env, config, default)
+- Source key: the specific key used to set the value`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params := opt.InitGlobalVars()
+			return params.WriteTable(cmd.OutOrStdout())
+		},
+	}
+
+	return cmd
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -50,7 +50,7 @@ During restore, milvus-backup copies backup data into the bucket specified by `m
 
 **How to fix it?**
 
-Run `./milvus-backup check config` to print the resolved configuration, and make sure `minio.bucketName` matches the bucket that the **target Milvus** is actually using. Run `./milvus-backup check` to verify connectivity.
+Run `./milvus-backup config show` to print the resolved configuration, and make sure `minio.bucketName` matches the bucket that the **target Milvus** is actually using. Run `./milvus-backup check` to verify connectivity.
 
 **Related issues:** [#1026](https://github.com/zilliztech/milvus-backup/issues/1026), [#1006](https://github.com/zilliztech/milvus-backup/issues/1006), [#923](https://github.com/zilliztech/milvus-backup/issues/923), [#895](https://github.com/zilliztech/milvus-backup/issues/895)
 


### PR DESCRIPTION
## Summary

Add a `config show` command that prints the resolved configuration table, and turn the old `check config` into a deprecated alias.

The configuration dump only printed the resolved values — it never connected to anything, so it did not belong under `check` (whose job is verifying connectivity). The `config` group's own description is "inspect and migrate", but until now it only had `migrate`. This wires up the "inspect" half as `config show`.

`check config` is kept as a deprecated stub: running it prints a deprecation notice pointing at `config show` and nothing else, and it is hidden from the `check` help listing. The stub is slated for removal in a release after 0.6.0. The `check` command still prints its effective configuration inline before connecting, so nothing is lost there.

## Changes

- Add `config show`, printing all configuration parameters with their values and sources
- Deprecate `check config`: it now only emits a notice redirecting to `config show` (via cobra's `Deprecated`, which also hides it from help), marked for removal in a release after 0.6.0
- Update `docs/FAQ.md` to reference `config show`

/kind improvement
