### PR TITLE
cmd: reject the flags deprecated in 0.5

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -375,8 +375,10 @@ jobs:
         timeout-minutes: 5
         shell: bash
         run: |
-          ./milvus-backup restore -n my_backup -c hello_milvus -s _recover
-          ./milvus-backup restore -n my_backup -c hello_milvus2 -s _recover
+          # --filter matches the collection name after -s is applied, so it
+          # names hello_milvus_recover rather than hello_milvus.
+          ./milvus-backup restore -n my_backup --filter hello_milvus_recover -s _recover
+          ./milvus-backup restore -n my_backup --filter hello_milvus2_recover -s _recover
       - name: Verify data
         timeout-minutes: 5
         shell: bash

--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ The main commands are:
 
 Run `milvus-backup <command> --help` for command-specific flags. See the [CLI end-to-end guide](docs/user_guide/e2e_demo_cli.md) for a complete backup and restore example.
 
+### Selecting collections
+
+`--filter` limits a command to some of the collections instead of all of them. It takes a comma-separated list, where an entry is a collection in the default database (`coll1`), a collection in a named database (`db1.coll1`), or every collection in a database (`db1.*`):
+
+```shell
+# back up two collections
+milvus-backup create -n my_backup --filter hello_milvus,db1.hello_milvus2
+
+# back up every collection in db1 (quoted, so the shell does not expand the *)
+milvus-backup create -n my_backup --filter 'db1.*'
+
+# restore the whole backup
+milvus-backup restore -n my_backup
+```
+
+On `restore`, `--filter` names collections as they will exist in the target Milvus, so it matches the name **after** `--suffix` or `--rename` has been applied:
+
+```shell
+# restores hello_milvus from the backup into a new hello_milvus_recover
+milvus-backup restore -n my_backup -s _recover --filter hello_milvus_recover
+
+# restores db1.coll1 into db2.coll1
+milvus-backup restore -n my_backup -r db1.coll1:db2.coll1 --filter db2.coll1
+```
+
+Filtering on the pre-rename name matches nothing and restores nothing.
+
 ## API server
 
 Start the REST API server with:

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -10,28 +9,30 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/backup"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
-	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
+// removedFlags are the create flags dropped in 0.6, after 0.5 accepted them with
+// a deprecation warning.
+var removedFlags = []flags.Removed{
+	{Name: "colls", Shorthand: "c", Advice: "use --filter instead"},
+	{Name: "databases", Shorthand: "d", Advice: "use --filter instead"},
+	{Name: "database_collections", Shorthand: "a", Advice: "use --filter instead"},
+	{Name: "force", Shorthand: "f", NoValue: true, Advice: "use --strategy=skip_flush instead"},
+	{Name: "meta_only", NoValue: true, Advice: "use --strategy=meta_only instead"},
+}
+
 type options struct {
 	backupName string
 
-	collectionNames string
-	databases       string
-	dbCollections   string
-
 	filter string
-
-	force    bool
-	metaOnly bool
 
 	strategy string
 
@@ -41,23 +42,6 @@ type options struct {
 }
 
 func (o *options) validate() error {
-	if len(o.collectionNames) != 0 {
-		log.Warn("collection_names is deprecated, use --filter instead !")
-	}
-	if len(o.databases) != 0 {
-		log.Warn("databases is deprecated, use --filter instead !")
-	}
-	if len(o.dbCollections) != 0 {
-		log.Warn("database_collections is deprecated, use --filter instead !")
-	}
-
-	if o.force {
-		log.Warn("force is deprecated, use --strategy=skip_flush instead !")
-	}
-	if o.metaOnly {
-		log.Warn("meta_only is deprecated, use --strategy=meta_only instead !")
-	}
-
 	if len(o.backupName) != 0 && backup.ValidateName(o.backupName) != nil {
 		return fmt.Errorf("invalid backup name %s", o.backupName)
 	}
@@ -80,115 +64,28 @@ func (o *options) complete() error {
 func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.backupName, "name", "n", "", "backup name, if unset will generate a name automatically")
 
-	cmd.Flags().StringVarP(&o.collectionNames, "colls", "c", "", "[DEPRECATED] use --filter instead. collectionNames to backup, use ',' to connect multiple collections")
-	cmd.Flags().StringVarP(&o.databases, "databases", "d", "", "[DEPRECATED] use --filter instead. databases to backup")
-	cmd.Flags().StringVarP(&o.dbCollections, "database_collections", "a", "", "[DEPRECATED] use --filter instead. databases and collections")
 	cmd.Flags().StringVarP(&o.filter, "filter", "", "", "specify which collections to backup, if not set, backup all collections. example: db1.coll1,db2.col1")
 
-	cmd.Flags().BoolVarP(&o.force, "force", "f", false, "[DEPRECATED] use --strategy=skip_flush instead. force backup, will skip flush, should make sure data has been stored into disk when using it")
-	cmd.Flags().BoolVarP(&o.metaOnly, "meta_only", "", false, "[DEPRECATED] use --strategy=meta_only instead. only backup collection meta instead of data")
 	cmd.Flags().StringVarP(&o.strategy, "strategy", "", "", "backup strategy, one of [meta_only, skip_flush, bulk_flush, serial_flush], if not set will auto select")
 
 	cmd.Flags().BoolVarP(&o.backupIndexExtra, "backup_index_extra", "", false, "whether backup index extra info")
 
 	cmd.Flags().BoolVarP(&o.rbac, "rbac", "", false, "whether backup RBAC meta")
+
+	flags.AddRemoved(cmd, removedFlags)
 }
 
 func (o *options) toFilter() (filter.Filter, error) {
-	if o.filter != "" {
-		return o.parseFilter(o.filter)
+	if o.filter == "" {
+		return filter.Filter{}, nil
 	}
 
-	if o.dbCollections != "" {
-		return o.dbCollectionsToFilter()
-	}
-
-	if o.collectionNames != "" {
-		return o.collectionNamesToFilter()
-	}
-
-	if o.databases != "" {
-		return o.databasesToFilter()
-	}
-
-	return filter.Filter{}, nil
-}
-
-func (o *options) parseFilter(filterStr string) (filter.Filter, error) {
-	f, err := filter.Parse(filterStr)
+	f, err := filter.Parse(o.filter)
 	if err != nil {
 		return filter.Filter{}, fmt.Errorf("parse filter: %w", err)
 	}
 
 	return f, nil
-}
-
-func (o *options) collectionNamesToFilter() (filter.Filter, error) {
-	nsStrs := strings.Split(o.collectionNames, ",")
-
-	dbCollFilter := make(map[string]filter.CollFilter, len(nsStrs))
-	for _, nsStr := range nsStrs {
-		ns, err := namespace.Parse(nsStr)
-		if err != nil {
-			return filter.Filter{}, fmt.Errorf("invalid collection name %s", nsStrs)
-		}
-
-		if _, ok := dbCollFilter[ns.DBName()]; !ok {
-			dbCollFilter[ns.DBName()] = filter.CollFilter{CollName: make(map[string]struct{})}
-		}
-		dbCollFilter[ns.DBName()].CollName[ns.CollName()] = struct{}{}
-	}
-
-	return filter.Filter{DBCollFilter: dbCollFilter}, nil
-}
-
-func (o *options) dbCollectionsToFilter() (filter.Filter, error) {
-	dbColls := make(map[string][]string)
-	if err := json.Unmarshal([]byte(o.dbCollections), &dbColls); err != nil {
-		return filter.Filter{}, fmt.Errorf("unmarshal dbCollections: %w", err)
-	}
-
-	dbCollFilter := make(map[string]filter.CollFilter)
-	for dbName, colls := range dbColls {
-		if len(colls) == 0 {
-			dbCollFilter[dbName] = filter.CollFilter{AllowAll: true}
-		} else {
-			collName := make(map[string]struct{}, len(colls))
-			for _, coll := range colls {
-				collName[coll] = struct{}{}
-			}
-			dbCollFilter[dbName] = filter.CollFilter{CollName: collName}
-		}
-	}
-
-	return filter.Filter{DBCollFilter: dbCollFilter}, nil
-}
-
-func (o *options) databasesToFilter() (filter.Filter, error) {
-	splits := strings.Split(o.databases, ",")
-	dbCollFilter := make(map[string]filter.CollFilter, len(splits))
-	for _, db := range splits {
-		dbCollFilter[db] = filter.CollFilter{AllowAll: true}
-	}
-
-	return filter.Filter{DBCollFilter: dbCollFilter}, nil
-}
-
-func (o *options) toStrategy() (backup.Strategy, error) {
-	if o.strategy != "" {
-		// already validated in validate()
-		return backup.ParseStrategy(o.strategy)
-	}
-
-	if o.force {
-		return backup.StrategySkipFlush, nil
-	}
-
-	if o.metaOnly {
-		return backup.StrategyMetaOnly, nil
-	}
-
-	return backup.StrategyAuto, nil
 }
 
 func (o *options) toOption(params *v2.Config) (backup.Option, error) {
@@ -197,7 +94,8 @@ func (o *options) toOption(params *v2.Config) (backup.Option, error) {
 		return backup.Option{}, err
 	}
 
-	strategy, err := o.toStrategy()
+	// already validated in validate()
+	strategy, err := backup.ParseStrategy(o.strategy)
 	if err != nil {
 		return backup.Option{}, err
 	}
@@ -275,6 +173,10 @@ func NewCmd(opt *root.Options) *cobra.Command {
 		Short: "create a backup",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.CheckRemoved(cmd, removedFlags); err != nil {
+				return err
+			}
+
 			params := opt.InitGlobalVars()
 
 			if err := o.complete(); err != nil {

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -1,45 +1,68 @@
 package create
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 )
 
-func TestOptions_collectionNamesToFilter(t *testing.T) {
-	o := &options{collectionNames: "coll1,db1.coll2,db2.coll3"}
-	f, err := o.collectionNamesToFilter()
-	assert.NoError(t, err)
+// A removed flag has to fail before the command reaches any other work, so that
+// an outdated command line is answered by the flag that has to change.
+func TestNewCmd_RemovedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "Colls", args: []string{"--colls", "coll1"}, want: "--colls was removed in 0.6, use --filter instead"},
+		{name: "CollsShorthand", args: []string{"-c", "coll1"}, want: "--colls was removed in 0.6, use --filter instead"},
+		{name: "Databases", args: []string{"--databases", "db1"}, want: "--databases was removed in 0.6, use --filter instead"},
+		{name: "DatabaseCollections", args: []string{"--database_collections", `{"db1":[]}`}, want: "--database_collections was removed in 0.6, use --filter instead"},
+		{name: "Force", args: []string{"--force"}, want: "--force was removed in 0.6, use --strategy=skip_flush instead"},
+		{name: "MetaOnly", args: []string{"--meta_only"}, want: "--meta_only was removed in 0.6, use --strategy=meta_only instead"},
+	}
 
-	assert.Equal(t, map[string]filter.CollFilter{
-		"default": {CollName: map[string]struct{}{"coll1": {}}},
-		"db1":     {CollName: map[string]struct{}{"coll2": {}}},
-		"db2":     {CollName: map[string]struct{}{"coll3": {}}},
-	}, f.DBCollFilter)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd(&root.Options{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
 }
 
-func TestOptions_databasesToFilter(t *testing.T) {
-	o := &options{databases: "db1,db2,db3"}
-	f, err := o.databasesToFilter()
-	assert.NoError(t, err)
+func TestOptions_toFilter(t *testing.T) {
+	t.Run("NoFilter", func(t *testing.T) {
+		var o options
+		f, err := o.toFilter()
+		assert.NoError(t, err)
+		assert.Empty(t, f.DBCollFilter)
+	})
 
-	assert.Equal(t, map[string]filter.CollFilter{
-		"db1": {AllowAll: true},
-		"db2": {AllowAll: true},
-		"db3": {AllowAll: true},
-	}, f.DBCollFilter)
-}
+	t.Run("Normal", func(t *testing.T) {
+		o := options{filter: "coll1,db1.coll2,db2.*"}
+		f, err := o.toFilter()
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]filter.CollFilter{
+			"default": {CollName: map[string]struct{}{"coll1": {}}},
+			"db1":     {CollName: map[string]struct{}{"coll2": {}}},
+			"db2":     {AllowAll: true},
+		}, f.DBCollFilter)
+	})
 
-func TestOptions_dbCollectionsToFilter(t *testing.T) {
-	o := &options{dbCollections: `{"db1":["coll1","coll2"],"db2":["coll3","coll4"],"db3":[]}`}
-	f, err := o.dbCollectionsToFilter()
-	assert.NoError(t, err)
-
-	assert.Equal(t, map[string]filter.CollFilter{
-		"db1": {CollName: map[string]struct{}{"coll1": {}, "coll2": {}}},
-		"db2": {CollName: map[string]struct{}{"coll3": {}, "coll4": {}}},
-		"db3": {AllowAll: true},
-	}, f.DBCollFilter)
+	t.Run("Invalid", func(t *testing.T) {
+		o := options{filter: "a.b.c"}
+		_, err := o.toFilter()
+		assert.Error(t, err)
+	})
 }

--- a/cmd/flags/removed.go
+++ b/cmd/flags/removed.go
@@ -1,0 +1,58 @@
+// Package flags holds flag helpers shared by the milvus-backup subcommands.
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Removed is a flag that no longer has an implementation behind it. The 0.5 line
+// still honored these and only logged a deprecation warning; 0.6 rejects them.
+//
+// Keeping them registered is not what makes the rejection safe: cobra already
+// fails on an unknown flag and exits non-zero, so all these stubs buy is the
+// message naming the replacement. That is worth one release to whoever upgrades,
+// and dropping them later degrades the message without letting anything through.
+//
+// TODO: delete the removed-flag tables and this package in a release after 0.6.
+type Removed struct {
+	// Name is the flag as it was spelled while it still worked.
+	Name string
+	// Shorthand is its one-letter form, empty if it never had one.
+	Shorthand string
+	// NoValue marks a flag that took no argument, so that it is registered as a
+	// boolean and an old command line spelling it as a bare "--force" parses.
+	NoValue bool
+	// Advice completes the sentence "--name was removed in 0.6, ...".
+	Advice string
+}
+
+// AddRemoved registers removed flags so that an outdated command line still
+// parses and CheckRemoved can answer it by naming the replacement, instead of
+// cobra reporting a bare "unknown flag". They are hidden from help: they do
+// nothing, and listing them beside the working flags would imply otherwise.
+func AddRemoved(cmd *cobra.Command, removed []Removed) {
+	for _, r := range removed {
+		if r.NoValue {
+			cmd.Flags().BoolP(r.Name, r.Shorthand, false, r.Advice)
+		} else {
+			cmd.Flags().StringP(r.Name, r.Shorthand, "", r.Advice)
+		}
+		// The flag was registered a line ago, so it cannot be missing.
+		_ = cmd.Flags().MarkHidden(r.Name)
+	}
+}
+
+// CheckRemoved fails if the command line uses a removed flag. Callers run it
+// before any other work, so that an outdated command is answered by the flag
+// that has to change rather than by an unrelated complaint.
+func CheckRemoved(cmd *cobra.Command, removed []Removed) error {
+	for _, r := range removed {
+		if cmd.Flags().Changed(r.Name) {
+			return fmt.Errorf("--%s was removed in 0.6, %s", r.Name, r.Advice)
+		}
+	}
+
+	return nil
+}

--- a/cmd/flags/removed_test.go
+++ b/cmd/flags/removed_test.go
@@ -1,0 +1,81 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testRemoved = []Removed{
+	{Name: "colls", Shorthand: "c", Advice: "use --filter instead"},
+	{Name: "force", Shorthand: "f", NoValue: true, Advice: "use --strategy=skip_flush instead"},
+	{Name: "meta_only", NoValue: true, Advice: "use --strategy=meta_only instead"},
+}
+
+// newTestCmd returns a command carrying testRemoved, with the given command line
+// already parsed into it.
+func newTestCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "test"}
+	AddRemoved(cmd, testRemoved)
+	require.NoError(t, cmd.ParseFlags(args))
+
+	return cmd
+}
+
+func TestAddRemoved(t *testing.T) {
+	cmd := newTestCmd(t)
+
+	t.Run("Registered", func(t *testing.T) {
+		for _, r := range testRemoved {
+			f := cmd.Flags().Lookup(r.Name)
+			require.NotNil(t, f, "flag --%s should still parse", r.Name)
+			assert.Equal(t, r.Shorthand, f.Shorthand)
+		}
+	})
+
+	t.Run("HiddenFromHelp", func(t *testing.T) {
+		usage := cmd.UsageString()
+		for _, r := range testRemoved {
+			assert.True(t, cmd.Flags().Lookup(r.Name).Hidden)
+			assert.NotContains(t, usage, "--"+r.Name)
+		}
+	})
+}
+
+func TestCheckRemoved(t *testing.T) {
+	t.Run("NotUsed", func(t *testing.T) {
+		assert.NoError(t, CheckRemoved(newTestCmd(t), testRemoved))
+	})
+
+	t.Run("LongForm", func(t *testing.T) {
+		err := CheckRemoved(newTestCmd(t, "--colls", "coll1"), testRemoved)
+		require.Error(t, err)
+		assert.Equal(t, "--colls was removed in 0.6, use --filter instead", err.Error())
+	})
+
+	t.Run("Shorthand", func(t *testing.T) {
+		err := CheckRemoved(newTestCmd(t, "-c", "coll1"), testRemoved)
+		require.Error(t, err)
+		assert.Equal(t, "--colls was removed in 0.6, use --filter instead", err.Error())
+	})
+
+	// A flag that took no value has to keep parsing bare, the way it was written
+	// on an old command line.
+	t.Run("NoValueBare", func(t *testing.T) {
+		err := CheckRemoved(newTestCmd(t, "--force"), testRemoved)
+		require.Error(t, err)
+		assert.Equal(t, "--force was removed in 0.6, use --strategy=skip_flush instead", err.Error())
+	})
+
+	// Setting a removed flag to its zero value is still a command line that has
+	// to be rewritten, so it is rejected rather than quietly accepted.
+	t.Run("NoValueExplicitFalse", func(t *testing.T) {
+		err := CheckRemoved(newTestCmd(t, "--meta_only=false"), testRemoved)
+		require.Error(t, err)
+		assert.Equal(t, "--meta_only was removed in 0.6, use --strategy=meta_only instead", err.Error())
+	})
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/meta"
@@ -15,14 +16,19 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )
 
+// removedFlags are the get flags dropped in 0.6.
+var removedFlags = []flags.Removed{
+	{Name: "detail", Shorthand: "d", NoValue: true, Advice: "get always prints the complete backup info"},
+}
+
 type options struct {
 	backupName string
-	detail     bool
 }
 
 func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.backupName, "name", "n", "", "get backup with this name")
