### PR TITLE
cfg: ship the sample configs as v2

### DIFF
--- a/.github/workflows/azure.yaml
+++ b/.github/workflows/azure.yaml
@@ -83,8 +83,8 @@ jobs:
         run: |
           # Update backup config with unique paths
           cp backup-azure.yaml backup.yaml
-          yq -i ".minio.rootPath = \"${{ steps.paths.outputs.milvus_root }}\"" backup.yaml
-          yq -i ".minio.backupRootPath = \"${{ steps.paths.outputs.backup_root }}\"" backup.yaml
+          yq -i ".milvus.storage.rootPath = \"${{ steps.paths.outputs.milvus_root }}\"" backup.yaml
+          yq -i ".backup.storage.rootPath = \"${{ steps.paths.outputs.backup_root }}\"" backup.yaml
 
       - name: Milvus deploy
         timeout-minutes: 15
@@ -95,7 +95,7 @@ jobs:
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |
           # Update Milvus config with unique root path
-          yq -i ".minio.rootPath = \"${{ steps.paths.outputs.milvus_root }}\"" user-az-storage.yaml
+          yq -i ".milvus.storage.rootPath = \"${{ steps.paths.outputs.milvus_root }}\"" user-az-storage.yaml
 
           # Deploy Milvus
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
@@ -130,10 +130,10 @@ jobs:
         timeout-minutes: 5
         shell: bash
         env:
-          MINIO_ACCESS_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          MINIO_SECRET_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
-          MINIO_BACKUP_ACCESS_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          MINIO_BACKUP_SECRET_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+          MILVUS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          MILVUS_STORAGE_AUTH_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+          BACKUP_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          BACKUP_STORAGE_AUTH_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |
           ./milvus-backup check
           ./milvus-backup list
@@ -144,10 +144,10 @@ jobs:
         timeout-minutes: 5
         shell: bash
         env:
-          MINIO_ACCESS_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          MINIO_SECRET_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
-          MINIO_BACKUP_ACCESS_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          MINIO_BACKUP_SECRET_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+          MILVUS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          MILVUS_STORAGE_AUTH_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+          BACKUP_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          BACKUP_STORAGE_AUTH_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |
           ./milvus-backup restore -n my_backup -s _recover
       

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -656,11 +656,11 @@ jobs:
         shell: bash
         run: |
           yq -i '.log.level = "debug"' configs/backup.yaml
-          yq -i '.milvus.port = 19530' configs/backup.yaml
-          yq -i '.minio.bucketName = "milvus-backup-test"' configs/backup.yaml
-          yq -i '.minio.rootPath = "backup-test-upstream"' configs/backup.yaml
-          yq -i '.minio.backupBucketName = "milvus-backup-test"' configs/backup.yaml
-          yq -i '.milvus.rpcChannelName = "backup-test-upstream-replicate-msg"' configs/backup.yaml
+          yq -i '.milvus.grpc.port = 19530' configs/backup.yaml
+          yq -i '.milvus.storage.bucketName = "milvus-backup-test"' configs/backup.yaml
+          yq -i '.milvus.storage.rootPath = "backup-test-upstream"' configs/backup.yaml
+          yq -i '.backup.storage.bucketName = "milvus-backup-test"' configs/backup.yaml
+          yq -i '.milvus.replicate.rpcChannelName = "backup-test-upstream-replicate-msg"' configs/backup.yaml
           yq -i '.milvus.etcd.rootPath = "backup-test-upstream"' configs/backup.yaml
           cat configs/backup.yaml
 
@@ -731,7 +731,7 @@ jobs:
         timeout-minutes: 1
         shell: bash
         run: |
-          yq -i '.milvus.port = 19500' configs/backup.yaml
+          yq -i '.milvus.grpc.port = 19500' configs/backup.yaml
           cat configs/backup.yaml
 
       - name: Restore secondary
@@ -835,12 +835,12 @@ jobs:
         shell: bash
         run: |
           yq -i '.log.level = "debug"' configs/backup.yaml
