### PR TITLE
storage: log the resolved transfer mode when a task starts

### DIFF
--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -108,6 +108,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 
 	streaming := storage.UseStreaming(args.Params.Transfer.Mode.Val,
 		args.MilvusStorage.Config(), args.BackupStorage.Config())
+	logger.Info("resolved transfer mode",
+		zap.String("transfer_mode", args.Params.Transfer.Mode.Val),
+		zap.Bool("streaming", streaming))
 
 	mb := newMetaBuilder(args.TaskID, args.Option.BackupName)
 	err := args.TaskMgr.AddBackupTask(args.TaskID, args.Option.BackupName)

--- a/core/check/task.go
+++ b/core/check/task.go
@@ -130,7 +130,10 @@ func (t *Task) checkWriteAndCopy(ctx context.Context) error {
 	t.logger.Info("copy from milvus storage to backup storage")
 	streaming := storage.UseStreaming(t.params.Transfer.Mode.Val,
 		t.milvusStorage.Config(), t.backupStorage.Config())
-	t.logger.Info("try to copy", zap.Bool("streaming", streaming), zap.String("dest_key", destKey))
+	t.logger.Info("try to copy",
+		zap.String("transfer_mode", t.params.Transfer.Mode.Val),
+		zap.Bool("streaming", streaming),
+		zap.String("dest_key", destKey))
 	opt := storage.CopyPrefixOpt{
 		Src:        t.milvusStorage,
 		Dest:       t.backupStorage,

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -168,11 +168,16 @@ func NewTask(args TaskArgs) (*Task, error) {
 
 	args.TaskMgr.AddRestoreTask(args.TaskID)
 
+	streaming := storage.UseStreaming(args.Params.Transfer.Mode.Val,
+		args.BackupStorage.Config(), args.MilvusStorage.Config())
+	logger.Info("resolved transfer mode",
+		zap.String("transfer_mode", args.Params.Transfer.Mode.Val),
+		zap.Bool("streaming", streaming))
+
 	return &Task{
 		args: args,
 
-		streaming: storage.UseStreaming(args.Params.Transfer.Mode.Val,
-			args.BackupStorage.Config(), args.MilvusStorage.Config()),
+		streaming: streaming,
 
 		copySem:       semaphore.NewWeighted(int64(args.Params.Transfer.Concurrency.Val)),
 		bulkInsertSem: semaphore.NewWeighted(int64(args.Params.Restore.Concurrency.ImportJobs.Val)),


### PR DESCRIPTION
## Summary

Backup and restore resolve `transfer.mode` into a decision — stream the objects through this process, or ask the storage backend to copy them — and then never report it. With the mode left at `auto` that decision is not one the operator made, so a backup running at network speed instead of backend speed leaves nothing in the log to explain itself. This is the last open item of #993.

## Changes

- Log the resolved transfer mode in `backup.NewTask` and `restore.NewTask`, next to where the decision is made. The configured mode is logged alongside the resolved boolean, so an `auto` that resolved to streaming reads differently from a `streaming` that was asked for — with only the boolean, the interesting case and the ordinary one look identical.
- Name the mode in the line `check` already emits, rather than adding a second one beside it. All three paths now carry the same `transfer_mode` field, so one grep covers them.
- Hoist `streaming` out of the `restore.Task` literal into a local, since it now has a second reader. The value and the comment explaining that it is decided once are unchanged.

## Notes

Two places where this differs from the letter of #993, both deliberate:

- The issue asks for the mode "at task start". `check` decides at the copy step rather than at task start, because that is where the two backends are known, so its line stays there — moving it would report a decision the task has not made yet.
- The issue's other three items landed in #1104 under different names than it proposed: `copyMode: auto/direct/proxy` under `backup` became `transfer.mode: auto/direct/streaming` at the top level, because `check` and `migrate` share the policy and it is not backup-specific. The behavior asked for is the behavior shipped.

## Verification

`go test --race ./...` and `golangci-lint run ./...` pass. The line was confirmed to actually emit by constructing a restore task against two mock backends and reading the output — worth checking, because the default logger in this package discards everything until `InitLogger` installs a sink, so a compiling log call proves nothing on its own.

No test asserts on the log. `TestUseStreaming` already covers which mode gets chosen, and the repository has no `zaptest/observer` precedent to assert on log output.

Fixes #993