-	cmd.Flags().BoolVarP(&o.detail, "detail", "d", false, "[DEPRECATED] get complete backup info")
+
+	flags.AddRemoved(cmd, removedFlags)
 }
 
 func (o *options) validate() error {
@@ -69,6 +75,10 @@ func NewCmd(opt *root.Options) *cobra.Command {
 		Short: "get a backup by name",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.CheckRemoved(cmd, removedFlags); err != nil {
+				return err
+			}
+
 			params := opt.InitGlobalVars()
 
 			if err := o.validate(); err != nil {

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -1,0 +1,36 @@
+package get
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+)
+
+// A removed flag has to fail before the command reaches any other work, so that
+// an outdated command line is answered by the flag that has to change.
+func TestNewCmd_RemovedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "Detail", args: []string{"--detail"}},
+		{name: "DetailShorthand", args: []string{"-d"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd(&root.Options{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Equal(t, "--detail was removed in 0.6, get always prints the complete backup info", err.Error())
+		})
+	}
+}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -2,12 +2,12 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
@@ -15,27 +15,13 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/storage"
 )
 
-type options struct {
-	collectionName string
+// removedFlags are the list flags dropped in 0.6.
+var removedFlags = []flags.Removed{
+	{Name: "collection", Shorthand: "c", Advice: "listing backups by collection is no longer supported"},
 }
 
-func (o *options) validate() error {
-	if o.collectionName != "" {
-		return errors.New("collectionName is deprecated")
-	}
-
-	return nil
-}
-
-func (o *options) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&o.collectionName, "collection", "c", "", "[DEPRECATED] only list backups contains a certain collection")
-}
-
-func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
+func run(cmd *cobra.Command, params *v2.Config) error {
 	ctx := context.Background()
-	if err := o.validate(); err != nil {
-		return err
-	}
 
 	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
@@ -59,19 +45,23 @@ func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 }
 
 func NewCmd(opt *root.Options) *cobra.Command {
-	var o options
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list all backups in object storage",
 
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.CheckRemoved(cmd, removedFlags); err != nil {
+				return err
+			}
+
 			params := opt.InitGlobalVars()
-			err := o.run(cmd, params)
-			cobra.CheckErr(err)
+			cobra.CheckErr(run(cmd, params))
+
+			return nil
 		},
 	}
 
