### PR TITLE
test: use testify assertions in l0compact tests

### DIFF
--- a/cmd/l0compact/l0compact_test.go
+++ b/cmd/l0compact/l0compact_test.go
@@ -1,29 +1,23 @@
 package l0compact
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestValidateRejectsBadNames(t *testing.T) {
 	// --output that would escape or nest outside a normal backup dir.
 	for _, bad := range []string{"../victim", "a/b", "..", "/abs", ".hidden"} {
 		o := &options{name: "src", output: bad}
-		if err := o.validate(); err == nil {
-			t.Errorf("validate() accepted invalid --output %q", bad)
-		}
+		assert.Error(t, o.validate(), "validate() accepted invalid --output %q", bad)
 	}
 	// --name is validated the same way.
-	if err := (&options{name: "../x", output: "out"}).validate(); err == nil {
-		t.Error("validate() accepted invalid --name ../x")
-	}
+	assert.Error(t, (&options{name: "../x", output: "out"}).validate(), "validate() accepted invalid --name ../x")
 	// A valid name/output pair passes.
-	if err := (&options{name: "src", output: "src_l0c"}).validate(); err != nil {
-		t.Errorf("validate() rejected valid names: %v", err)
-	}
+	assert.NoError(t, (&options{name: "src", output: "src_l0c"}).validate())
 	// Default output is also validated (derived from a valid name).
 	o := &options{name: "src"}
-	if err := o.validate(); err != nil {
-		t.Errorf("validate() rejected defaulted output: %v", err)
-	}
-	if o.output != "src_l0compacted" {
-		t.Errorf("default output = %q", o.output)
-	}
+	assert.NoError(t, o.validate())
+	assert.Equal(t, "src_l0compacted", o.output)
 }