-          yq -i '.minio.bucketName = "milvus-bucket"' configs/backup.yaml
-          yq -i '.minio.rootPath = "file"' configs/backup.yaml
-          yq -i '.minio.backupPort = 9010' configs/backup.yaml
-          yq -i '.minio.backupBucketName = "milvus-bucket"' configs/backup.yaml
-          yq -i '.minio.backupRootPath = "backup"' configs/backup.yaml
-          yq -i '.minio.crossStorage = true' configs/backup.yaml
+          yq -i '.milvus.storage.bucketName = "milvus-bucket"' configs/backup.yaml
+          yq -i '.milvus.storage.rootPath = "file"' configs/backup.yaml
+          yq -i '.backup.storage.port = 9010' configs/backup.yaml
+          yq -i '.backup.storage.bucketName = "milvus-bucket"' configs/backup.yaml
+          yq -i '.backup.storage.rootPath = "backup"' configs/backup.yaml
+          yq -i '.transfer.mode = "streaming"' configs/backup.yaml
           cat configs/backup.yaml || true
           go get
           go build
@@ -912,8 +912,8 @@ jobs:
         timeout-minutes: 5
         shell: bash
         run: |
-          yq -i '.milvus.port = 19531' configs/backup.yaml
-          yq -i '.minio.port = 9010' configs/backup.yaml
+          yq -i '.milvus.grpc.port = 19531' configs/backup.yaml
+          yq -i '.milvus.storage.port = 9010' configs/backup.yaml
       - name: Restore backup
         timeout-minutes: 5
         shell: bash

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -148,15 +148,15 @@ jobs:
         shell: bash
         working-directory: deployment/${{ matrix.milvus_mode }}
         run: |
-          yq -i '.minio.rootPath = "${{ matrix.milvus_minio_rootpath }}"' values.yaml
+          yq -i '.milvus.storage.rootPath = "${{ matrix.milvus_minio_rootpath }}"' values.yaml
       - name: Build
         timeout-minutes: 5
         shell: bash
         run: |
           if [ ${{ matrix.deploy_tools }} == 'helm' ]; then
-            yq -i '.minio.bucketName = "milvus-bucket"' configs/backup.yaml
-            yq -i '.minio.rootPath = "${{ matrix.milvus_minio_rootpath }}"' configs/backup.yaml
-            yq -i '.minio.backupBucketName = "${{ matrix.backup_bucket_name }}"' configs/backup.yaml
+            yq -i '.milvus.storage.bucketName = "milvus-bucket"' configs/backup.yaml
+            yq -i '.milvus.storage.rootPath = "${{ matrix.milvus_minio_rootpath }}"' configs/backup.yaml
+            yq -i '.backup.storage.bucketName = "${{ matrix.backup_bucket_name }}"' configs/backup.yaml
 
           fi
           yq -i '.log.level = "debug"' configs/backup.yaml

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -44,9 +44,9 @@ jobs:
         shell: bash
         run: |
           if [ ${{ matrix.deploy_tools }} == 'helm' ]; then
-            yq -i '.minio.bucketName = "milvus-bucket"' configs/backup.yaml
-            yq -i '.minio.backupBucketName = "milvus-bucket"' configs/backup.yaml
-            yq -i '.minio.rootPath = "file"' configs/backup.yaml
+            yq -i '.milvus.storage.bucketName = "milvus-bucket"' configs/backup.yaml
+            yq -i '.backup.storage.bucketName = "milvus-bucket"' configs/backup.yaml
+            yq -i '.milvus.storage.rootPath = "file"' configs/backup.yaml
           fi
           yq -i '.log.level = "debug"' configs/backup.yaml
           cat configs/backup.yaml || true

--- a/configs/backup-azure.yaml
+++ b/configs/backup-azure.yaml
@@ -1,103 +1,94 @@
+# The schema version this file is written in. Required by v2.
+configVersion: v2
+
 # Configures the system log output.
 log:
   level: info # Only supports debug, info, warn, error, panic, or fatal. Default 'info'.
   console: true # whether print log to console
   file:
-    filename: "logs/backup.log"
+    path: "logs/backup.log"
 