-	o.addFlags(cmd)
+	flags.AddRemoved(cmd, removedFlags)
 
 	return cmd
 }

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -1,0 +1,36 @@
+package list
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/cmd/root"
+)
+
+// A removed flag has to fail before the command reaches any other work, so that
+// an outdated command line is answered by the flag that has to change.
+func TestNewCmd_RemovedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "Collection", args: []string{"--collection", "coll1"}},
+		{name: "CollectionShorthand", args: []string{"-c", "coll1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd(&root.Options{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Equal(t, "--collection was removed in 0.6, listing backups by collection is no longer supported", err.Error())
+		})
+	}
+}

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -2,7 +2,6 @@ package restore
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,11 +10,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/restore"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
-	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/storage"
@@ -23,17 +22,22 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
+// removedFlags are the restore flags dropped in 0.6, after 0.5 accepted them
+// with a deprecation warning.
+var removedFlags = []flags.Removed{
+	{Name: "collections", Shorthand: "c", Advice: "use --filter instead"},
+	{Name: "databases", Shorthand: "d", Advice: "use --filter instead"},
+	{Name: "database_collections", Shorthand: "a", Advice: "use --filter instead"},
+	{Name: "restore_index", NoValue: true, Advice: "use --rebuild_index instead"},
+}
+
 type options struct {
 	backupName            string
 	renameSuffix          string
 	renameCollectionNames string
 
-	collectionNames     string
-	databases           string
-	databaseCollections string
-	filter              string
+	filter string
 
-	restoreIndex bool
 	rebuildIndex bool
 
 	metaOnly             bool
@@ -51,32 +55,6 @@ func (o *options) validate() error {
 		return errors.New("backup name is required")
 	}
 
-	if o.collectionNames != "" || o.databases != "" || o.databaseCollections != "" {
-		log.Warn("collection_names, databases and database_collections are deprecated, use filter instead !")
-	}
-
-	if o.filter != "" && o.collectionNames != "" {
-		return errors.New("filter and collection_names cannot be set at the same time")
-	}
-	if o.filter != "" && o.databases != "" {
-		return errors.New("filter and databases cannot be set at the same time")
-	}
-	if o.filter != "" && o.databaseCollections != "" {
-		return errors.New("filter and database_collections cannot be set at the same time")
-	}
-
-	if o.collectionNames != "" && o.databaseCollections != "" {
-		return errors.New("collection_names and database_collections cannot be set at the same time")
-	}
-
-	if o.collectionNames != "" && o.databases != "" {
-		return errors.New("collection_names and databases cannot be set at the same time")
-	}
-
-	if o.databaseCollections != "" && o.databases != "" {
-		return errors.New("database_collections and databases cannot be set at the same time")
-	}
-
 	if o.renameSuffix != "" && o.renameCollectionNames != "" {
 		return errors.New("suffix and rename flag cannot be set at the same time")
 	}
@@ -85,25 +63,17 @@ func (o *options) validate() error {
 		return errors.New("drop_exist_collection and skip_create_collection cannot be true at the same time")
 	}
 
-	if o.restoreIndex {
-		log.Warn("restore_index is deprecated, use rebuild_index instead")
-	}
-
 	return nil
 }
 
 func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.backupName, "name", "n", "", "backup name to restore")
 
