### PR TITLE
cmd: clean up command help descriptions

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -28,7 +28,7 @@ func writeConfig(w io.Writer, c *cfg.Config) error {
 func NewCmd(opt *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
-		Short: "check if the connects is right.",
+		Short: "check connectivity to Milvus and object storage",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -9,7 +9,7 @@ import (
 func newShowCmd(opt *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
-		Short: "Print all configuration parameters with their values and sources",
+		Short: "print all configuration parameters with their values and sources",
 		Long: `Print all configuration parameters in a table format showing:
 - Parameter name (config file key)
 - Current value (secrets are masked)

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -272,7 +272,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "create a backup.",
+		Short: "create a backup",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()

--- a/cmd/del/delete.go
+++ b/cmd/del/delete.go
@@ -51,7 +51,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "delete backup by name.",
+		Short: "delete a backup by name",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -66,7 +66,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	var o options
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "get subcommand get backup by name.",
+		Short: "get a backup by name",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()

--- a/cmd/l0compact/l0compact.go
+++ b/cmd/l0compact/l0compact.go
@@ -65,7 +65,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	var o options
 	cmd := &cobra.Command{
 		Use:   "l0compact",
-		Short: "Fold a backup's L0 (delete-only) segments into per-segment deltalogs so it restores without L0 import (writes a full physical copy).",
+		Short: "fold a backup's L0 (delete-only) segments into per-segment deltalogs so it restores without L0 import",
 		Long: "Fold a backup's L0 (delete-only) segments into per-segment deltalogs so it restores without L0 import.\n\n" +
 			"The output is a complete, standalone backup: every insert_log and delta_log object from the source is\n" +
 			"physically copied into the output backup (the source is left untouched). This roughly doubles the\n" +

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -62,7 +62,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	var o options
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Shows all backup in object storage.",
+		Short: "list all backups in object storage",
 
 		Run: func(cmd *cobra.Command, args []string) {
 			params := opt.InitGlobalVars()

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -67,7 +67,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "migrate",
-		Short: "migrate the backup data to zilliz cloud cluster",
+		Short: "migrate backup data to a Zilliz Cloud cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()
 

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -362,8 +362,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	var o options
 	cmd := &cobra.Command{
 		Use:   "restore",
-		Short: "restore a backup",
-		Long:  "restore a backup",
+		Short: "restore a backup into Milvus",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -99,7 +99,7 @@ func newSecondaryCmd(opt *root.Options) *cobra.Command {
 	var o secondaryOption
 	cmd := &cobra.Command{
 		Use:   "secondary",
-		Short: "restore backup to secondary cluster",
+		Short: "restore a backup to a secondary cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -38,8 +38,8 @@ func NewCmd(opt *Options) *cobra.Command {
 			DisableDefaultCmd: true,
 		},
 		Use:   "milvus-backup",
-		Short: "milvus-backup is a backup&restore tool for milvus.",
-		Long:  `milvus-backup is a backup&restore tool for milvus.`,
+		Short: "milvus-backup is a backup & restore tool for Milvus",
+		Long:  `milvus-backup is a backup & restore tool for Milvus.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Printf("execute %s args:%v error:%v\n", cmd.Name(), args, errors.New("unrecognized command"))
 			os.Exit(1)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -66,7 +66,7 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	var o options
 	cmd := &cobra.Command{
 		Use:   "server",
-		Short: "server subcommand start milvus-backup RESTAPI server.",
+		Short: "start the milvus-backup REST API server",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()


### PR DESCRIPTION
## Summary

Sweep every cobra command's `Short`/`Long` for a consistent house style and fix awkward or broken wording. No behavior change — only the help text.

Conventions applied:
- **`Short`**: lowercase start, no trailing period, concise. It sits in the `Available Commands` list next to its siblings, so parallel casing reads as one block.
- **`Long`**: capitalized prose. It renders as a standalone paragraph, so full sentences are correct (unchanged where already good).
- Proper nouns capitalized: `Milvus`, `Zilliz Cloud`, `REST API`.

Notable wording fixes:
- `check`: `check if the connects is right.` → `check connectivity to Milvus and object storage`
- `get`: `get subcommand get backup by name.` → `get a backup by name`
- `server`: `server subcommand start milvus-backup RESTAPI server.` → `start the milvus-backup REST API server`
- `list`: `Shows all backup in object storage.` → `list all backups in object storage`
- `migrate`: `migrate the backup data to zilliz cloud cluster` → `migrate backup data to a Zilliz Cloud cluster`
- `restore`: dropped the `Long` that just duplicated `Short`; `Short` → `restore a backup into Milvus`
- `root`: `backup&restore tool for milvus` → `backup & restore tool for Milvus`

## Changes

- Lowercase every `Short`, drop trailing periods, and remove redundant "subcommand" phrasing
- Fix grammar/typos and capitalize proper nouns across all `cmd/*` commands
- Remove the `restore` `Long` that duplicated its `Short`

/kind improvement