-http:
-  simpleResponse: true
+# The Milvus deployment to back up, and the storage it keeps its data in.
+milvus:
+  user: "root"
+  password: "Milvus"
+
+  grpc:
+    address: localhost
+    port: 19530
+    # disabled, server (verify the server certificate), or mutual (also present
+    # a client certificate).
+    tlsMode: disabled
+
+  replicate:
+    # Milvus replicate msg channel name, default is by-dev-replicate-msg
+    rpcChannelName: "by-dev-replicate-msg"
+
+  # Milvus storage configs, make them the same with milvus config.
+  storage:
+    provider: "azure"
+    address: core.windows.net
+    port: 443
+    region: "westus2"
+    useSSL: true
+    # The Azure storage account, required by the azure provider. Supply it
+    # through MILVUS_STORAGE_ACCOUNT_NAME rather than writing it here.
+    accountName: ""
+    # For azure the bucket is the blob container.
+    bucketName: "milvus-data"
+    rootPath: "milvus/azure-instance"
+
+    auth:
+      # Azure signs with the account name and one of its access keys.
+      type: sharedKey
+      # Supply through MILVUS_STORAGE_AUTH_ACCOUNT_KEY.
+      accountKey: ""
+
+backup:
+  # Where backup data is written. Anything left out is inherited from
+  # milvus.storage, so only what differs is named here.
+  storage:
+    accountName: ""
+    # Backup data is stored under bucketName/rootPath.
+    bucketName: "milvus-data"
+    rootPath: "backup"
+
+    auth:
+      type: sharedKey
+      # Supply through BACKUP_STORAGE_AUTH_ACCOUNT_KEY.
+      accountKey: ""
+
+  concurrency:
+    # number of collections to backup in parallel.
+    collections: 4
+    # number of segments to backup in parallel
+    segments: 1024
+
+  # Pause GC during backup through the Milvus management endpoint.
+  pauseGC: true
+
+restore:
+  concurrency:
+    # Collection level parallelism to restore
+    collections: 2
+    # max number of import jobs to run in parallel,
+    # should be less than milvus's config dataCoord.import.maxImportJobNum
+    importJobs: 768
+
+  # keep temporary files during restore, only use to debug
+  keepTempFiles: false
+
+# How objects move between the two storage backends. Both ends are the same
+# Azure account here, so auto asks the storage service to copy.
+transfer:
+  mode: auto
+
+  # number of threads to copy data. reduce it if blocks your storage's network bandwidth
+  concurrency: 128
 
 # Zilliz Cloud config.
 # If you want to migrate data to Zilliz Cloud, you need to configure the following parameters.
 # Otherwise, you can ignore it.
-cloud:
-  address: https://api.cloud.zilliz.com
-  apikey: <your-api-key>
-
-# milvus proxy address, compatible to milvus.yaml
-milvus:
-  address: localhost
-  port: 19530
-  user: "root"
-  password: "Milvus"
-
-  # tls mode values [0, 1, 2]
-  # 0 is close, 1 is one-way authentication, 2 is mutual authentication
-  tlsMode: 0
-  # tls cert path for validate server, will be used when tlsMode is 1 or 2
-  caCertPath: ""
-  serverName: ""
-  # mutual tls cert path, for server to validate client.
-  # Will be used when tlsMode is 2
-  # for backward compatibility, if not set, will use tlsmode 1.
-  # WARN: in future version, if user set tlsmode 2, but not set mtlsCertPath, will cause error.
-  mtlsCertPath: ""
-  mtlsKeyPath: ""
-
-  # Milvus replicate msg channel name, default is by-dev-replicate-msg
-  rpcChannelName: "by-dev-replicate-msg"
-
-# Related configuration of minio, which is responsible for data persistence for Milvus.
-minio:
-  # Milvus storage configs, make them the same with milvus config
-  storageType: "azure" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent), gcpnative
-  # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials for authentication.
-  address: core.windows.net # Address of MinIO/S3
-  port: 443   # Port of MinIO/S3
-  region: "westus2"      # region of MinIO/S3
-  accessKeyID: ""  # accessKeyID of MinIO/S3
-  secretAccessKey: "" # MinIO/S3 encryption string
-  token: ""     # token of MinIO/S3
-  gcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  useSSL: true # Access to MinIO/S3 with SSL
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "milvus-data" # Milvus Bucket name in MinIO/S3, make it the same as your milvus instance
-  rootPath: "milvus/azure-instance" # Milvus storage root path in MinIO/S3, make it the same as your milvus instance
-
-  # Backup storage configs, the storage you want to put the backup data
-  backupStorageType: "azure" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent)
-  backupAddress: core.windows.net # Address of MinIO/S3
-  backupRegion: "westus2"   # region of MinIO/S3
-  backupPort: 443   # Port of MinIO/S3
-  backupAccessKeyID: ""  # accessKeyID of MinIO/S3
-  backupSecretAccessKey: "" # MinIO/S3 encryption string
-  backupToken: ""       # token of MinIO/S3
-  backupGcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  backupBucketName: "milvus-data" # Bucket name to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupRootPath: "backup" # Rootpath to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupUseSSL: true # Access to MinIO/S3 with SSL
-
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported. 
-  # Set this option to true to enable data transfer through Milvus Backup.
-  # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
-  # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: false
-  
-backup:
-  parallelism:
-    # number of threads to copy data. reduce it if blocks your storage's network bandwidth
-    copydata: 128
-
-    # number of collections to backup in parallel.
-    backupCollection: 4
-    # number of segments to backup in parallel
-    backupSegment: 1024
-
-    # Collection level parallelism to restore
-    restoreCollection: 2
-    # max number of import job to run in parallel,
-    # should be less than milvus's config dataCoord.import.maxImportJobNum
-    importJob: 768
-  
-  # keep temporary files during restore, only use to debug 
-  keepTempFiles: false
-  
-  # Pause GC during backup through Milvus Http API. 
-  gcPause:
-    enable: true
-    address: http://localhost:9091
-    
+zillizCloud:
+  endpoint: https://api.cloud.zilliz.com
+  apiKey: <your-api-key>