-	cmd.Flags().StringVarP(&o.databases, "databases", "d", "", "[DEPRECATED] Use --filter instead. databases to restore, if not set, restore all databases")
-	cmd.Flags().StringVarP(&o.databaseCollections, "database_collections", "a", "", "[DEPRECATED] Use --filter instead. databases and collections to restore, json format: {\"db1\":[\"c1\", \"c2\"],\"db2\":[]}")
-	cmd.Flags().StringVarP(&o.collectionNames, "collections", "c", "", "[DEPRECATED] Use --filter instead. collectionNames to restore")
-	cmd.Flags().StringVarP(&o.filter, "filter", "", "", "Specify which collections to restore, if not set, restore all collections in backup. example: db1.coll1,db2.coll2")
+	cmd.Flags().StringVarP(&o.filter, "filter", "", "", "Specify which collections to restore, if not set, restore all collections in backup. Matched against the name after --suffix or --rename is applied. example: db1.coll1,db2.coll2")
 
 	cmd.Flags().StringVarP(&o.renameSuffix, "suffix", "s", "", "add a suffix to collection name to restore")
 	cmd.Flags().StringVarP(&o.renameCollectionNames, "rename", "r", "", "rename collections to new names, format: db1.collection1:db2.collection1_new,db1.collection2:db2.collection2_new")
 
