### PR TITLE
cfg: extract v1 to v2 translation for the config loader

### DIFF
--- a/internal/cfg/migrate/migrate.go
+++ b/internal/cfg/migrate/migrate.go
@@ -1,13 +1,18 @@
 // Package migrate translates a resolved v1 configuration into a v2
-// configuration plus a report of everything that needs a human's attention.
+// configuration. Two entry points share one field mapping: Migrate, which also
+// returns a report of everything that needs a human's attention and backs the
+// `config migrate` command, and Translate, which the config loader uses to run
+// an existing v1 file through the v2 schema.
 //
 // Migration renames configuration keys and environment variables; it does not
 // relocate values between mechanisms. A value the operator keeps in an
 // environment variable stays there: the v2 file records the v2 variable name to
-// set rather than baking the secret into the file.
+// set rather than baking the secret into the file. Translate is the exception,
+// since a running process needs the secret itself rather than advice about it.
 package migrate
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -21,12 +26,43 @@ import (
 // warnings, the embedded comments, the environment renames, and any validation
 // problems (via Report.Err) that --strict promotes to a failure.
 func Migrate(src *cfg.Config) (*v2.Config, *Report) {
+	r := newReport()
+	out := translate(src, r)
+
+	scanLegacyEnv(src, r)
+	r.recordValidation(out.Validate())
+
+	return out, r
+}
+
+// Translate maps a resolved v1 configuration into a complete v2 configuration
+// for the config loader, which decodes a v1 file with the v1 schema and then
+// translates it, rather than teaching the v2 schema to read v1 names.
+//
+// It differs from Migrate in the two ways a running process needs: every value
+// is carried into the result, including a secret that reached v1 through an
+// environment variable, which the loader needs in hand to connect; and the v2
+// validation problems are returned as an error instead of being collected for
+// a human to read.
+func Translate(src *cfg.Config) (*v2.Config, error) {
+	out := translate(src, nil)
+
+	if err := out.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg: translate v1 config to v2: %w", err)
+	}
+
+	return out, nil
+}
+
+// translate applies the v1 to v2 field mapping shared by Migrate and Translate.
+// A nil report selects the loader path: nothing is reported, and secrets are
+// copied into the config rather than deferred to an environment variable.
+func translate(src *cfg.Config, r *Report) *v2.Config {
 	out := v2.New()
 	// Start from a fully defaulted baseline so the fields with no v1 source
 	// report as defaulted, which the v2 validator relies on to tell an
 	// inapplicable credential from one left unset.
 	param.Defaults(out)
-	r := newReport()
 
 	migrateLog(src, out)
 	migrateServer(src, out, r)
@@ -36,10 +72,7 @@ func Migrate(src *cfg.Config) (*v2.Config, *Report) {
 	migrateTransfer(src, out, r)
 	migrateCloud(src, out, r)
 
-	scanLegacyEnv(src, r)
-	r.recordValidation(out.Validate())
-
-	return out, r
+	return out
 }
 
 func migrateLog(src *cfg.Config, out *v2.Config) {
@@ -268,8 +301,12 @@ func effective(field, primary *cfg.Value[string]) *cfg.Value[string] {
 // environment variable: then it leaves the v2 field at its default and records
 // that the secret must be supplied through the v2 variable instead of being
 // written into the file.
+//
+// That withholding only makes sense for a file someone is about to read. On the
+// loader path (a nil report) the secret is always copied, because a running
+// process needs the resolved value to connect.
 func mapSecret(out, in *cfg.Value[string], v2env string, r *Report) {
-	if in.Used.Kind == param.SourceEnv {
+	if r != nil && in.Used.Kind == param.SourceEnv {
 		r.comment(out, "set via env "+v2env)
 		r.deferToEnv(out)
 		r.warnf("%s is supplied via environment variable %s in v1; set %s in your v2 deployment (its value was not written to the file)",

--- a/internal/cfg/migrate/report.go
+++ b/internal/cfg/migrate/report.go
@@ -13,6 +13,11 @@ import (
 // about values that changed meaning, the per-field comments embedded in the
 // output file, the validation problems the migrated config still has, and the
 // v1 environment variables that need renaming.
+//
+// A nil *Report is valid and discards everything written to it. It marks the
+// runtime translate path, which maps a v1 config into v2 without producing
+// migration advice for anyone to read, so every method here tolerates a nil
+// receiver.
 type Report struct {
 	// Comments maps a lower-cased v2 config key to the head comment Render
 	// writes above it.
@@ -41,11 +46,17 @@ func newReport() *Report {
 }
 
 func (r *Report) warnf(format string, args ...any) {
+	if r == nil {
+		return
+	}
 	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
 }
 
 // comment records a head comment for a v2 field, keyed by its config key.
 func (r *Report) comment(f param.Field, text string) {
+	if r == nil {
+		return
+	}
 	if keys := f.ConfigKeys(); len(keys) > 0 {
 		r.Comments[strings.ToLower(keys[0])] = text
 	}
@@ -54,12 +65,18 @@ func (r *Report) comment(f param.Field, text string) {
 // commentKey records a head comment for a v2 field named directly by its
 // config key, for callers that do not hold the field.
 func (r *Report) commentKey(key, text string) {
+	if r == nil {
+		return
+	}
 	r.Comments[strings.ToLower(key)] = text
 }
 
 // deferToEnv marks a field as supplied through an environment variable, so its
 // empty value in the file is expected rather than a validation error.
 func (r *Report) deferToEnv(f param.Field) {
+	if r == nil {
+		return
+	}
 	if keys := f.ConfigKeys(); len(keys) > 0 {
 		r.deferred[strings.ToLower(keys[0])] = true
 	}
@@ -69,7 +86,7 @@ func (r *Report) deferToEnv(f param.Field) {
 // every problem except those on fields whose value the operator deliberately
 // left in an environment variable, which are empty in the file on purpose.
 func (r *Report) recordValidation(err error) {
-	if err == nil {
+	if r == nil || err == nil {
 		return
 	}
 

--- a/internal/cfg/migrate/translate_test.go
+++ b/internal/cfg/migrate/translate_test.go
@@ -1,0 +1,131 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+// The loader needs the secret itself, so Translate carries an env-supplied one
+// into the config. Migrate deliberately does the opposite, see
+// TestMigrate_EnvSecretDeferred.
+func TestTranslate_KeepsEnvSecret(t *testing.T) {
+	t.Setenv("MINIO_SECRET_KEY", "supersecret")
+
+	out, err := Translate(loadV1(t, `
+minio:
+  storageType: s3
+  accessKeyID: ak
+  backupBucketName: backups
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "supersecret", out.Milvus.Storage.Auth.SecretAccessKey.Val)
+	// The backup side inherits the primary secret in v1, so it has to end up
+	// with the resolved value too rather than the default.
+	assert.Equal(t, "supersecret", out.Backup.Storage.Auth.SecretAccessKey.Val)
+}
+
+func TestTranslate_MapsRenamedKeys(t *testing.T) {
+	out, err := Translate(loadV1(t, `
+milvus:
+  address: milvus-proxy
+  port: 19531
+  rpcChannelName: my-replicate
+http:
+  debugMode: true
+cloud:
+  address: https://api.example.com
+backup:
+  gcPause:
+    enable: false
+    address: http://datacoord:9091
+  parallelism:
+    backupCollection: 8
+    copydata: 32
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "milvus-proxy", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
+	assert.Equal(t, "my-replicate", out.Milvus.Replicate.RPCChannelName.Val)
+	assert.True(t, out.Server.DebugMode.Val)
+	assert.Equal(t, "https://api.example.com", out.Cloud.Endpoint.Val)
+	assert.Equal(t, "http://datacoord:9091", out.Milvus.Management.Endpoint.Val)
+	assert.False(t, out.Backup.PauseGC.Val)
+	assert.Equal(t, 8, out.Backup.Concurrency.Collections.Val)
+	assert.Equal(t, 32, out.Transfer.Concurrency.Val)
+}
+
+// Every value decision Migrate explains with a warning still has to be made
+// when nobody is listening. This config trips each report-only path at once:
+// the dropped http.enabled, the mutual TLS downgrade, the inherited backup root
+// path, and crossStorage against two different backends.
+func TestTranslate_SettlesValuesWithoutReport(t *testing.T) {
+	out, err := Translate(loadV1(t, `
+http:
+  enabled: false
+milvus:
+  tlsMode: 2
+minio:
+  storageType: s3
+  accessKeyID: ak
+  secretAccessKey: sk
+  rootPath: custom-root
+  crossStorage: false
+  backupAddress: backup-s3
+`))
+	require.NoError(t, err)
+
+	// v1 downgraded mutual TLS to server TLS without a client key pair, and v2
+	// rejects the un-downgraded value, so the translation has to settle it.
+	assert.Equal(t, v2.TLSServer, out.Milvus.Grpc.TLSMode.Val)
+	assert.Equal(t, v2.TransferAuto, out.Transfer.Mode.Val)
+	// v1 put backup data under a customized Milvus root path; v2 keeps the two
+	// independent, so the inherited location is carried over explicitly.
+	assert.Equal(t, "custom-root", out.Backup.Storage.RootPath.Val)
+}
+
+func TestTranslate_CrossStorageStreams(t *testing.T) {
+	out, err := Translate(loadV1(t, "minio:\n  crossStorage: true\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, v2.TransferStreaming, out.Transfer.Mode.Val)
+}
+
+// v1 never validated the provider name and only failed when it came time to
+// build a client. Translating runs the v2 validator, so the mistake surfaces
+// while the config is being loaded.
+func TestTranslate_ReportsValidationError(t *testing.T) {
+	_, err := Translate(loadV1(t, "minio:\n  storageType: bogus\n"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "translate v1 config to v2")
+	assert.ErrorContains(t, err, "bogus")
+}
+
+// Both entry points run the same mapping, so a config with no secret to
+// withhold has to translate identically either way.
+func TestTranslate_MatchesMigrateWithoutEnvSecrets(t *testing.T) {
+	const content = `
+milvus:
+  address: milvus-proxy
+  tlsMode: 1
+minio:
+  storageType: s3
+  accessKeyID: ak
+  secretAccessKey: sk
+  crossStorage: true
+`
+
+	translated, err := Translate(loadV1(t, content))
+	require.NoError(t, err)
+
+	migrated, report := Migrate(loadV1(t, content))
+	require.NoError(t, report.Err())
+
+	assert.Equal(t, migrated, translated)
+}


### PR DESCRIPTION
## Summary

Prepares the config loader for dispatching on the schema version: a v1 file will be decoded with the v1 schema and then translated into v2, so downstream code only ever sees a v2 config. That needs the v1 to v2 mapping `Migrate` already implements, but `Migrate` cannot be reused as is — it withholds a secret that reached v1 through an environment variable, so the file it emits does not bake the secret in, while a running process needs that value to connect.

## Changes

- Extract the v1 to v2 field mapping out of `Migrate` into a shared `translate`.
- Add `Translate`, the loader-facing entry point: it carries every value into the result, including one that came from an environment variable, and returns the v2 validation error instead of collecting it for a human to read.
- Make `*Report` nil-safe. A nil report selects the loader path, so the report-only branches turn into no-ops rather than growing a second set of call sites.
- Add tests for the env-secret difference, the value decisions `Migrate` would warn about (mutual TLS downgrade, inherited backup root path, crossStorage), the validation error path, and that both entry points agree when there is no secret to withhold.

`Migrate` and the `config migrate` command keep their behavior.

Part of #1089
