### PR TITLE
cfg: load either schema version and run the program on v2

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/check"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 )
 
 // writeConfig prints a labeled table of the effective configuration to w.
-func writeConfig(w io.Writer, c *cfg.Config) error {
+func writeConfig(w io.Writer, c *v2.Config) error {
 	if _, err := io.WriteString(w, "Configuration:\n"); err != nil {
 		return fmt.Errorf("check: write config header: %w", err)
 	}
@@ -42,10 +42,10 @@ func NewCmd(opt *root.Options) *cobra.Command {
 			grpc, err := milvus.NewGrpc(&params.Milvus)
 			cobra.CheckErr(err)
 
-			milvusStorage, err := storage.NewMilvusStorage(ctx, &params.Minio)
+			milvusStorage, err := storage.NewMilvusStorage(ctx, params)
 			cobra.CheckErr(err)
 
-			backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+			backupStorage, err := storage.NewBackupStorage(ctx, params)
 			cobra.CheckErr(err)
 
 			taskArgs := check.TaskArgs{

--- a/cmd/check/check_test.go
+++ b/cmd/check/check_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/loader"
 )
 
 func TestWriteConfig(t *testing.T) {
-	c, err := cfg.Load("", nil)
+	c, err := loader.Load("", nil)
 	assert.NoError(t, err)
 
 	var buf bytes.Buffer
@@ -19,5 +19,5 @@ func TestWriteConfig(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "Configuration:")
 	assert.Contains(t, out, "PARAMETER")
-	assert.Contains(t, out, "Milvus.Address")
+	assert.Contains(t, out, "Milvus.Grpc.Address")
 }

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/backup"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -191,7 +191,7 @@ func (o *options) toStrategy() (backup.Strategy, error) {
 	return backup.StrategyAuto, nil
 }
 
-func (o *options) toOption(params *cfg.Config) (backup.Option, error) {
+func (o *options) toOption(params *v2.Config) (backup.Option, error) {
 	f, err := o.toFilter()
 	if err != nil {
 		return backup.Option{}, err
@@ -204,7 +204,7 @@ func (o *options) toOption(params *cfg.Config) (backup.Option, error) {
 
 	return backup.Option{
 		BackupName: o.backupName,
-		PauseGC:    params.Backup.GCPause.Enable.Val,
+		PauseGC:    params.Backup.PauseGC.Val,
 
 		Strategy: strategy,
 
@@ -216,17 +216,17 @@ func (o *options) toOption(params *cfg.Config) (backup.Option, error) {
 	}, nil
 }
 
-func (o *options) toArgs(params *cfg.Config) (backup.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+func (o *options) toArgs(params *v2.Config) (backup.TaskArgs, error) {
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return backup.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), &params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
 	if err != nil {
 		return backup.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	option, err := o.toOption(params)
 	if err != nil {
 		return backup.TaskArgs{}, err
@@ -243,7 +243,7 @@ func (o *options) toArgs(params *cfg.Config) (backup.TaskArgs, error) {
 	}, nil
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	start := time.Now()
 
 	args, err := o.toArgs(params)

--- a/cmd/del/delete.go
+++ b/cmd/del/delete.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/del"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )
@@ -30,13 +30,13 @@ func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.name, "name", "n", "", "delete backup with this name")
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return fmt.Errorf("delete: create backup storage: %w", err)
 	}
 
-	task := del.NewTask(backupStorage, mpath.BackupDir(params.Minio.BackupRootPath.Val, o.name))
+	task := del.NewTask(backupStorage, mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.name))
 	if err := task.Execute(context.Background()); err != nil {
 		return fmt.Errorf("delete: execute task: %w", err)
 	}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
 	"github.com/zilliztech/milvus-backup/internal/storage"
@@ -32,15 +32,15 @@ func (o *options) validate() error {
 	return nil
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	ctx := context.Background()
 
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return fmt.Errorf("create backup storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	backupInfo, err := meta.Read(ctx, backupStorage, backupDir)
 	if err != nil {
 		return fmt.Errorf("read backup meta: %w", err)

--- a/cmd/l0compact/l0compact.go
+++ b/cmd/l0compact/l0compact.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/backup"
 	corel0 "github.com/zilliztech/milvus-backup/core/l0compact"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )
@@ -43,14 +43,14 @@ func (o *options) validate() error {
 	return nil
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	ctx := context.Background()
-	cli, err := storage.NewBackupStorage(ctx, &params.Minio)
+	cli, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return fmt.Errorf("l0compact: create storage: %w", err)
 	}
-	srcDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.name)
-	dstDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.output)
+	srcDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.name)
+	dstDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.output)
 	// Destination handling (reject-if-exists, or clear when --force) lives in the
 	// task so it is applied uniformly.
 	task := corel0.NewTask(cli, srcDir, dstDir, corel0.WithForce(o.force))

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 )
@@ -31,18 +31,18 @@ func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.collectionName, "collection", "c", "", "[DEPRECATED] only list backups contains a certain collection")
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	ctx := context.Background()
 	if err := o.validate(); err != nil {
 		return err
 	}
 
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return fmt.Errorf("cmd: create backup storage %w", err)
 	}
 
-	summaries, err := meta.List(ctx, backupStorage, params.Minio.BackupRootPath.Val)
+	summaries, err := meta.List(ctx, backupStorage, params.Backup.Storage.RootPath.Val)
 	if err != nil {
 		return fmt.Errorf("cmd: list backup %w", err)
 	}

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/migrate"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
@@ -30,7 +30,7 @@ func (o *options) validate() error {
 	return nil
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	taskID := uuid.NewString()
 	task, err := migrate.NewTask(taskID, o.backupName, o.clusterID, params)
 	if err != nil {

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/restore"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
@@ -257,22 +257,22 @@ func (o *options) renameCollectionNamesToMapper() (*restore.TableMapper, error) 
 	return newTableMapperFromCollRename(renameMap)
 }
 
-func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
+func (o *options) toArgs(params *v2.Config) (restore.TaskArgs, error) {
 	plan, err := o.toPlan()
 	if err != nil {
 		return restore.TaskArgs{}, err
 	}
 
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), &params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
 	if err != nil {
 		return restore.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)
@@ -292,7 +292,7 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 		Plan:          plan,
 		Option:        o.toOption(),
 		Params:        params,
-		BackupDir:     mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName),
+		BackupDir:     mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName),
 		BackupStorage: backupStorage,
 		MilvusStorage: milvusStorage,
 
@@ -300,7 +300,7 @@ func (o *options) toArgs(params *cfg.Config) (restore.TaskArgs, error) {
 	}, nil
 }
 
-func (o *options) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	start := time.Now()
 
 	args, err := o.toArgs(params)

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/restore/secondary"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
@@ -42,13 +42,13 @@ func (o *secondaryOption) validate() error {
 	return nil
 }
 
-func (o *secondaryOption) toArgs(params *cfg.Config) (secondary.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), &params.Minio)
+func (o *secondaryOption) toArgs(params *v2.Config) (secondary.TaskArgs, error) {
+	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
 	if err != nil {
 		return secondary.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, o.backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
 	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
 	if err != nil {
 		return secondary.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)
@@ -77,7 +77,7 @@ func (o *secondaryOption) toArgs(params *cfg.Config) (secondary.TaskArgs, error)
 	}, nil
 }
 