-	cmd.Flags().BoolVarP(&o.restoreIndex, "restore_index", "", false, "[DEPRECATED] Use --rebuild_index instead. restore index info")
 	cmd.Flags().BoolVarP(&o.rebuildIndex, "rebuild_index", "", false, "Rebuild index from meta information.")
 
 	cmd.Flags().BoolVarP(&o.metaOnly, "meta_only", "", false, "if true, restore meta only")
@@ -114,14 +84,14 @@ func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.skipCreateCollection, "skip_create_collection", "", false, "if true, will skip collection, use when collection exist, restore index or data")
 	cmd.Flags().BoolVarP(&o.rbac, "rbac", "", false, "whether restore RBAC meta")
 	cmd.Flags().BoolVarP(&o.useV2Restore, "use_v2_restore", "", false, "if true, use multi-segment merged restore")
+
+	flags.AddRemoved(cmd, removedFlags)
 }
 
 func (o *options) toOption() *restore.Option {
-	rebuildIndex := o.restoreIndex || o.rebuildIndex
-
 	return &restore.Option{
 		DropExistIndex:       o.dropExistIndex,
-		RebuildIndex:         rebuildIndex,
+		RebuildIndex:         o.rebuildIndex,
 		UseAutoIndex:         o.useAutoIndex,
 		DropExistCollection:  o.dropExistCollection,
 		SkipCreateCollection: o.skipCreateCollection,
@@ -133,22 +103,6 @@ func (o *options) toOption() *restore.Option {
 
 func (o *options) toTaskFilter() (filter.Filter, error) {
 	return filter.Parse(o.filter)
-}
-
-func (o *options) toBackupFilter() (filter.Filter, error) {
-	if o.collectionNames != "" {
-		return o.collectionNamesToBackupFilter()
-	}
-
-	if o.databases != "" {
-		return o.databasesToBackupFilter()
-	}
-
-	if o.databaseCollections != "" {
-		return o.dbCollectionsToBackupFilter()
-	}
-
-	return filter.Filter{}, nil
 }
 
 func (o *options) toCollMapper() (restore.CollMapper, error) {
@@ -164,11 +118,6 @@ func (o *options) toCollMapper() (restore.CollMapper, error) {
 }
 
 func (o *options) toPlan() (*restore.Plan, error) {
-	backupFilter, err := o.toBackupFilter()
-	if err != nil {
-		return nil, err
-	}
-
 	collMapper, err := o.toCollMapper()
 	if err != nil {
 		return nil, err
@@ -179,66 +128,14 @@ func (o *options) toPlan() (*restore.Plan, error) {
 		return nil, err
 	}
 
+	// Plan.BackupFilter is left unset: it exists for the removed database and
+	// collection flags, and the HTTP API is the only caller that still has them.
 	return &restore.Plan{
-		BackupFilter: backupFilter,
-
 		// not support db mapping now
 		CollMapper: collMapper,
 
 		TaskFilter: taskFilter,
 	}, nil
-}
-
-func (o *options) collectionNamesToBackupFilter() (filter.Filter, error) {
-	collFilter := make(map[string]filter.CollFilter)
-
-	nsStrs := strings.Split(o.collectionNames, ",")
-	for _, nsStr := range nsStrs {
-		ns, err := namespace.Parse(nsStr)
-		if err != nil {
-			return filter.Filter{}, fmt.Errorf("invalid collection name %s", nsStr)
-		}
-
-		if _, ok := collFilter[ns.DBName()]; !ok {
-			collFilter[ns.DBName()] = filter.CollFilter{CollName: make(map[string]struct{})}
-		}
-		collFilter[ns.DBName()].CollName[ns.CollName()] = struct{}{}
-	}
-
-	return filter.Filter{DBCollFilter: collFilter}, nil
-}
-
-func (o *options) databasesToBackupFilter() (filter.Filter, error) {
-	collFilter := make(map[string]filter.CollFilter)
-
-	splits := strings.Split(o.databases, ",")
-	for _, db := range splits {
-		collFilter[db] = filter.CollFilter{AllowAll: true}
-	}
-
-	return filter.Filter{DBCollFilter: collFilter}, nil
-}
-
-func (o *options) dbCollectionsToBackupFilter() (filter.Filter, error) {
-	dbColls := make(map[string][]string)
-	if err := json.Unmarshal([]byte(o.databaseCollections), &dbColls); err != nil {
-		return filter.Filter{}, fmt.Errorf("unmarshal dbCollections: %w", err)
-	}
-
-	collFilter := make(map[string]filter.CollFilter)
-	for dbName, colls := range dbColls {
-		if len(colls) == 0 {
-			collFilter[dbName] = filter.CollFilter{AllowAll: true}
-		} else {
-			collName := make(map[string]struct{}, len(colls))
-			for _, coll := range colls {
-				collName[coll] = struct{}{}
-			}
-			collFilter[dbName] = filter.CollFilter{CollName: collName}
-		}
-	}
-
-	return filter.Filter{DBCollFilter: collFilter}, nil
 }
 
 func (o *options) renameCollectionNamesToMapper() (*restore.TableMapper, error) {
@@ -363,8 +260,20 @@ func NewCmd(opt *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore",
 		Short: "restore a backup into Milvus",
+		Long: "Restore a backup into Milvus.\n\n" +
+			"--filter names collections as they will exist in the target Milvus, that is, after\n" +
+			"--suffix or --rename has been applied. Restoring only hello_milvus under a _recover\n" +
+			"suffix is therefore \"--suffix _recover --filter hello_milvus_recover\", not\n" +
+			"\"--filter hello_milvus\", which matches nothing.\n\n" +
+			"The removed --collections, --databases and --database_collections selected\n" +
+			"collections by their name in the backup instead; --filter is not a drop-in\n" +
+			"replacement for them when the restore also renames.",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.CheckRemoved(cmd, removedFlags); err != nil {
+				return err
+			}
+
 			params := opt.InitGlobalVars()
 
 			if err := o.validate(); err != nil {

--- a/cmd/restore/restore_test.go
+++ b/cmd/restore/restore_test.go
@@ -1,12 +1,44 @@
 package restore
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 )
+
+// A removed flag has to fail before the command reaches any other work, so that
+// an outdated command line is answered by the flag that has to change.
+func TestNewCmd_RemovedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "Collections", args: []string{"--collections", "coll1"}, want: "--collections was removed in 0.6, use --filter instead"},
+		{name: "CollectionsShorthand", args: []string{"-c", "coll1"}, want: "--collections was removed in 0.6, use --filter instead"},
+		{name: "Databases", args: []string{"--databases", "db1"}, want: "--databases was removed in 0.6, use --filter instead"},
+		{name: "DatabaseCollections", args: []string{"--database_collections", `{"db1":[]}`}, want: "--database_collections was removed in 0.6, use --filter instead"},
+		{name: "RestoreIndex", args: []string{"--restore_index"}, want: "--restore_index was removed in 0.6, use --rebuild_index instead"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd(&root.Options{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
+}
 
 func TestOptions_validate(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {

--- a/docs/user_guide/e2e_demo_cli.md
+++ b/docs/user_guide/e2e_demo_cli.md
@@ -48,10 +48,10 @@ Restore the backup using the following command:
 
 This will create a new collection called `hello_milvus_recover` which contains the data from the original collection.
 
-**Note:** if you want to restore index as well, add `--restore_index`, like this:
+**Note:** if you want to restore index as well, add `--rebuild_index`, like this:
 
 ```
-./milvus-backup restore --restore_index -n my_backup -s _recover
+./milvus-backup restore --rebuild_index -n my_backup -s _recover
 ```
 
 This will help you restore data and index at the same time. If you don't add this flag, you need to restore index manually.


### PR DESCRIPTION
## Summary

0.5 accepted these flags with a deprecation warning; 0.6 stops honoring them. Each one stays
registered but hidden from help, so an outdated command line is answered by the flag that has to
change rather than by cobra's bare `unknown flag`:

```console
$ milvus-backup create --colls c1
Error: --colls was removed in 0.6, use --filter instead
```

The registration is not what makes this safe — cobra already fails on an unknown flag and exits 1,
so the stubs only buy the message. Deleting them in a later release degrades that message without
letting anything through, which is why the removal is left as a TODO rather than done here.

One replacement is not a drop-in swap. On `restore`, `--filter` matches the collection name **after**
`--suffix` or `--rename` is applied, while the removed `--collections` matched the name in the backup.
So `restore -c hello_milvus -s _recover` becomes `restore --filter hello_milvus_recover -s _recover`;
filtering on the pre-rename name matches nothing and restores nothing. This is now stated in
`restore --help` and the README, and the CI job that relied on `-c` is rewritten accordingly.

## Changes

- Add `cmd/flags`, where one table per command drives registration, hiding and the error message, so
  the advice in help and the advice in the error cannot drift apart.
- Reject the removed flags in `create` (`--colls`, `--databases`, `--database_collections`, `--force`,
  `--meta_only`), `restore` (`--collections`, `--databases`, `--database_collections`,
  `--restore_index`), `get` (`--detail`) and `list` (`--collection`).
- Drop the code that existed only to serve them: six `*ToFilter` / `*ToBackupFilter` helpers, the
  `force` and `meta_only` branches of `toStrategy`, and six mutual-exclusion checks in `restore`
  validation. `Plan.BackupFilter` stays, since the HTTP API still sets it.
- Document the post-rename `--filter` semantics in `restore --help` and a new README section, and fix
  the two callers that still passed removed flags (`.github/workflows/main.yaml`,
  `docs/user_guide/e2e_demo_cli.md`).

Part of #695