--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -1,108 +1,164 @@
+# The schema version this file is written in. Required by v2.
+# A file without it is read as v1 and translated, which still works but is
+# deprecated: run `milvus-backup config migrate` to convert it.
+configVersion: v2
+
 # Configures the system log output.
 log:
   level: info # Only supports debug, info, warn, error, panic, or fatal. Default 'info'.
   console: true # whether print log to console
   file:
-    filename: "logs/backup.log"
+    path: "logs/backup.log"
+
+# The milvus-backup HTTP API server itself.
+server:
+  debugMode: false
+  # Set when the API is served behind a reverse proxy under a path prefix.
+  swaggerBasePath: ""
+
+# The Milvus deployment to back up, and the storage it keeps its data in.
+milvus:
+  user: "root"
+  password: "Milvus"
+
+  # The public gRPC endpoint, used for metadata, collection and database
+  # operations, flush, and RBAC.
+  grpc:
+    address: localhost
+    port: 19530
+
+    # disabled, server (verify the server certificate), or mutual (also present
+    # a client certificate).
+    tlsMode: disabled
+    # Verifies the server certificate. Used when tlsMode is server or mutual.
+    caCertPath: ""
+    serverName: ""
+    # The client key pair. Required when tlsMode is mutual.
+    mtlsCertPath: ""
+    mtlsKeyPath: ""
+
+  # The public REST endpoint, used for segment describe during backup and for
+  # import during restore. Derived from the gRPC connection when left empty,
+  # which covers deployments where one proxy serves both protocols.
+  rest:
+    endpoint: ""
+
+  # The Milvus internal management endpoint, serving GC pause/resume.
+  management:
+    endpoint: http://localhost:9091
+
+  replicate:
+    # Milvus replicate msg channel name, default is by-dev-replicate-msg
+    rpcChannelName: "by-dev-replicate-msg"
+
+  etcd:
+    endpoints:
+      - 127.0.0.1:2379
+    rootPath: "by-dev"
+
+  # Milvus storage configs, make them the same with milvus config.
+  storage:
+    # Supported providers: local, minio, s3, aws, gcp, gcpnative, azure,
+    # aliyun, tencent, hwc.
+    provider: "minio"
+    address: localhost
+    port: 9000
+    region: ""
+    useSSL: false
+    # The Azure storage account. Required by the azure provider, and rejected
+    # for every other one.
+    # accountName: ""
+    # Milvus bucket name, make it the same as your milvus instance.
+    bucketName: "a-bucket"
+    # Milvus storage root path, make it the same as your milvus instance.
+    rootPath: "files"
+
+    # Only the credentials the chosen type uses may be set: naming one it does
+    # not use is a mistake, and is rejected rather than ignored.
+    auth:
+      # static: an access key pair. iam: fetched from an IAM endpoint.
+      # sharedKey: an Azure account key. serviceAccount: a GCP credentials
+      # file. default: resolved by the provider SDK.
+      type: static
+
+      # type: static
+      accessKeyID: minioadmin
+      secretAccessKey: minioadmin
+      # sessionToken: ""
+
+      # type: sharedKey, the Azure storage account key.
+      # accountKey: ""
+
+      # type: serviceAccount, path to the GCP service account JSON file.
+      # credentialsFile: ""
+
+      # type: iam, the endpoint credentials are fetched from. AWS and GCP read
+      # instance metadata from a well-known address, while MinIO needs one
+      # configured.
+      # endpoint: ""
+
+backup:
+  # Where backup data is written. Anything left out is inherited from
+  # milvus.storage, so a backup kept in the same backend only names what
+  # differs. rootPath is the exception and always defaults to "backup".
+  storage:
+    provider: "minio"
+    address: localhost
+    port: 9000
+    region: ""
+    useSSL: false
+    # accountName: ""
+    # Backup data is stored under bucketName/rootPath.
+    bucketName: "a-bucket"
+    rootPath: "backup"
+
+    auth:
+      type: static
+      accessKeyID: minioadmin
+      secretAccessKey: minioadmin
+      # sessionToken: ""
+      # accountKey: ""
+      # credentialsFile: ""
+      # endpoint: ""
+
+  concurrency:
+    # number of collections to backup in parallel.
+    collections: 4
+    # number of segments to backup in parallel
+    segments: 1024
+
+  # Pause GC during backup through the Milvus management endpoint.
+  pauseGC: true
+
+restore:
+  concurrency:
+    # Collection level parallelism to restore
+    collections: 2
+    # max number of import jobs to run in parallel,
+    # should be less than milvus's config dataCoord.import.maxImportJobNum
+    importJobs: 768
+
+  # keep temporary files during restore, only use to debug
+  keepTempFiles: false
+
+# How objects move between the two storage backends.
+transfer:
+  # auto asks the storage service to copy when both ends are the same backend,
+  # and streams through milvus-backup otherwise. direct always asks the storage
+  # service to copy; streaming always goes through milvus-backup.
+  mode: auto
+
+  # number of threads to copy data. reduce it if blocks your storage's network bandwidth
+  concurrency: 128
+
+  # File size threshold (MiB) above which multipart copy is used for
+  # S3-compatible storage. GCP does not support multipart copy and will always
+  # use single copy.
+  multipartCopyThresholdMiB: 500
 
 # Zilliz Cloud config.
 # If you want to migrate data to Zilliz Cloud, you need to configure the following parameters.
 # Otherwise, you can ignore it.