-func (o *secondaryOption) run(cmd *cobra.Command, params *cfg.Config) error {
+func (o *secondaryOption) run(cmd *cobra.Command, params *v2.Config) error {
 	args, err := o.toArgs(params)
 	if err != nil {
 		return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/loader"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 )
 
@@ -16,20 +17,37 @@ type Options struct {
 	YamlOverrides []string
 }
 
-func (o *Options) InitGlobalVars() *cfg.Config {
+// InitGlobalVars loads the configuration, whichever schema version the file is
+// written in, and initializes logging from it. Everything downstream sees v2.
+func (o *Options) InitGlobalVars() *v2.Config {
 	overrides, err := parseOverrides(o.YamlOverrides)
 	if err != nil {
 		panic(err)
 	}
 
-	params, err := cfg.Load(o.Config, overrides)
+	params, err := loader.Load(o.Config, overrides)
 	if err != nil {
 		panic(err)
 	}
 
-	log.InitLogger(&params.Log)
+	log.InitLogger(logConfig(&params.Log))
 
 	return params
+}
+
+// logConfig maps the log section onto the logger's own configuration, so the
+// log package does not have to know about a configuration schema.
+func logConfig(c *v2.LogConfig) *log.Config {
+	return &log.Config{
+		Level:   c.Level.Val,
+		Console: c.Console.Val,
+		File: log.FileLogConfig{
+			Filename:   c.File.Path.Val,
+			MaxSize:    c.File.MaxSizeMiB.Val,
+			MaxDays:    c.File.MaxDays.Val,
+			MaxBackups: c.File.MaxBackups.Val,
+		},
+	}
 }
 
 func NewCmd(opt *Options) *cobra.Command {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/server"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 )
 
 const (
@@ -49,7 +49,7 @@ func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.port, "port", "p", "", "Port to listen")
 }
 
-func (o *options) run(params *cfg.Config) error {
+func (o *options) run(params *v2.Config) error {
 	srv, err := server.New(params, server.Port(o.port))
 	if err != nil {
 		return fmt.Errorf("fail to create server, %w", err)

--- a/core/backup/coll_dml_task.go
+++ b/core/backup/coll_dml_task.go
@@ -30,7 +30,7 @@ type collDMLTask struct {
 	milvusStorage  storage.Client
 	milvusRootPath string
 
-	crossStorage bool
+	streaming bool
 
 	backupStorage storage.Client
 	backupDir     string
@@ -58,7 +58,7 @@ func newCollDMLTask(ns namespace.NS, args collTaskArgs) *collDMLTask {
 		milvusStorage:  args.MilvusStorage,
 		milvusRootPath: args.MilvusRootPath,
 
-		crossStorage: args.CrossStorage,
+		streaming: args.Streaming,
 
 		backupStorage: args.BackupStorage,
 		backupDir:     args.BackupDir,
@@ -529,7 +529,7 @@ func (dmlt *collDMLTask) backupSegmentData(ctx context.Context, seg *backuppb.Se
 		Src:       dmlt.milvusStorage,
 		Dest:      dmlt.backupStorage,
 		Attrs:     attrs,
-		Streaming: dmlt.crossStorage,
+		Streaming: dmlt.streaming,
 		Sem:       dmlt.throttling.CopySem,
 		TraceFn: func(size int64, cost time.Duration) {
 			dmlt.taskMgr.UpdateBackupTask(dmlt.taskID, taskmgr.IncBackupCollCopiedSize(dmlt.ns, size, cost))

--- a/core/backup/coll_strategy.go
+++ b/core/backup/coll_strategy.go
@@ -47,7 +47,7 @@ type collTaskArgs struct {
 
 	MilvusStorage  storage.Client
 	MilvusRootPath string
-	CrossStorage   bool
+	Streaming      bool
 	BackupStorage  storage.Client
 	BackupDir      string
 

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -12,7 +11,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/zilliztech/milvus-backup/core/tasklet"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
@@ -37,7 +36,7 @@ type TaskArgs struct {
 	BackupStorage storage.Client
 	BackupDir     string
 
-	Params *cfg.Config
+	Params *v2.Config
 
 	TaskMgr *taskmgr.Mgr
 }
@@ -64,12 +63,12 @@ type Task struct {
 	logger *zap.Logger
 
 	option Option
-	params *cfg.Config
+	params *v2.Config
 
 	milvusStorage  storage.Client
 	milvusRootPath string
 
-	crossStorage bool
+	streaming bool
 
 	backupStorage storage.Client
 	backupDir     string
@@ -107,10 +106,8 @@ func newGCCtrl(taskID string, pauseGC bool, grpc milvus.Grpc, manage milvus.Mana
 func NewTask(args TaskArgs) (*Task, error) {
 	logger := log.L().With(zap.String("task_id", args.TaskID))
 
-	crossStorage := args.Params.Minio.CrossStorage.Val
-	if args.BackupStorage.Config().Provider != args.MilvusStorage.Config().Provider {
-		crossStorage = true
-	}
+	streaming := storage.UseStreaming(args.Params.Transfer.Mode.Val,
+		args.MilvusStorage.Config(), args.BackupStorage.Config())
 
 	mb := newMetaBuilder(args.TaskID, args.Option.BackupName)
 	err := args.TaskMgr.AddBackupTask(args.TaskID, args.Option.BackupName)
@@ -119,9 +116,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 	}
 
 	throttling := concurrencyThrottling{
-		CollSem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.BackupCollection.Val)),
-		SegSem:  semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.BackupSegment.Val)),
-		CopySem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.CopyData.Val)),
+		CollSem: semaphore.NewWeighted(int64(args.Params.Backup.Concurrency.Collections.Val)),
+		SegSem:  semaphore.NewWeighted(int64(args.Params.Backup.Concurrency.Segments.Val)),
+		CopySem: semaphore.NewWeighted(int64(args.Params.Transfer.Concurrency.Val)),
 	}
 
 	return &Task{
@@ -134,9 +131,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 		params: args.Params,
 
 		milvusStorage:  args.MilvusStorage,
-		milvusRootPath: args.Params.Minio.RootPath.Val,
+		milvusRootPath: args.Params.Milvus.Storage.RootPath.Val,
 
-		crossStorage: crossStorage,
+		streaming: streaming,
 
 		backupStorage: args.BackupStorage,
 		backupDir:     args.BackupDir,
@@ -149,7 +146,7 @@ func NewTask(args TaskArgs) (*Task, error) {
 
 		taskMgr: args.TaskMgr,
 
-		rpcChannelName: args.Params.Milvus.RPCChannelName.Val,
+		rpcChannelName: args.Params.Milvus.Replicate.RPCChannelName.Val,
 	}, nil
 }
 
@@ -166,16 +163,15 @@ func (t *Task) initClients() error {
 	}
 	t.restful = restfulCli
 
-	manageAddr := t.params.Backup.GCPause.Address.Val
+	manageAddr := t.params.Milvus.Management.Endpoint.Val
 	if t.option.ManageAddr != "" {
 		manageAddr = t.option.ManageAddr
 	}
 	t.manage = milvus.NewManage(manageAddr)
 
 	if t.option.BackupIndexExtra {
-		endpoints := strings.Split(t.params.Milvus.Etcd.Endpoints.Val, ",")
 		etcdCli, err := clientv3.New(clientv3.Config{
-			Endpoints:   endpoints,
+			Endpoints:   t.params.Milvus.Etcd.Endpoints.Val,
 			DialTimeout: 5 * time.Second,
 		})
 		if err != nil {
@@ -394,7 +390,7 @@ func (t *Task) newCollTaskArgs() collTaskArgs {
 		TaskID:         t.taskID,
 		MilvusStorage:  t.milvusStorage,
 		MilvusRootPath: t.milvusRootPath,
-		CrossStorage:   t.crossStorage,
+		Streaming:      t.streaming,
 		BackupStorage:  t.backupStorage,
 		BackupDir:      t.backupDir,
 		Throttling:     t.throttling,

--- a/core/check/task.go
+++ b/core/check/task.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/storage"
@@ -19,7 +19,7 @@ import (
 )
 
 type TaskArgs struct {
-	Params *cfg.Config
+	Params *v2.Config
 
 	Grpc milvus.Grpc
 
@@ -32,7 +32,7 @@ type TaskArgs struct {
 type Task struct {
 	logger *zap.Logger
 
-	params *cfg.Config
+	params *v2.Config
 
 	grpc milvus.Grpc
 
@@ -88,7 +88,7 @@ func (t *Task) writeResult(version string, milvusEmpty bool) error {
 
 func (t *Task) checkMilvusStorage(ctx context.Context) (bool, error) {
 	t.logger.Info("check milvus storage")
-	files, _, err := storage.ListPrefixFlat(ctx, t.milvusStorage, mpath.MilvusRootDir(t.params.Minio.RootPath.Val), true)
+	files, _, err := storage.ListPrefixFlat(ctx, t.milvusStorage, mpath.MilvusRootDir(t.params.Milvus.Storage.RootPath.Val), true)
 	if err != nil {
 		return false, fmt.Errorf("check: list milvus root dir %w", err)
 	}
@@ -104,7 +104,7 @@ func (t *Task) checkMilvusStorage(ctx context.Context) (bool, error) {
 
 func (t *Task) checkBackupStorage(ctx context.Context) error {
 	t.logger.Info("check backup storage")
-	_, _, err := storage.ListPrefixFlat(ctx, t.backupStorage, mpath.BackupRootDir(t.params.Minio.BackupRootPath.Val), false)
+	_, _, err := storage.ListPrefixFlat(ctx, t.backupStorage, mpath.BackupRootDir(t.params.Backup.Storage.RootPath.Val), false)
 	if err != nil {
 		return fmt.Errorf("check: list backup root dir %w", err)
 	}
@@ -114,8 +114,8 @@ func (t *Task) checkBackupStorage(ctx context.Context) error {
 
 func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	t.logger.Info("check write and copy")
-	srcKey := path.Join(t.params.Minio.RootPath.Val, "milvus_backup_check_src_"+uuid.NewString())
-	destKey := path.Join(t.params.Minio.BackupRootPath.Val, "milvus_backup_check_dst_"+uuid.NewString())
+	srcKey := path.Join(t.params.Milvus.Storage.RootPath.Val, "milvus_backup_check_src_"+uuid.NewString())
+	destKey := path.Join(t.params.Backup.Storage.RootPath.Val, "milvus_backup_check_dst_"+uuid.NewString())
 	if err := storage.Write(ctx, t.milvusStorage, srcKey, []byte{1}); err != nil {
 		return fmt.Errorf("check: write to milvus storage %w", err)
 	}
@@ -128,18 +128,16 @@ func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	t.logger.Info("write to milvus storage success", zap.String("key", srcKey))
 
 	t.logger.Info("copy from milvus storage to backup storage")
-	crossStorage := t.params.Minio.CrossStorage.Val
-	if t.backupStorage.Config().Provider != t.milvusStorage.Config().Provider {
-		crossStorage = true
-	}
-	t.logger.Info("try to copy", zap.Bool("cross_storage", crossStorage), zap.String("dest_key", destKey))
+	streaming := storage.UseStreaming(t.params.Transfer.Mode.Val,
+		t.milvusStorage.Config(), t.backupStorage.Config())
+	t.logger.Info("try to copy", zap.Bool("streaming", streaming), zap.String("dest_key", destKey))
 	opt := storage.CopyPrefixOpt{
 		Src:        t.milvusStorage,
 		Dest:       t.backupStorage,
 		SrcPrefix:  srcKey,
 		DestPrefix: destKey,
 		Sem:        semaphore.NewWeighted(1),
-		Streaming:  crossStorage,
+		Streaming:  streaming,
 	}
 	task := storage.NewCopyPrefixTask(opt)
 	if err := task.Execute(ctx); err != nil {

--- a/core/migrate/task.go
+++ b/core/migrate/task.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/cloud"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
@@ -153,9 +153,9 @@ func (v *volume) apply(ctx context.Context) error {
 func newVolumeStorage(ctx context.Context, vol *volume) (storage.Client, error) {
 	var cred storage.Credential
 	switch vol.currentResp.resp.Cloud {
-	case cfg.CloudProviderGCP:
+	case v2.ProviderGCP:
 		cred = storage.Credential{Type: storage.OAuth2TokenSource, OAuth2TokenSource: vol}
-	case cfg.CloudProviderAWS:
+	case v2.ProviderAWS:
 		cred = storage.Credential{Type: storage.MinioCredProvider, MinioCredProvider: vol}
 	default:
 		return nil, fmt.Errorf("migrate: unsupported cloud provider %s", vol.currentResp.resp.Cloud)
@@ -194,17 +194,17 @@ type Task struct {
 	copySem *semaphore.Weighted
 }
 
-func NewTask(taskID, backupName, clusterID string, params *cfg.Config) (*Task, error) {
+func NewTask(taskID, backupName, clusterID string, params *v2.Config) (*Task, error) {
 	logger := log.With(zap.String("task_id", taskID))
-	cloudCli := cloud.NewClient(params.Cloud.Address.Val, params.Cloud.APIKey.Val)
+	cloudCli := cloud.NewClient(params.Cloud.Endpoint.Val, params.Cloud.APIKey.Val)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	backupStorage, err := storage.NewBackupStorage(ctx, &params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("migrate: new backup storage %w", err)
 	}
-	backupDir := mpath.BackupDir(params.Minio.BackupRootPath.Val, backupName)
+	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, backupName)
 
 	return &Task{
 		logger: logger,
@@ -220,7 +220,7 @@ func NewTask(taskID, backupName, clusterID string, params *cfg.Config) (*Task, e
 
 		// use taskID as volume prefix
 		volume:  newVolume(clusterID, taskID, cloudCli),
-		copySem: semaphore.NewWeighted(int64(params.Backup.Parallelism.CopyData.Val)),
+		copySem: semaphore.NewWeighted(int64(params.Transfer.Concurrency.Val)),
 	}, nil
 }
 

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -48,7 +48,7 @@ type collTask struct {
 
 	targetNS namespace.NS
 
-	crossStorage  bool
+	streaming     bool
 	keepTempFiles bool
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
@@ -89,7 +89,7 @@ type collTaskArgs struct {
 
 	backupDir     string
 	keepTempFiles bool
-	crossStorage  bool
+	streaming     bool
 
 	backupStorage storage.Client
 	milvusStorage storage.Client
@@ -130,7 +130,7 @@ func newCollTask(args collTaskArgs) *collTask {
 		copySem:       args.copySem,
 		bulkInsertSem: args.bulkInsertSem,
 
-		crossStorage:  args.crossStorage,
+		streaming:     args.streaming,
 		keepTempFiles: args.keepTempFiles,
 		backupDir:     args.backupDir,
 
@@ -346,7 +346,7 @@ func (ct *collTask) copyAndRewriteDir(ctx context.Context, b batch) (batch, erro
 	isSameBucket := ct.milvusStorage.Config().Bucket == ct.backupStorage.Config().Bucket
 	isSameStorage := ct.backupStorage.Config().Provider == ct.milvusStorage.Config().Provider
 	// if milvus bucket and backup bucket are not the same, should copy the data first
-	if isSameBucket && isSameStorage && !ct.crossStorage {
+	if isSameBucket && isSameStorage && !ct.streaming {
 		ct.logger.Info("milvus and backup store in the same bucket, no need to copy the data")
 		return b, nil
 	}

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -16,7 +16,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/restore/conv"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -32,7 +32,7 @@ type TaskArgs struct {
 
 	Backup *backuppb.BackupInfo
 
-	Params *cfg.Config
+	Params *v2.Config
 
 	BackupDir     string
 	BackupStorage storage.Client
@@ -244,7 +244,7 @@ func (t *Task) runCollTasks(ctx context.Context) error {
 	loadArgs := t.loadTaskArgs()
 
 	g, subCtx := errgroup.WithContext(ctx)
-	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
+	g.SetLimit(t.args.Params.Restore.Concurrency.Collections.Val)
 	for _, coll := range t.args.Backup.GetCollectionBackups() {
 		g.Go(func() error {
 			return t.runCollTask(subCtx, dbNameBackup[coll.GetDbName()], coll, ddlArgs, dmlArgs, loadArgs)

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore/conv"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
@@ -138,7 +138,7 @@ type TaskArgs struct {
 	Plan   *Plan
 	Option *Option
 
-	Params *cfg.Config
+	Params *v2.Config
 
 	BackupDir     string
 	BackupStorage storage.Client
@@ -149,6 +149,10 @@ type TaskArgs struct {
 
 type Task struct {
 	args TaskArgs
+
+	// streaming is decided once: it depends on the transfer policy and the two
+	// backends, none of which vary per collection.
+	streaming bool
 
 	grpc    milvus.Grpc
 	restful milvus.Restful
@@ -167,8 +171,11 @@ func NewTask(args TaskArgs) (*Task, error) {
 	return &Task{
 		args: args,
 
-		copySem:       semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.CopyData.Val)),
-		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Backup.Parallelism.ImportJob.Val)),
+		streaming: storage.UseStreaming(args.Params.Transfer.Mode.Val,
+			args.BackupStorage.Config(), args.MilvusStorage.Config()),
+
+		copySem:       semaphore.NewWeighted(int64(args.Params.Transfer.Concurrency.Val)),
+		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Restore.Concurrency.ImportJobs.Val)),
 
 		logger: logger,
 	}, nil
@@ -267,8 +274,8 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 			collBackup:    collBackup,
 			option:        t.args.Option,
 			collOverride:  t.args.Plan.CollOverrides[targetNS.String()],
-			crossStorage:  t.args.Params.Minio.CrossStorage.Val,
-			keepTempFiles: t.args.Params.Backup.KeepTempFiles.Val,
+			streaming:     t.streaming,
+			keepTempFiles: t.args.Params.Restore.KeepTempFiles.Val,
 			backupDir:     t.args.BackupDir,
 			backupStorage: t.args.BackupStorage,
 			milvusStorage: t.args.MilvusStorage,
@@ -509,7 +516,7 @@ func (t *Task) runCollTasks(ctx context.Context, collTasks []*collTask) error {
 	t.logger.Info("start restore collection")
 
 	g, subCtx := errgroup.WithContext(ctx)
-	g.SetLimit(t.args.Params.Backup.Parallelism.RestoreCollection.Val)
+	g.SetLimit(t.args.Params.Restore.Concurrency.Collections.Val)
 	for _, collTask := range collTasks {
 		g.Go(func() error {
 			if err := collTask.Execute(subCtx); err != nil {

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -24,7 +24,7 @@ func newTestTask() *Task {
 
 		args: TaskArgs{
 			Plan:   &Plan{},
-			Params: &cfg.Config{},
+			Params: &v2.Config{},
 		},
 	}
 }

--- a/core/server/check.go
+++ b/core/server/check.go
@@ -28,12 +28,12 @@ func (s *Server) handleCheck(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &s.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, s.params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	backupStorage, err := storage.NewBackupStorage(ctx, &s.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, s.params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/backup"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/utils"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
@@ -51,7 +51,7 @@ func (s *Server) handleCreateBackup(c *gin.Context) {
 }
 
 type createBackupHandler struct {
-	params *cfg.Config
+	params *v2.Config
 
 	request *backuppb.CreateBackupRequest
 
@@ -60,7 +60,7 @@ type createBackupHandler struct {
 	milvusStorage storage.Client
 }
 
-func newCreateBackupHandler(request *backuppb.CreateBackupRequest, params *cfg.Config) *createBackupHandler {
+func newCreateBackupHandler(request *backuppb.CreateBackupRequest, params *v2.Config) *createBackupHandler {
 	return &createBackupHandler{request: request, params: params}
 }
 
@@ -71,13 +71,13 @@ func (h *createBackupHandler) complete() {
 }
 
 func (h *createBackupHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return err
 	}
 	h.backupStorage = backupStorage
 
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &h.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func (h *createBackupHandler) toStrategy() (backup.Strategy, error) {
 	return backup.StrategyAuto, nil
 }
 
-func (h *createBackupHandler) toOption(params *cfg.Config) (backup.Option, error) {
+func (h *createBackupHandler) toOption(params *v2.Config) (backup.Option, error) {
 	f, err := h.toFilter()
 	if err != nil {
 		return backup.Option{}, fmt.Errorf("server: build filter: %w", err)
@@ -187,7 +187,7 @@ func (h *createBackupHandler) toOption(params *cfg.Config) (backup.Option, error
 
 	return backup.Option{
 		BackupName:       h.request.GetBackupName(),
-		PauseGC:          h.request.GetGcPauseEnable() || params.Backup.GCPause.Enable.Val,
+		PauseGC:          h.request.GetGcPauseEnable() || params.Backup.PauseGC.Val,
 		ManageAddr:       manageAddr,
 		Strategy:         strategy,
 		BackupRBAC:       h.request.GetRbac(),
@@ -202,7 +202,7 @@ func (h *createBackupHandler) toArgs() (backup.TaskArgs, error) {
 		return backup.TaskArgs{}, fmt.Errorf("server: build option: %w", err)
 	}
 
-	backupRoot := h.params.Minio.BackupRootPath.Val
+	backupRoot := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetBackupRootPath() != "" {
 		backupRoot = h.request.GetBackupRootPath()
 		log.Info("use backup root from request", zap.String("backup_root", backupRoot))

--- a/core/server/del.go
+++ b/core/server/del.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/core/del"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )
@@ -38,14 +38,14 @@ func (s *Server) handleDeleteBackup(c *gin.Context) {
 }
 
 type delHandler struct {
-	params *cfg.Config
+	params *v2.Config
 
 	req *backuppb.DeleteBackupRequest
 
 	backupStorage storage.Client
 }
 
-func newDelHandler(req *backuppb.DeleteBackupRequest, params *cfg.Config) *delHandler {
+func newDelHandler(req *backuppb.DeleteBackupRequest, params *v2.Config) *delHandler {
 	return &delHandler{
 		req:    req,
 		params: params,
@@ -67,7 +67,7 @@ func (h *delHandler) validate() error {
 }
 
 func (h *delHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create backup storage: %w", err)
 	}
@@ -93,7 +93,7 @@ func (h *delHandler) run(ctx context.Context) *backuppb.DeleteBackupResponse {
 		return resp
 	}
 
-	task := del.NewTask(h.backupStorage, mpath.BackupDir(h.params.Minio.BackupRootPath.Val, h.req.GetBackupName()))
+	task := del.NewTask(h.backupStorage, mpath.BackupDir(h.params.Backup.Storage.RootPath.Val, h.req.GetBackupName()))
 	if err := task.Execute(ctx); err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()

--- a/core/server/get_backup.go
+++ b/core/server/get_backup.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
@@ -52,12 +52,12 @@ type getBackupHandler struct {
 
 	taskMgr *taskmgr.Mgr
 
-	params *cfg.Config
+	params *v2.Config
 
 	backupStorage storage.Client
 }
 
-func newGetBackupHandler(request *backuppb.GetBackupRequest, params *cfg.Config) *getBackupHandler {
+func newGetBackupHandler(request *backuppb.GetBackupRequest, params *v2.Config) *getBackupHandler {
 	return &getBackupHandler{request: request, params: params, taskMgr: taskmgr.DefaultMgr()}
 }
 
@@ -76,7 +76,7 @@ func (h *getBackupHandler) validate() error {
 }
 
 func (h *getBackupHandler) initClient(ctx context.Context) error {
-	cli, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	cli, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: init backup storage client %w", err)
 	}
@@ -137,7 +137,7 @@ func (h *getBackupHandler) get(ctx context.Context) *backuppb.BackupInfoResponse
 
 func (h *getBackupHandler) readFromStorage(ctx context.Context, backupName string) (*backuppb.BackupInfo, int64, error) {
 	// get backup meta from storage
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetPath() != "" {
 		backupRootPath = h.request.GetPath()
 	}

--- a/core/server/list.go
+++ b/core/server/list.go
@@ -31,7 +31,7 @@ func (s *Server) handleListBackups(c *gin.Context) {
 		return
 	}
 
-	backupStorage, err := storage.NewBackupStorage(c.Request.Context(), &s.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(c.Request.Context(), s.params)
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
@@ -39,7 +39,7 @@ func (s *Server) handleListBackups(c *gin.Context) {
 		return
 	}
 
-	summaries, err := meta.List(c.Request.Context(), backupStorage, s.params.Minio.BackupRootPath.Val)
+	summaries, err := meta.List(c.Request.Context(), backupStorage, s.params.Backup.Storage.RootPath.Val)
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore"
 	"github.com/zilliztech/milvus-backup/core/utils"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
@@ -51,7 +51,7 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 }
 
 type restoreHandler struct {
-	params  *cfg.Config
+	params  *v2.Config
 	request *backuppb.RestoreBackupRequest
 
 	backupStorage  storage.Client
@@ -60,7 +60,7 @@ type restoreHandler struct {
 	milvusStorage storage.Client
 }
 
-func newRestoreHandler(request *backuppb.RestoreBackupRequest, params *cfg.Config) *restoreHandler {
+func newRestoreHandler(request *backuppb.RestoreBackupRequest, params *v2.Config) *restoreHandler {
 	return &restoreHandler{request: request, params: params}
 }
 
@@ -133,7 +133,7 @@ func (h *restoreHandler) complete() {
 }
 
 func (h *restoreHandler) initClient(ctx context.Context) error {
-	backupCfg := storage.BackupStorageConfig(&h.params.Minio)
+	backupCfg := storage.BackupStorageConfig(h.params)
 	if h.request.GetBucketName() != "" {
 		log.Info("use bucket name from request", zap.String("bucketName", h.request.GetBucketName()))
 		backupCfg.Bucket = h.request.GetBucketName()
@@ -146,13 +146,13 @@ func (h *restoreHandler) initClient(ctx context.Context) error {
 		return fmt.Errorf("server: create backup bucket: %w", err)
 	}
 
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if h.request.GetPath() != "" {
 		log.Info("use path from request", zap.String("path", h.request.GetPath()))
 		backupRootPath = h.request.GetPath()
 	}
 
-	milvusStorage, err := storage.NewMilvusStorage(ctx, &h.params.Minio)
+	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create milvus storage: %w", err)
 	}

--- a/core/server/restore_secondary.go
+++ b/core/server/restore_secondary.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore/secondary"
 	"github.com/zilliztech/milvus-backup/core/tasklet"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
@@ -47,12 +47,12 @@ func (s *Server) handleRestoreSecondary(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-func newRestoreSecondaryHandler(request *backuppb.RestoreSecondaryRequest, params *cfg.Config) *restoreSecondaryHandler {
+func newRestoreSecondaryHandler(request *backuppb.RestoreSecondaryRequest, params *v2.Config) *restoreSecondaryHandler {
 	return &restoreSecondaryHandler{request: request, params: params}
 }
 
 type restoreSecondaryHandler struct {
-	params  *cfg.Config
+	params  *v2.Config
 	request *backuppb.RestoreSecondaryRequest
 
 	backupStorage  storage.Client
@@ -122,12 +122,12 @@ func (h *restoreSecondaryHandler) run(ctx context.Context) *backuppb.RestoreBack
 }
 
 func (h *restoreSecondaryHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, &h.params.Minio)
+	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
 	if err != nil {
 		return fmt.Errorf("server: create backup storage: %w", err)
 	}
 
-	backupRootPath := h.params.Minio.BackupRootPath.Val
+	backupRootPath := h.params.Backup.Storage.RootPath.Val
 	if len(h.request.GetPath()) != 0 {
 		backupRootPath = h.request.GetPath()
 	}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -9,17 +9,17 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 
 	"github.com/zilliztech/milvus-backup/docs"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 )
 
 // Server is the Backup Server
 type Server struct {
 	engine *gin.Engine
 	config *config
-	params *cfg.Config
+	params *v2.Config
 }
 
-func New(params *cfg.Config, opts ...Option) (*Server, error) {
+func New(params *v2.Config, opts ...Option) (*Server, error) {
 	cfg := newDefaultConfig()
 	for _, opt := range opts {
 		opt(cfg)
@@ -42,7 +42,7 @@ func (s *Server) Run() error {
 
 // registerHTTPServer register the http server, panic when failed
 func (s *Server) initEngine() {
-	if !s.params.HTTP.DebugMode.Val {
+	if !s.params.Server.DebugMode.Val {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
@@ -51,7 +51,7 @@ func (s *Server) initEngine() {
 
 	s.engine = engine
 
-	if bp := s.params.HTTP.SwaggerBasePath.Val; bp != "" {
+	if bp := s.params.Server.SwaggerBasePath.Val; bp != "" {
 		docs.SwaggerInfo.BasePath = bp
 	}
 

--- a/internal/cfg/load.go
+++ b/internal/cfg/load.go
@@ -8,12 +8,19 @@ import (
 //
 // precedence: overrides (--set) > env > config file > default
 func Load(configPath string, overrides map[string]string) (*Config, error) {
-	cfg := New()
-
 	src, err := param.NewSource(configPath, overrides)
 	if err != nil {
 		return nil, err
 	}
+
+	return LoadFrom(src)
+}
+
+// LoadFrom resolves a v1 configuration from an already read source. It is the
+// entry point the version dispatcher uses, so the file is read only once.
+func LoadFrom(src *param.Source) (*Config, error) {
+	cfg := New()
+
 	if err := cfg.Resolve(src); err != nil {
 		return nil, err
 	}

--- a/internal/cfg/loader/load.go
+++ b/internal/cfg/loader/load.go
@@ -1,0 +1,82 @@
+// Package loader resolves a milvus-backup configuration file of either schema
+// version into the v2 configuration the rest of the program runs on.
+//
+// A v1 file is decoded with the v1 schema and then translated, rather than
+// teaching the v2 schema to read v1 names: one file is decoded as one schema
+// version, and the mapping between them lives in one place, next to the
+// `config migrate` command that writes the same mapping out as a file.
+package loader
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/migrate"
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/log"
+)
+
+// versionV1 is what a config file declares to ask for the v1 schema. v1 files
+// predate the discriminator, so it is never required; it exists so a file can
+// say which schema it is written in rather than being identified by omission.
+const versionV1 = "v1"
+
+// Load resolves the configuration at configPath into a v2 configuration,
+// whichever schema version the file is written in.
+//
+// precedence: overrides (--set) > env > config file > default, among the names
+// the file's own schema version defines. A v1 file is resolved with v1 names,
+// including the v1 environment variables, and translated afterwards.
+func Load(configPath string, overrides map[string]string) (*v2.Config, error) {
+	src, err := param.NewSource(configPath, overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	version, declared := v2.DeclaredVersion(src)
+	if !declared {
+		// With no file, overrides and env are all there is, and they name v2
+		// parameters. With a file, the missing discriminator dates it to v1.
+		if src.ConfigFilePath() == "" {
+			return v2.LoadFrom(src)
+		}
+
+		return loadV1(src)
+	}
+
+	switch {
+	case strings.EqualFold(version, v2.Version):
+		return v2.LoadFrom(src)
+	case strings.EqualFold(version, versionV1):
+		return loadV1(src)
+	default:
+		return nil, fmt.Errorf("cfg: %s declares %s %q, which is not a schema version this build knows (want %q or %q)",
+			src.ConfigFilePath(), v2.VersionKey, version, versionV1, v2.Version)
+	}
+}
+
+// loadV1 resolves a v1 file and translates it into the v2 configuration the
+// program runs on, so a deployment that has not migrated yet keeps working.
+func loadV1(src *param.Source) (*v2.Config, error) {
+	v1, err := cfg.LoadFrom(src)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := migrate.Translate(v1)
+	if err != nil {
+		return nil, err
+	}
+
+	// Say so once per run: the v1 schema is still read, but the translation is a
+	// compatibility step, and `config migrate` turns it into a file to keep.
+	log.Warn("cfg: loaded a v1 configuration and translated it to v2; "+
+		"run `milvus-backup config migrate` to convert the file itself",
+		zap.String("path", src.ConfigFilePath()))
+
+	return out, nil
+}

--- a/internal/cfg/loader/load_test.go
+++ b/internal/cfg/loader/load_test.go
@@ -1,0 +1,124 @@
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// write puts content in a temp file and returns its path, so a test starts from
+// a real file the loader has to identify on its own.
+func write(t *testing.T, content string) string {
+	t.Helper()
+
+	p := filepath.Join(t.TempDir(), "backup.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+
+	return p
+}
+
+func TestLoad_V2File(t *testing.T) {
+	out, err := Load(write(t, `
+configVersion: v2
+milvus:
+  grpc:
+    address: milvus-proxy
+    port: 19531
+`), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "milvus-proxy", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
+}
+
+// A file without the discriminator predates it, so it is v1 and gets
+// translated. The v1 spellings have to land in their v2 homes.
+func TestLoad_V1FileIsTranslated(t *testing.T) {
+	out, err := Load(write(t, `
+milvus:
+  address: milvus-proxy
+  port: 19531
+  rpcChannelName: my-replicate
+backup:
+  gcPause:
+    address: http://datacoord:9091
+  parallelism:
+    copydata: 32
+`), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "milvus-proxy", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
+	assert.Equal(t, "my-replicate", out.Milvus.Replicate.RPCChannelName.Val)
+	assert.Equal(t, "http://datacoord:9091", out.Milvus.Management.Endpoint.Val)
+	assert.Equal(t, 32, out.Transfer.Concurrency.Val)
+}
+
+// Naming the v1 schema explicitly picks the same path as omitting the key.
+func TestLoad_V1FileWithExplicitVersion(t *testing.T) {
+	out, err := Load(write(t, `
+configVersion: v1
+milvus:
+  address: milvus-proxy
+`), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "milvus-proxy", out.Milvus.Grpc.Address.Val)
+}
+
+// A v1 deployment keeps its v1 environment variables, because the v1 file is
+// resolved with the v1 schema before anything is translated.
+func TestLoad_V1EnvNamesStillResolve(t *testing.T) {
+	t.Setenv("MILVUS_ADDRESS", "from-v1-env")
+	t.Setenv("MINIO_BUCKET_NAME", "v1-bucket")
+
+	out, err := Load(write(t, "milvus:\n  port: 19531\n"), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-v1-env", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, "v1-bucket", out.Milvus.Storage.BucketName.Val)
+}
+
+// A v2 file is resolved with v2 names only, so a v1 variable left set in the
+// environment is inert rather than quietly winning.
+func TestLoad_V2FileIgnoresV1EnvNames(t *testing.T) {
+	t.Setenv("MILVUS_ADDRESS", "from-v1-env")
+	t.Setenv("MILVUS_GRPC_ADDRESS", "from-v2-env")
+
+	out, err := Load(write(t, "configVersion: v2\n"), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-v2-env", out.Milvus.Grpc.Address.Val)
+}
+
+// With no file there is no discriminator to read, and nothing to be backward
+// compatible with either: overrides and env name v2 parameters.
+func TestLoad_NoConfigFileUsesV2Names(t *testing.T) {
+	t.Setenv("MILVUS_GRPC_ADDRESS", "from-v2-env")
+
+	out, err := Load("", map[string]string{"MILVUS_GRPC_PORT": "19531"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-v2-env", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
+}
+
+func TestLoad_UnknownVersion(t *testing.T) {
+	_, err := Load(write(t, "configVersion: v3\n"), nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "v3")
+	assert.ErrorContains(t, err, "not a schema version this build knows")
+}
+
+// The v1 path validates what it produced, so a provider v1 never checked fails
+// while the config is being loaded instead of when a client is built.
+func TestLoad_V1ValidationError(t *testing.T) {
+	_, err := Load(write(t, "minio:\n  storageType: bogus\n"), nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bogus")
+}

--- a/internal/cfg/v2/load.go
+++ b/internal/cfg/v2/load.go
@@ -46,6 +46,32 @@ func LoadFrom(src *param.Source) (*Config, error) {
 	return cfg, nil
 }
 
+// DeclaredVersion returns the schema version the config file declares, and
+// whether it declares one at all. The version dispatcher reads it to pick the
+// schema a file is decoded with.
+//
+// Declaring nothing means one of two things, which the caller tells apart by
+// whether there is a file: a source with no config file is env-only, and a file
+// without the key predates the discriminator, which arrived with v2.
+func DeclaredVersion(src *param.Source) (string, bool) {
+	if src.ConfigFilePath() == "" {
+		return "", false
+	}
+
+	raw, ok := src.ConfigFileValue(VersionKey)
+	if !ok {
+		return "", false
+	}
+	// A version that is not a string is still a declaration, just an unusable
+	// one. Report it as written so the caller can quote it back.
+	version, ok := raw.(string)
+	if !ok {
+		return fmt.Sprint(raw), true
+	}
+
+	return version, true
+}
+
 // checkVersion verifies the file carries the v2 discriminator. A source with
 // no config file is env-only and has no version to check.
 func checkVersion(src *param.Source) error {
@@ -53,16 +79,14 @@ func checkVersion(src *param.Source) error {
 		return nil
 	}
 
-	raw, ok := src.ConfigFileValue(VersionKey)
+	version, ok := DeclaredVersion(src)
 	if !ok {
 		return fmt.Errorf("cfg: %s is not a v2 config: missing %q, expected %q",
 			src.ConfigFilePath(), VersionKey, Version)
 	}
-
-	version, ok := raw.(string)
-	if !ok || !strings.EqualFold(version, Version) {
+	if !strings.EqualFold(version, Version) {
 		return fmt.Errorf("cfg: %s declares %s %v, but the v2 loader only accepts %q",
-			src.ConfigFilePath(), VersionKey, raw, Version)
+			src.ConfigFilePath(), VersionKey, version, Version)
 	}
 
 	return nil

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/internal/aimd"
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/retry"
@@ -232,23 +232,15 @@ func grpcAuth(username, password string) string {
 	return ""
 }
 
-func transCred(cfg *cfg.MilvusConfig) (credentials.TransportCredentials, error) {
-	tlsMode := cfg.TLSMode.Val
-	if tlsMode < 0 || tlsMode > 2 {
-		return nil, errors.New("milvus.TLSMode is illegal, support value 0, 1, 2")
-	}
-
-	// tls mode 0 disable tls
-	if tlsMode == 0 {
+func transCred(c *v2.MilvusGrpcConfig) (credentials.TransportCredentials, error) {
+	if c.TLSMode.Val == v2.TLSDisabled {
 		return insecure.NewCredentials(), nil
 	}
 
-	// tls mode 1, 2
-
-	// validate server cert
-	tlsCfg := &tls.Config{ServerName: cfg.ServerName.Val}
-	if cfg.CACertPath.Val != "" {
-		b, err := os.ReadFile(cfg.CACertPath.Val)
+	// Both server and mutual verify the server certificate.
+	tlsCfg := &tls.Config{ServerName: c.ServerName.Val}
+	if c.CACertPath.Val != "" {
+		b, err := os.ReadFile(c.CACertPath.Val)
 		if err != nil {
 			return nil, fmt.Errorf("client: read ca cert %w", err)
 		}
@@ -260,22 +252,12 @@ func transCred(cfg *cfg.MilvusConfig) (credentials.TransportCredentials, error) 
 		tlsCfg.RootCAs = cp
 	}
 
-	// tls mode 1, server tls
-	if tlsMode == 1 {
-		return credentials.NewTLS(tlsCfg), nil
-	}
-
-	// tls mode 2, mutual tls
-	// use mTLS but key/cert path not set, for backward compatibility, use server tls instead
-	// WARN: this behavior will be removed after v0.6.0
-	if tlsMode == 2 {
-		if cfg.MTLSKeyPath.Val == "" || cfg.MTLSCertPath.Val == "" {
-			log.Warn("client: mutual tls enabled but key/cert path not set! will use server tls instead")
-			return credentials.NewTLS(tlsCfg), nil
-		}
-
-		// use mTLS
-		cert, err := tls.LoadX509KeyPair(cfg.MTLSCertPath.Val, cfg.MTLSKeyPath.Val)
+	// Mutual additionally presents a client certificate. v1 quietly fell back to
+	// server TLS when the key pair was missing; nothing falls back here, because
+	// a v2 config is rejected in validation and a v1 config is downgraded while
+	// it is translated. Silently weakening TLS is not something to keep doing.
+	if c.TLSMode.Val == v2.TLSMutual {
+		cert, err := tls.LoadX509KeyPair(c.MTLSCertPath.Val, c.MTLSKeyPath.Val)
 		if err != nil {
 			return nil, fmt.Errorf("client: load client cert: %w", err)
 		}
@@ -296,15 +278,15 @@ func isUnimplemented(err error) bool {
 	return s.Code() == codes.Unimplemented
 }
 
-func NewGrpc(cfg *cfg.MilvusConfig) (*GrpcClient, error) {
+func NewGrpc(c *v2.MilvusConfig) (*GrpcClient, error) {
 	logger := log.L()
 
-	host := net.JoinHostPort(cfg.Address.Val, strconv.Itoa(cfg.Port.Val))
+	host := net.JoinHostPort(c.Grpc.Address.Val, strconv.Itoa(c.Grpc.Port.Val))
 	logger.Info("New milvus grpc client", zap.String("host", host))
 
-	auth := grpcAuth(cfg.User.Val, cfg.Password.Val)
+	auth := grpcAuth(c.User.Val, c.Password.Val)
 
-	cerd, err := transCred(cfg)
+	cerd, err := transCred(&c.Grpc)
 	if err != nil {
 		return nil, fmt.Errorf("client: create transport credentials: %w", err)
 	}
@@ -325,7 +307,7 @@ func NewGrpc(cfg *cfg.MilvusConfig) (*GrpcClient, error) {
 
 		limiters: newLimiters(),
 
-		user: cfg.User.Val,
+		user: c.User.Val,
 		auth: auth,
 	}
 

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -16,7 +16,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 )
 
@@ -29,21 +30,30 @@ func TestGrpcAuth(t *testing.T) {
 }
 
 func TestTransCred(t *testing.T) {
-	cred, err := transCred(&cfg.MilvusConfig{TLSMode: cfg.Value[int]{Val: 3}})
-	assert.Error(t, err)
-	assert.Nil(t, cred)
+	t.Run("Disabled", func(t *testing.T) {
+		cred, err := transCred(&v2.MilvusGrpcConfig{TLSMode: param.Value[string]{Val: v2.TLSDisabled}})
+		assert.NoError(t, err)
+		assert.Equal(t, insecure.NewCredentials(), cred)
+	})
 
-	cred, err = transCred(&cfg.MilvusConfig{TLSMode: cfg.Value[int]{Val: 0}})
-	assert.NoError(t, err)
-	assert.Equal(t, insecure.NewCredentials(), cred)
+	t.Run("Server", func(t *testing.T) {
+		cred, err := transCred(&v2.MilvusGrpcConfig{TLSMode: param.Value[string]{Val: v2.TLSServer}})
+		assert.NoError(t, err)
+		assert.NotNil(t, cred)
+	})
 
-	cred, err = transCred(&cfg.MilvusConfig{TLSMode: cfg.Value[int]{Val: 1}})
-	assert.NoError(t, err)
-	assert.NotNil(t, cred)
-
-	cred, err = transCred(&cfg.MilvusConfig{TLSMode: cfg.Value[int]{Val: 2}})
-	assert.NoError(t, err)
-	assert.NotNil(t, cred)
+	// v1 quietly fell back to server TLS when the mutual key pair was missing
+	// or unreadable. Configuration validation rules out a missing pair, and an
+	// unreadable one is an error rather than a weaker connection.
+	t.Run("MutualWithUnreadableKeyPair", func(t *testing.T) {
+		cred, err := transCred(&v2.MilvusGrpcConfig{
+			TLSMode:      param.Value[string]{Val: v2.TLSMutual},
+			MTLSCertPath: param.Value[string]{Val: "/no/such/cert.pem"},
+			MTLSKeyPath:  param.Value[string]{Val: "/no/such/key.pem"},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, cred)
+	})
 }
 
 func TestIsUnimplemented(t *testing.T) {

--- a/internal/client/milvus/restful.go
+++ b/internal/client/milvus/restful.go
@@ -2,7 +2,6 @@ package milvus
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -11,7 +10,7 @@ import (
 	"github.com/imroc/req/v3"
 	"go.uber.org/zap"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/retry"
 )
@@ -250,25 +249,31 @@ func restfulAuth(username, password string) string {
 	return ""
 }
 
-func NewRestful(cfg *cfg.MilvusConfig) (*RestfulClient, error) {
-	host := net.JoinHostPort(cfg.Address.Val, strconv.Itoa(cfg.Port.Val))
-	log.Info("new milvus restful client", zap.String("host", host))
-
-	var baseURL string
-	switch cfg.TLSMode.Val {
-	case 0:
-		baseURL = "http://" + host
-	case 1, 2:
-		baseURL = "https://" + host
-	default:
-		return nil, errors.New("client: invalid tls mode")
-	}
+func NewRestful(c *v2.MilvusConfig) (*RestfulClient, error) {
+	baseURL := restfulBaseURL(c)
+	log.Info("new milvus restful client", zap.String("baseURL", baseURL))
 
 	cli := req.C().SetBaseURL(baseURL)
 
-	if auth := restfulAuth(cfg.User.Val, cfg.Password.Val); len(auth) != 0 {
+	if auth := restfulAuth(c.User.Val, c.Password.Val); len(auth) != 0 {
 		cli.SetCommonBearerAuthToken(auth)
 	}
 
 	return &RestfulClient{cli: cli}, nil
+}
+
+// restfulBaseURL uses the configured REST endpoint, and derives one from the
+// gRPC connection when none is set, which covers the deployments where a single
+// proxy serves both protocols.
+func restfulBaseURL(c *v2.MilvusConfig) string {
+	if endpoint := c.Rest.Endpoint.Val; endpoint != "" {
+		return endpoint
+	}
+
+	host := net.JoinHostPort(c.Grpc.Address.Val, strconv.Itoa(c.Grpc.Port.Val))
+	if c.Grpc.TLSMode.Val == v2.TLSDisabled {
+		return "http://" + host
+	}
+
+	return "https://" + host
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -40,7 +40,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
 	"github.com/zilliztech/milvus-backup/internal/progressbar"
 )
 
@@ -57,19 +56,11 @@ func init() {
 	_globalR.Store(r)
 }
 
-func InitLogger(params *cfg.LogConfig) {
-	cfg := &Config{
-		Level:   params.Level.Val,
-		Console: params.Console.Val,
-		File: FileLogConfig{
-			Filename:   params.File.Filename.Val,
-			MaxSize:    params.File.MaxSize.Val,
-			MaxDays:    params.File.MaxDays.Val,
-			MaxBackups: params.File.MaxBackups.Val,
-		},
-	}
-
-	lg, p, err := initLogger(cfg)
+// InitLogger replaces the global logger with one built from conf. The caller
+// maps its own configuration onto Config, which keeps this package free of any
+// configuration schema — the schema packages log through it.
+func InitLogger(conf *Config) {
+	lg, p, err := initLogger(conf)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -8,58 +8,91 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 )
 
-func newBackupCredential(params *cfg.MinioConfig) Credential {
-	var cred Credential
-	if params.BackupStorageType.Val == cfg.CloudProviderAzure {
-		cred.AzureAccountName = params.BackupAccessKeyID.Val
-	}
+// newCredential maps a storage section's auth onto the credential the clients
+// take. v2 names the authentication method outright, so this is a switch on
+// auth.type rather than v1's guesswork over the provider, the useIAM flag and
+// whether a GCP credential file happened to be set.
+func newCredential(s *v2.StorageConfig) Credential {
+	auth := &s.Auth
 
-	if params.BackupUseIAM.Val {
-		cred.Type = IAM
-		cred.IAMEndpoint = params.BackupIAMEndpoint.Val
-		return cred
-	}
+	// Azure builds its service URL from the account name whichever way it
+	// authenticates, so the name is carried on every credential.
+	cred := Credential{AzureAccountName: s.AccountName.Val}
 
-	if params.BackupStorageType.Val == cfg.CloudProviderGCPNative &&
-		params.BackupGcpCredentialJSON.Val != "" {
+	switch auth.Type.Val {
+	case v2.AuthSharedKey:
+		// Azure signs with the account name and one of its access keys.
+		cred.Type = Static
+		cred.AK = s.AccountName.Val
+		cred.SK = auth.AccountKey.Val
+	case v2.AuthServiceAccount:
 		cred.Type = GCPCredJSON
-		cred.GCPCredJSON = params.BackupGcpCredentialJSON.Val
-		return cred
+		cred.GCPCredJSON = auth.CredentialsFile.Val
+	case v2.AuthIAM:
+		cred.Type = IAM
+		cred.IAMEndpoint = auth.Endpoint.Val
+	case v2.AuthDefault:
+		// The provider SDK resolves credentials on its own: an instance role,
+		// workload identity, or DefaultAzureCredential. That is what the clients
+		// already do for IAM when there is no endpoint to fetch from.
+		cred.Type = IAM
+	default:
+		cred.Type = Static
+		cred.AK = auth.AccessKeyID.Val
+		cred.SK = auth.SecretAccessKey.Val
+		cred.Token = auth.SessionToken.Val
 	}
 
-	cred.Type = Static
-	cred.AK = params.BackupAccessKeyID.Val
-	cred.SK = params.BackupSecretAccessKey.Val
-	cred.Token = params.BackupToken.Val
 	return cred
 }
 
-func BackupStorageConfig(params *cfg.MinioConfig) Config {
-	ep := net.JoinHostPort(params.BackupAddress.Val, strconv.Itoa(params.BackupPort.Val))
+// storageConfig maps one storage section onto a client config.
+// multipartCopyThresholdMiB is passed in because it belongs to the transfer
+// policy rather than to either backend: it describes how bytes move between
+// them.
+func storageConfig(s *v2.StorageConfig, multipartCopyThresholdMiB int64) Config {
 	return Config{
-		Provider:                  params.BackupStorageType.Val,
-		Endpoint:                  ep,
-		UseSSL:                    params.BackupUseSSL.Val,
-		Bucket:                    params.BackupBucketName.Val,
-		Credential:                newBackupCredential(params),
-		Region:                    params.BackupRegion.Val,
-		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
+		Provider:                  s.Provider.Val,
+		Endpoint:                  net.JoinHostPort(s.Address.Val, strconv.Itoa(s.Port.Val)),
+		UseSSL:                    s.UseSSL.Val,
+		Region:                    s.Region.Val,
+		Credential:                newCredential(s),
+		Bucket:                    s.BucketName.Val,
+		MultipartCopyThresholdMiB: multipartCopyThresholdMiB,
 	}
 }
 
-func NewBackupStorage(ctx context.Context, params *cfg.MinioConfig) (Client, error) {
-	ep := net.JoinHostPort(params.BackupAddress.Val, strconv.Itoa(params.BackupPort.Val))
+// MilvusStorageConfig describes the backend the Milvus deployment keeps its
+// data in.
+func MilvusStorageConfig(c *v2.Config) Config {
+	return storageConfig(&c.Milvus.Storage, c.Transfer.MultipartCopyThresholdMiB.Val)
+}
+
+// BackupStorageConfig describes the backend backup data is written to.
+func BackupStorageConfig(c *v2.Config) Config {
+	return storageConfig(&c.Backup.Storage, c.Transfer.MultipartCopyThresholdMiB.Val)
+}
+
+func NewMilvusStorage(ctx context.Context, c *v2.Config) (Client, error) {
+	conf := MilvusStorageConfig(c)
+	log.Info("create milvus storage client",
+		zap.String("endpoint", conf.Endpoint),
+		zap.String("bucket", conf.Bucket))
+
+	return NewClient(ctx, conf)
+}
+
+func NewBackupStorage(ctx context.Context, c *v2.Config) (Client, error) {
+	conf := BackupStorageConfig(c)
 	log.Info("create backup storage client",
-		zap.String("endpoint", ep),
-		zap.String("bucket", params.BackupBucketName.Val))
+		zap.String("endpoint", conf.Endpoint),
+		zap.String("bucket", conf.Bucket))
 
-	cfg := BackupStorageConfig(params)
-
-	cli, err := NewClient(ctx, cfg)
+	cli, err := NewClient(ctx, conf)
 	if err != nil {
 		return nil, fmt.Errorf("create backup storage client: %w", err)
 	}
@@ -70,73 +103,54 @@ func NewBackupStorage(ctx context.Context, params *cfg.MinioConfig) (Client, err
 	return cli, nil
 }
 
-func newMilvusCredential(params *cfg.MinioConfig) Credential {
-	var cred Credential
-	if params.StorageType.Val == cfg.CloudProviderAzure {
-		cred.AzureAccountName = params.AccessKeyID.Val
-	}
-
-	if params.UseIAM.Val {
-		cred.Type = IAM
-		cred.IAMEndpoint = params.IAMEndpoint.Val
-		return cred
-	}
-
-	if params.StorageType.Val == cfg.CloudProviderGCPNative &&
-		params.GcpCredentialJSON.Val != "" {
-		cred.Type = GCPCredJSON
-		cred.GCPCredJSON = params.GcpCredentialJSON.Val
-		return cred
-	}
-
-	cred.Type = Static
-	cred.AK = params.AccessKeyID.Val
-	cred.SK = params.SecretAccessKey.Val
-	cred.Token = params.Token.Val
-	return cred
-}
-
-func MilvusStorageConfig(params *cfg.MinioConfig) Config {
-	ep := net.JoinHostPort(params.Address.Val, strconv.Itoa(params.Port.Val))
-	return Config{
-		Provider:                  params.StorageType.Val,
-		Endpoint:                  ep,
-		UseSSL:                    params.UseSSL.Val,
-		Credential:                newMilvusCredential(params),
-		Bucket:                    params.BucketName.Val,
-		Region:                    params.Region.Val,
-		MultipartCopyThresholdMiB: params.MultipartCopyThresholdMiB.Val,
+// UseStreaming reports whether objects have to be streamed through
+// milvus-backup rather than copied by the storage service itself.
+//
+// v1 asked this as the boolean minio.crossStorage, and separately forced
+// streaming when the two providers differed. v2 states the policy directly:
+// auto keeps that rule, while direct and streaming pin the answer.
+func UseStreaming(mode string, src, dest Config) bool {
+	switch mode {
+	case v2.TransferStreaming:
+		return true
+	case v2.TransferDirect:
+		return false
+	default:
+		return !sameBackend(src, dest)
 	}
 }
 
-func NewMilvusStorage(ctx context.Context, params *cfg.MinioConfig) (Client, error) {
-	ep := net.JoinHostPort(params.Address.Val, strconv.Itoa(params.Port.Val))
-	log.Info("create milvus storage client",
-		zap.String("endpoint", ep),
-		zap.String("bucket", params.BucketName.Val))
-
-	cfg := MilvusStorageConfig(params)
-
-	return NewClient(ctx, cfg)
+// sameBackend reports whether two configs name the same backend, i.e. the same
+// provider reached at the same endpoint. Buckets and root paths may differ
+// within one backend, so they are not compared.
+func sameBackend(a, b Config) bool {
+	return a.Provider == b.Provider &&
+		a.Endpoint == b.Endpoint &&
+		a.Region == b.Region &&
+		a.UseSSL == b.UseSSL &&
+		a.Credential.AzureAccountName == b.Credential.AzureAccountName
 }
 
 func NewClient(ctx context.Context, conf Config) (Client, error) {
+	// v2 gives each provider exactly one name, so the v1 spelling aliases (ali,
+	// alibaba, alicloud, tc) do not reach here: they are folded into the
+	// canonical name while the configuration is loaded.
 	switch conf.Provider {
-	case cfg.CloudProviderAli, cfg.CloudProviderAliyun, cfg.CloudProviderAlibaba, cfg.CloudProviderAliCloud:
+	case v2.ProviderAliyun:
 		return newAliyunClient(conf)
-	case cfg.CloudProviderAWS, cfg.S3, cfg.Minio:
+	case v2.ProviderAWS, v2.ProviderS3, v2.ProviderMinio:
 		return newMinioClient(conf)
-	case cfg.CloudProviderAzure:
+	case v2.ProviderAzure:
 		return newAzureClient(conf)
-	case cfg.CloudProviderTencent, cfg.CloudProviderTencentShort:
+	case v2.ProviderTencent:
 		return newTencentClient(conf)
-	case cfg.CloudProviderGCP:
+	case v2.ProviderGCP:
 		return newGCPClient(conf)
-	case cfg.CloudProviderGCPNative:
+	case v2.ProviderGCPNative:
 		return newGCPNativeClient(ctx, conf)
-	case cfg.CloudProviderHwc:
+	case v2.ProviderHwc:
 		return NewHwcClient(conf)
-	case cfg.Local:
+	case v2.ProviderLocal:
 		return newLocalClient(conf), nil
 	default:
 		return nil, fmt.Errorf("storage: unsupported storage type: %s", conf.Provider)

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -5,97 +5,103 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 )
 
-func TestNewBackupCredential(t *testing.T) {
-	t.Run("Azure", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupStorageType: cfg.Value[string]{Val: cfg.CloudProviderAzure},
-			BackupAccessKeyID: cfg.Value[string]{Val: "accountName"},
-			BackupUseIAM:      cfg.Value[bool]{Val: true},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "accountName", cred.AzureAccountName)
-	})
-
-	t.Run("IAM", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupUseIAM:      cfg.Value[bool]{Val: true},
-			BackupIAMEndpoint: cfg.Value[string]{Val: "iamEndpoint"},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "iamEndpoint", cred.IAMEndpoint)
-	})
-
-	t.Run("GCPCredJSON", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupStorageType:       cfg.Value[string]{Val: cfg.CloudProviderGCPNative},
-			BackupGcpCredentialJSON: cfg.Value[string]{Val: "path/to/json"},
-		}
-		cred := newBackupCredential(params)
-		assert.Equal(t, GCPCredJSON, cred.Type)
-		assert.Equal(t, "path/to/json", cred.GCPCredJSON)
-	})
-
+func TestNewCredential(t *testing.T) {
 	t.Run("Static", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			BackupAccessKeyID:     cfg.Value[string]{Val: "ak"},
-			BackupSecretAccessKey: cfg.Value[string]{Val: "sk"},
-			BackupToken:           cfg.Value[string]{Val: "token"},
-		}
-		cred := newBackupCredential(params)
+		cred := newCredential(&v2.StorageConfig{Auth: v2.StorageAuthConfig{
+			Type:            param.Value[string]{Val: v2.AuthStatic},
+			AccessKeyID:     param.Value[string]{Val: "ak"},
+			SecretAccessKey: param.Value[string]{Val: "sk"},
+			SessionToken:    param.Value[string]{Val: "token"},
+		}})
+
 		assert.Equal(t, Static, cred.Type)
 		assert.Equal(t, "ak", cred.AK)
 		assert.Equal(t, "sk", cred.SK)
 		assert.Equal(t, "token", cred.Token)
+	})
+
+	// Azure signs with the account name and one of its access keys.
+	t.Run("SharedKey", func(t *testing.T) {
+		cred := newCredential(&v2.StorageConfig{
+			AccountName: param.Value[string]{Val: "accountName"},
+			Auth: v2.StorageAuthConfig{
+				Type:       param.Value[string]{Val: v2.AuthSharedKey},
+				AccountKey: param.Value[string]{Val: "accountKey"},
+			},
+		})
+
+		assert.Equal(t, Static, cred.Type)
+		assert.Equal(t, "accountName", cred.AzureAccountName)
+		assert.Equal(t, "accountName", cred.AK)
+		assert.Equal(t, "accountKey", cred.SK)
+	})
+
+	t.Run("ServiceAccount", func(t *testing.T) {
+		cred := newCredential(&v2.StorageConfig{Auth: v2.StorageAuthConfig{
+			Type:            param.Value[string]{Val: v2.AuthServiceAccount},
+			CredentialsFile: param.Value[string]{Val: "path/to/json"},
+		}})
+
+		assert.Equal(t, GCPCredJSON, cred.Type)
+		assert.Equal(t, "path/to/json", cred.GCPCredJSON)
+	})
+
+	t.Run("IAM", func(t *testing.T) {
+		cred := newCredential(&v2.StorageConfig{Auth: v2.StorageAuthConfig{
+			Type:     param.Value[string]{Val: v2.AuthIAM},
+			Endpoint: param.Value[string]{Val: "iamEndpoint"},
+		}})
+
+		assert.Equal(t, IAM, cred.Type)
+		assert.Equal(t, "iamEndpoint", cred.IAMEndpoint)
+	})
+
+	// The SDK resolves credentials on its own, which is what the clients do for
+	// IAM when there is no endpoint to fetch them from.
+	t.Run("Default", func(t *testing.T) {
+		cred := newCredential(&v2.StorageConfig{
+			AccountName: param.Value[string]{Val: "accountName"},
+			Auth: v2.StorageAuthConfig{
+				Type: param.Value[string]{Val: v2.AuthDefault},
+			},
+		})
+
+		assert.Equal(t, IAM, cred.Type)
+		assert.Empty(t, cred.IAMEndpoint)
+		assert.Equal(t, "accountName", cred.AzureAccountName)
 	})
 }
 
-func TestNewMilvusCredential(t *testing.T) {
-	t.Run("Azure", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			StorageType: cfg.Value[string]{Val: cfg.CloudProviderAzure},
-			AccessKeyID: cfg.Value[string]{Val: "accountName"},
-			UseIAM:      cfg.Value[bool]{Val: true},
-		}
-		cred := newMilvusCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "accountName", cred.AzureAccountName)
+func TestUseStreaming(t *testing.T) {
+	minio := Config{Provider: v2.ProviderMinio, Endpoint: "localhost:9000"}
+	s3 := Config{Provider: v2.ProviderS3, Endpoint: "s3.amazonaws.com:443"}
+
+	t.Run("Streaming", func(t *testing.T) {
+		assert.True(t, UseStreaming(v2.TransferStreaming, minio, minio))
+		assert.True(t, UseStreaming(v2.TransferStreaming, minio, s3))
 	})
 
-	t.Run("IAM", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			UseIAM:      cfg.Value[bool]{Val: true},
-			IAMEndpoint: cfg.Value[string]{Val: "iamEndpoint"},
-		}
-		cred := newMilvusCredential(params)
-		assert.Equal(t, IAM, cred.Type)
-		assert.Equal(t, "iamEndpoint", cred.IAMEndpoint)
+	t.Run("Direct", func(t *testing.T) {
+		assert.False(t, UseStreaming(v2.TransferDirect, minio, minio))
+		assert.False(t, UseStreaming(v2.TransferDirect, minio, s3))
 	})
 
-	t.Run("GCPCredJSON", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			StorageType:       cfg.Value[string]{Val: cfg.CloudProviderGCPNative},
-			GcpCredentialJSON: cfg.Value[string]{Val: "path/to/json"},
-		}
-		cred := newMilvusCredential(params)
-		assert.Equal(t, GCPCredJSON, cred.Type)
-		assert.Equal(t, "path/to/json", cred.GCPCredJSON)
+	t.Run("AutoSameBackend", func(t *testing.T) {
+		assert.False(t, UseStreaming(v2.TransferAuto, minio, minio))
 	})
 
-	t.Run("Static", func(t *testing.T) {
-		params := &cfg.MinioConfig{
-			AccessKeyID:     cfg.Value[string]{Val: "ak"},
-			SecretAccessKey: cfg.Value[string]{Val: "sk"},
-			Token:           cfg.Value[string]{Val: "token"},
-		}
-		cred := newMilvusCredential(params)
-		assert.Equal(t, Static, cred.Type)
-		assert.Equal(t, "ak", cred.AK)
-		assert.Equal(t, "sk", cred.SK)
-		assert.Equal(t, "token", cred.Token)
+	t.Run("AutoDifferentBackend", func(t *testing.T) {
+		assert.True(t, UseStreaming(v2.TransferAuto, minio, s3))
+	})
+
+	// v1 only compared the provider, so two MinIO deployments looked like one
+	// backend and were copied server-side, which cannot work.
+	t.Run("AutoSameProviderDifferentEndpoint", func(t *testing.T) {
+		other := Config{Provider: v2.ProviderMinio, Endpoint: "elsewhere:9000"}
+		assert.True(t, UseStreaming(v2.TransferAuto, minio, other))
 	})
 }

--- a/internal/storage/gcp_native.go
+++ b/internal/storage/gcp_native.go
@@ -192,6 +192,14 @@ func isStandardGCSEndpoint(endpoint string) bool {
 }
 
 func newGCPNativeClient(ctx context.Context, cfg Config) (*GCPNativeClient, error) {
+	// This client only knows how to read a service account key file. Say so
+	// here: without the check the missing path surfaces as a bare "unable to
+	// read credentials file: open :" from the read below.
+	if cfg.Credential.Type != GCPCredJSON {
+		return nil, fmt.Errorf("storage: gcpnative needs a service account credentials file, got credential type %s",
+			cfg.Credential.Type)
+	}
+
 	var opts []option.ClientOption
 	// Only set a custom endpoint for a genuine non-GCS host (an emulator).
 	// For the standard GCS service we must leave the endpoint unset so the

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/zilliztech/milvus-backup/internal/cfg"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/retry"
 )
@@ -93,7 +93,7 @@ func (m *MinioClient) CopyObject(ctx context.Context, i CopyObjectInput) error {
 
 	// gcp does not support multipart copy
 	threshold := m.multipartCopyThreshold()
-	if i.SrcAttr.Length >= threshold && srcCli.cfg.Provider != cfg.CloudProviderGCP {
+	if i.SrcAttr.Length >= threshold && srcCli.cfg.Provider != v2.ProviderGCP {
 		m.logger.Debug("copy object by multipart", zap.String("src_key", i.SrcAttr.Key), zap.String("dest_key", i.DestKey))
 		return m.multiPartCopy(ctx, srcCli, i)
 	}


### PR DESCRIPTION
## Summary

The v2 schema landed alongside v1 but nothing ran on it: the loader resolved v1 names and every consumer read the v1 config. This points the program at v2 and keeps existing v1 files working by translating them, so the switch is atomic — there is no half-migrated state where some components read one schema and some read the other.

## Changes

- Add `internal/cfg/loader`, which dispatches on the `configVersion` discriminator: a v2 file loads directly, and a file without the key predates it, so it is resolved with the v1 schema — including the v1 environment variables — and translated with `migrate.Translate`. The file is read once and decoded as exactly one schema version. With no config file there is nothing to be backward compatible with, so overrides and env name v2 parameters.
- Take v2 types in the adapters. The storage factory switches on `auth.type` instead of inferring credentials from the provider, a `useIAM` flag and whether a GCP credential file happened to be set; the provider switch drops the v1 spelling aliases (`ali`, `alibaba`, `alicloud`, `tc`), which are folded into the canonical name while the config is loaded. `NewGrpc` reads the named TLS modes, and `NewRestful` prefers a configured REST endpoint over deriving one from the gRPC connection.
- Stop importing a config schema in `internal/log`: the caller maps its own configuration onto `log.Config`, which is what lets a schema package log.
- Replace `minio.crossStorage` with `storage.UseStreaming` over `transfer.mode`. `auto` keeps what v1 did for differing providers, and additionally streams between two deployments of the same provider — which v1 attempted to storage-side copy and could not. The local `crossStorage` names follow the config.
- Convert every consumer under `cmd/` and `core/` to the v2 field paths, and the affected tests along with them.

Two silent fallbacks are gone. Mutual TLS without a readable client key pair is now an error rather than a quiet downgrade to server TLS — validation rejects a v2 config that asks for it and translation settles the v1 downgrade beforehand, so nothing reaches the client. `gcpnative` says it needs a service account credentials file instead of failing on an empty path.

`configs/backup.yaml` deliberately stays v1: CI injects v1 keys into it with `yq`, so leaving it alone keeps the E2E matrix exercising the translation path. Converting it — and the `yq` keys with it — belongs in its own PR.

Part of #1089