--- a/internal/l0compact/deltalog_test.go
+++ b/internal/l0compact/deltalog_test.go
@@ -4,36 +4,27 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeltalogV1JSONRoundTrip(t *testing.T) {
 	in := []DeleteEntry{{PK: PrimaryKey{Type: PKInt64, Int: 42}, Ts: 100}}
 	blob, err := WriteDeltalog(in, KindV1, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	out, err := ReadDeltalog(blob, KindV1, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(out) != 1 || out[0].PK.Int != 42 || out[0].Ts != 100 {
-		t.Fatalf("got %+v", out)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
 }
 
 func TestDeltalogV2RoundTripVarChar(t *testing.T) {
 	in := []DeleteEntry{{PK: PrimaryKey{Type: PKVarChar, Str: "k1"}, Ts: 7}}
 	blob, err := WriteDeltalog(in, KindV2, PKVarChar)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	out, err := ReadDeltalog(blob, KindV2, PKVarChar)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(out) != 1 || out[0].PK.Str != "k1" || out[0].Ts != 7 {
-		t.Fatalf("got %+v", out)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
 }
 
 // TestDeltalogV1MultiEvent guards the fix for a v1 deltalog file that carries
@@ -43,27 +34,17 @@ func TestDeltalogV2RoundTripVarChar(t *testing.T) {
 func TestDeltalogV1MultiEvent(t *testing.T) {
 	// event 1 (via the normal writer): pk=1 @ ts=10
 	blob, err := WriteDeltalog([]DeleteEntry{{PK: PrimaryKey{Type: PKInt64, Int: 1}, Ts: 10}}, KindV1, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// append a second Delete event to the SAME file: pk=2 @ ts=20
 	payload2, err := writeParquetStringColumn([]string{`{"pk":2,"ts":20,"pkType":5}`}, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	blob = append(blob, buildDeltaEvent(payload2)...)
 
 	out, err := ReadDeltalog(blob, KindV1, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(out) != 2 { // was 1 before the fix
-		t.Fatalf("want 2 entries from 2 events, got %d: %+v", len(out), out)
-	}
+	require.NoError(t, err)
+	require.Len(t, out, 2, "want 2 entries from 2 events") // was 1 before the fix
 	seen := map[int64]uint64{out[0].PK.Int: out[0].Ts, out[1].PK.Int: out[1].Ts}
-	if seen[1] != 10 || seen[2] != 20 {
-		t.Fatalf("got %+v", out)
-	}
+	assert.Equal(t, map[int64]uint64{1: 10, 2: 20}, seen)
 }
 
 // buildDeltaEvent encodes one v1 Delete data event: 17B header + 16B fixpart + payload.
@@ -78,13 +59,11 @@ func buildDeltaEvent(payload []byte) []byte {
 
 func TestDeltalogV1MultiFieldRead(t *testing.T) {
 	// multi-field variant: envelope with version=MULTI_FIELD wrapping a 2-col parquet.
-	payload, _ := WriteParquetPKTs([]PrimaryKey{{Type: PKInt64, Int: 9}}, []uint64{3}, PKInt64)
-	blob, _ := BuildV1Envelope(eventDelete, 5 /*Int64*/, 0, map[string]string{"version": "MULTI_FIELD"}, payload)
+	payload, err := WriteParquetPKTs([]PrimaryKey{{Type: PKInt64, Int: 9}}, []uint64{3}, PKInt64)
+	require.NoError(t, err)
+	blob, err := BuildV1Envelope(eventDelete, 5 /*Int64*/, 0, map[string]string{"version": "MULTI_FIELD"}, payload)
+	require.NoError(t, err)
 	out, err := ReadDeltalog(blob, KindV1, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(out) != 1 || out[0].PK.Int != 9 || out[0].Ts != 3 {
-		t.Fatalf("got %+v", out)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []DeleteEntry{{PK: PrimaryKey{Type: PKInt64, Int: 9}, Ts: 3}}, out)
 }

--- a/internal/l0compact/envelope_test.go
+++ b/internal/l0compact/envelope_test.go
@@ -1,6 +1,11 @@
 package l0compact
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 // envHeaderArgs configures the descriptor fields used by buildV1Envelope.
 type envHeaderArgs struct {
@@ -15,9 +20,7 @@ type envHeaderArgs struct {
 func buildV1Envelope(t *testing.T, args envHeaderArgs, payload []byte) []byte {
 	t.Helper()
 	blob, err := BuildV1Envelope(args.typeCode, args.payloadType, args.fieldID, args.extras, payload)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return blob
 }
 
@@ -31,16 +34,10 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 	}, payload)
 
 	desc, events, err := parseV1Envelope(blob)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if desc.PayloadDataType != 20 || desc.FieldID != 0 {
-		t.Fatalf("desc=%+v", desc)
-	}
-	if len(events) != 1 || string(events[0].Payload) != string(payload) {
-		t.Fatalf("events=%d payload mismatch", len(events))
-	}
-	if _, ok := desc.Extras["version"]; ok {
-		t.Fatal("json variant should have no MULTI_FIELD version")
-	}
+	require.NoError(t, err)
+	assert.EqualValues(t, 20, desc.PayloadDataType)
+	assert.EqualValues(t, 0, desc.FieldID)
+	require.Len(t, events, 1)
+	assert.Equal(t, payload, events[0].Payload)
+	assert.NotContains(t, desc.Extras, "version", "json variant should have no MULTI_FIELD version")
 }

--- a/internal/l0compact/insertpk_test.go
+++ b/internal/l0compact/insertpk_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // buildSingleInt64Parquet builds a bare single-column Int64 parquet blob,
@@ -25,23 +27,18 @@ func buildSingleInt64Parquet(t *testing.T, vals []int64) []byte {
 	rec := b.NewRecord()
 	defer rec.Release()
 	blob, err := writeRecord(schema, rec)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return blob
 }
 
 func TestReadInsertPKV1(t *testing.T) {
 	// v1 insert: envelope (Insert event, PayloadDataType=Int64) wrapping a single Int64 column parquet.
 	payload := buildSingleInt64Parquet(t, []int64{11, 22}) // helper in test file
-	blob, _ := BuildV1Envelope(eventInsert, 5, 100, map[string]string{}, payload)
+	blob, err := BuildV1Envelope(eventInsert, 5, 100, map[string]string{}, payload)
+	require.NoError(t, err)
 	pks, err := ReadInsertPK([][]byte{blob}, KindV1, 100, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pks) != 2 || pks[0].Int != 11 || pks[1].Int != 22 {
-		t.Fatalf("got %+v", pks)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []PrimaryKey{{Type: PKInt64, Int: 11}, {Type: PKInt64, Int: 22}}, pks)
 }
 
 func TestReadInsertPKV2ByFieldID(t *testing.T) {
@@ -49,10 +46,6 @@ func TestReadInsertPKV2ByFieldID(t *testing.T) {
 	g0 := buildTaggedParquetInt64(t, map[int64][]int64{1: {0, 0}}) // system col, no pk
 	g1 := buildTaggedParquetInt64(t, map[int64][]int64{100: {5, 6}})
 	pks, err := ReadInsertPK([][]byte{g0, g1}, KindV2, 100, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pks) != 2 || pks[0].Int != 5 || pks[1].Int != 6 {
-		t.Fatalf("got %+v", pks)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []PrimaryKey{{Type: PKInt64, Int: 5}, {Type: PKInt64, Int: 6}}, pks)
 }

--- a/internal/l0compact/parquet_test.go
+++ b/internal/l0compact/parquet_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // buildTaggedParquetInt64 builds a parquet blob with one Int64 column per
@@ -39,9 +41,7 @@ func buildTaggedParquetInt64(t *testing.T, cols map[int64][]int64) []byte {
 	defer rec.Release()
 
 	blob, err := writeRecord(schema, rec)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return blob
 }
 
@@ -49,30 +49,26 @@ func TestParquet2ColRoundTripInt64(t *testing.T) {
 	pks := []PrimaryKey{{Type: PKInt64, Int: 1}, {Type: PKInt64, Int: 2}}
 	tss := []uint64{10, 20}
 	blob, err := WriteParquetPKTs(pks, tss, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	gotPKs, gotTs, err := ReadParquetPKTs(blob, PKInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(gotPKs) != 2 || gotPKs[0].Int != 1 || gotPKs[1].Int != 2 || gotTs[0] != 10 || gotTs[1] != 20 {
-		t.Fatalf("roundtrip mismatch: %+v %+v", gotPKs, gotTs)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, pks, gotPKs)
+	assert.Equal(t, tss, gotTs)
 }
 
 func TestParquetColumnByFieldID(t *testing.T) {
 	// A parquet with two field-id-tagged columns; PK field id = 100.
 	blob := buildTaggedParquetInt64(t, map[int64][]int64{100: {5, 6, 7}, 1: {1, 1, 1}})
 	pks, found, err := ReadParquetColumnByFieldID(blob, 100, PKInt64)
-	if err != nil || !found {
-		t.Fatalf("found=%v err=%v", found, err)
-	}
-	if len(pks) != 3 || pks[0].Int != 5 || pks[2].Int != 7 {
-		t.Fatalf("got %+v", pks)
-	}
-	_, found2, _ := ReadParquetColumnByFieldID(blob, 999, PKInt64)
-	if found2 {
-		t.Fatal("field 999 should not be found")
-	}
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, []PrimaryKey{
+		{Type: PKInt64, Int: 5},
+		{Type: PKInt64, Int: 6},
+		{Type: PKInt64, Int: 7},
+	}, pks)
+
+	_, found, err = ReadParquetColumnByFieldID(blob, 999, PKInt64)
+	assert.NoError(t, err)
+	assert.False(t, found, "field 999 should not be found")
 }

--- a/internal/l0compact/pk_test.go
+++ b/internal/l0compact/pk_test.go
@@ -1,31 +1,30 @@
 package l0compact
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestPrimaryKeyMapKey(t *testing.T) {
 	// PrimaryKey must be usable as a comparable map key (delete map is pk->ts).
 	m := map[PrimaryKey]uint64{}
 	m[PrimaryKey{Type: PKInt64, Int: 7}] = 100
-	if m[PrimaryKey{Type: PKInt64, Int: 7}] != 100 {
-		t.Fatal("int64 pk map lookup failed")
-	}
+	assert.Equal(t, uint64(100), m[PrimaryKey{Type: PKInt64, Int: 7}])
 	m[PrimaryKey{Type: PKVarChar, Str: "a"}] = 200
-	if m[PrimaryKey{Type: PKVarChar, Str: "a"}] != 200 {
-		t.Fatal("varchar pk map lookup failed")
-	}
-	if _, ok := m[PrimaryKey{Type: PKInt64, Int: 8}]; ok {
-		t.Fatal("absent key present")
-	}
+	assert.Equal(t, uint64(200), m[PrimaryKey{Type: PKVarChar, Str: "a"}])
+	assert.NotContains(t, m, PrimaryKey{Type: PKInt64, Int: 8})
 }
 
 func TestPKTypeFromDataType(t *testing.T) {
-	if got, _ := PKTypeFromDataType(5); got != PKInt64 {
-		t.Fatalf("5 -> %v", got)
-	}
-	if got, _ := PKTypeFromDataType(21); got != PKVarChar {
-		t.Fatalf("21 -> %v", got)
-	}
-	if _, err := PKTypeFromDataType(101); err == nil {
-		t.Fatal("want error for non-pk type")
-	}
+	got, err := PKTypeFromDataType(5)
+	assert.NoError(t, err)
+	assert.Equal(t, PKInt64, got)
+
+	got, err = PKTypeFromDataType(21)
+	assert.NoError(t, err)
+	assert.Equal(t, PKVarChar, got)
+
+	_, err = PKTypeFromDataType(101)
+	assert.Error(t, err, "want error for non-pk type")
 }

--- a/internal/l0compact/version_test.go
+++ b/internal/l0compact/version_test.go
@@ -1,16 +1,19 @@
 package l0compact
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestClassifyVersion(t *testing.T) {
 	cases := map[int64]StorageKind{0: KindV1, 1: KindV1, 2: KindV2, 3: KindV2}
 	for v, want := range cases {
 		got, err := ClassifyVersion(v)
-		if err != nil || got != want {
-			t.Fatalf("v=%d got=%v err=%v want=%v", v, got, err, want)
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
 	}
-	if _, err := ClassifyVersion(4); err == nil {
-		t.Fatal("want fail-fast on version 4")
-	}
+
+	_, err := ClassifyVersion(4)
+	assert.Error(t, err, "want fail-fast on version 4")
 }


### PR DESCRIPTION
## Summary

The l0compact tests were written with hand-rolled `if` checks followed by `t.Fatalf` /
`t.Errorf`, which the repo's agent rules explicitly call out as the wrong style. This
converts them to testify assertions so a failure prints an expected-vs-actual diff instead
of an ad-hoc message.

Test-only change, no production code touched.

## Changes

- Convert every hand-written check in `internal/l0compact/` (deltalog, parquet, insertpk, envelope, pk, version) and `cmd/l0compact/` to `assert` / `require`
- Use `require` for preconditions (setup writers, values about to be dereferenced) and `assert` for the actual checks, so one run reports every mismatch
- Replace compound conditions like `len(out) != 1 || out[0].PK.Int != 42 || out[0].Ts != 100` with a single `assert.Equal` on the whole value
- Stop discarding errors in `deltalog_test.go` — `WriteParquetPKTs` and `BuildV1Envelope` results are now checked with `require.NoError`

`core/l0compact/` already used testify and is unchanged.

/kind improvement