-cloud:
-  address: https://api.cloud.zilliz.com
-  apikey: <your-api-key>
-
-# milvus proxy address, compatible to milvus.yaml
-milvus:
-  address: localhost
-  port: 19530
-  user: "root"
-  password: "Milvus"
-
-  # tls mode values [0, 1, 2]
-  # 0 is close, 1 is one-way authentication, 2 is mutual authentication
-  tlsMode: 0
-  # tls cert path for validate server, will be used when tlsMode is 1 or 2
-  caCertPath: ""
-  serverName: ""
-  # mutual tls cert path, for server to validate client.
-  # Will be used when tlsMode is 2
-  # for backward compatibility, if not set, will use tlsmode 1.
-  # WARN: in future version, if user set tlsmode 2, but not set mtlsCertPath, will cause error.
-  mtlsCertPath: ""
-  mtlsKeyPath: ""
-
-  # Milvus replicate msg channel name, default is by-dev-replicate-msg
-  rpcChannelName: "by-dev-replicate-msg"
-
-  etcd:
-    endpoints: 127.0.0.1:2379 # you can set multiple endpoints, separated by comma, for example: "127.0.0.1:2379,127.0.0.1:2380,127.0.0.1:2381"
-    rootPath: "by-dev"
-
-# Related configuration of minio, which is responsible for data persistence for Milvus.
-minio:
-  # Milvus storage configs, make them the same with milvus config
-  storageType: "minio" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent), gcpnative
-  # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials for authentication.
-  address: localhost # Address of MinIO/S3
-  port: 9000   # Port of MinIO/S3
-  region: ""      # region of MinIO/S3
-  accessKeyID: minioadmin  # accessKeyID of MinIO/S3
-  secretAccessKey: minioadmin # MinIO/S3 encryption string
-  token: ""     # token of MinIO/S3
-  gcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  useSSL: false # Access to MinIO/S3 with SSL
-  useIAM: false
-  iamEndpoint: ""
-  bucketName: "a-bucket" # Milvus Bucket name in MinIO/S3, make it the same as your milvus instance
-  rootPath: "files" # Milvus storage root path in MinIO/S3, make it the same as your milvus instance
-
-  # Backup storage configs, the storage you want to put the backup data
-  backupStorageType: "minio" # support storage type: local, minio, s3, aws, gcp, ali(aliyun), azure, tc(tencent)
-  backupAddress: localhost # Address of MinIO/S3
-  backupRegion: ""   # region of MinIO/S3
-  backupPort: 9000   # Port of MinIO/S3
-  backupAccessKeyID: minioadmin  # accessKeyID of MinIO/S3
-  backupSecretAccessKey: minioadmin # MinIO/S3 encryption string
-  backupToken: ""       # token of MinIO/S3
-  backupGcpCredentialJSON: "/path/to/json-key-file" # The JSON content contains the gcs service account credentials.
-  # Used only for the "gcpnative" cloud provider.
-  backupBucketName: "a-bucket" # Bucket name to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupRootPath: "backup" # Rootpath to store backup data. Backup data will store to backupBucketName/backupRootPath
-  backupUseSSL: false # Access to MinIO/S3 with SSL
-
-  # If you need to back up or restore data between two different storage systems, direct client-side copying is not supported.
-  # Set this option to true to enable data transfer through Milvus Backup.
-  # Note: This option will be automatically set to true if `minio.storageType` and `minio.backupStorageType` differ.
-  # However, if they are the same but belong to different services, you must manually set this option to `true`.
-  crossStorage: false
-
-  # File size threshold (MiB) above which multipart copy is used for S3-compatible storage.
-  # Default is 500. GCP does not support multipart copy and will always use single copy.
-  multipartCopyThresholdMiB: 500
-  
-backup:
-  parallelism:
-    # number of threads to copy data. reduce it if blocks your storage's network bandwidth
-    copydata: 128
-
-    # number of collections to backup in parallel.
-    backupCollection: 4
-    # number of segments to backup in parallel
-    backupSegment: 1024
-
-    # Collection level parallelism to restore
-    restoreCollection: 2
-    # max number of import job to run in parallel,
-    # should be less than milvus's config dataCoord.import.maxImportJobNum
-    importJob: 768
-  
-  # keep temporary files during restore, only use to debug 
-  keepTempFiles: false
-  
-  # Pause GC during backup through Milvus Http API. 
-  gcPause:
-    enable: true
-    address: http://localhost:9091
-    
+zillizCloud:
+  endpoint: https://api.cloud.zilliz.com
+  apiKey: <your-api-key>


### PR DESCRIPTION
## Summary

The loader reads either schema version, but the files shipped with the repo were still v1, so every run started by translating them and warning about it. This writes them as v2.

CI edits `configs/backup.yaml` with `yq` and injects credentials through the environment, both of which name keys. A v2 file with v1 keys written into it loads with those keys **ignored** — a test running against the wrong bucket rather than a failure — so the workflows have to move in the same commit.

## Changes

- Rewrite `configs/backup.yaml` and `configs/backup-azure.yaml` as v2, keeping the explanatory comments and adding the ones the new shape needs (auth types, storage inheritance, transfer modes).
- Comment out every credential a given auth type does not use. v2 rejects a credential its type cannot use rather than ignoring it, so listing them all as empty strings does not load — the sample now shows which field belongs to which `auth.type`.
- Update the `yq` paths in `main.yaml`, `nightly.yaml`, `perf.yaml` and `azure.yaml` to their v2 spellings, e.g. `.minio.bucketName` → `.milvus.storage.bucketName` and `.minio.backupRootPath` → `.backup.storage.rootPath`.
- Map `.minio.crossStorage = true` to `.transfer.mode = "streaming"` in the cross-storage job, which backs up between two MinIO deployments on different ports.
- Pass the azure credentials as `MILVUS_STORAGE_ACCOUNT_NAME` / `MILVUS_STORAGE_AUTH_ACCOUNT_KEY` (and the backup-side pair) instead of overloading `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`, which is how v1 spelled an Azure account name and key.

## Verification

Both sample files were loaded with `config show` to confirm they resolve. The `main.yaml` upstream-test block was replayed against the new `configs/backup.yaml` — every injected value lands on the intended v2 parameter with `SOURCE=config`, which is the failure mode this change is guarding against. The azure file was loaded with the four new environment variables set, confirming the credentials resolve with `SOURCE=env`.

Docs still describe v1 keys (`docs/user_guide/env_variables.md` is a full v1 variable table, and `cross_storage.md` is written around `crossStorage`); that is its own change.

Part of #1089
