### PR TITLE
log: write the bootstrap logger to stderr

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -125,9 +125,21 @@ func initFileLog(cfg *FileLogConfig) (*lumberjack.Logger, error) {
 	}, nil
 }
 
+// newStdLogger builds the logger the package starts with, the one in use until
+// InitLogger replaces it with the configured one.
+//
+// It writes to stderr rather than going through initLogger, which builds its
+// sinks from the file and console settings and so would have none to build from
+// here. Anything logged while the configuration is still being read — an
+// unknown key, a deprecated schema version — would otherwise be discarded,
+// which is the opposite of what a warning raised at that point is for. stderr
+// keeps it clear of the stdout a command writes its own output to.
+//
+// No caller skip: the package-level Warn and friends already add one for their
+// own frame, and the logger InitLogger builds adds none.
 func newStdLogger() (*zap.Logger, *ZapProperties) {
 	conf := &Config{Level: "info", File: FileLogConfig{}}
-	lg, r, _ := initLogger(conf, zap.AddCallerSkip(1))
+	lg, r, _ := InitLoggerWithWriteSyncer(conf, zapcore.AddSync(os.Stderr))
 	return lg, r
 }
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// captureStderr builds a logger with newStdLogger while stderr is a pipe, and
+// returns everything fn logs through it. The logger resolves stderr when it is
+// built, so it has to be built inside the redirect.
+func captureStderr(t *testing.T, fn func(lg *zap.Logger)) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	lg, _ := newStdLogger()
+	fn(lg)
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func TestNewStdLogger(t *testing.T) {
+	// The configuration is read before the log settings inside it can be
+	// applied, so the logger in use at that point is this one. Sending it
+	// nowhere would discard exactly the warnings raised while reading.
+	t.Run("WritesToStderr", func(t *testing.T) {
+		out := captureStderr(t, func(lg *zap.Logger) {
+			lg.Warn("cfg: unknown v2 config file key")
+		})
+
+		assert.Contains(t, out, "cfg: unknown v2 config file key")
+		assert.Contains(t, out, "[WARN]")
+	})
+
+	// A caller skip here would be one too many: the package-level Warn and
+	// friends already add one for their own frame. The assertion is on the
+	// exact line, because an extra skip lands on captureStderr — still in this
+	// file, so matching the file name alone would pass either way.
+	t.Run("ReportsTheCallSite", func(t *testing.T) {
+		var warnLine int
+		out := captureStderr(t, func(lg *zap.Logger) {
+			_, _, line, _ := runtime.Caller(0)
+			warnLine = line + 2
+			lg.Warn("from the test")
+		})
+
+		assert.Contains(t, out, fmt.Sprintf("log/log_test.go:%d", warnLine))
+	})
+}


### PR DESCRIPTION
## Summary

The configuration file is read before the log settings inside it can be applied, so anything the loader has to say goes through the logger `newStdLogger` builds. That logger was given a `Config` with no file name and `Console` left false, and `initLogger` only appends a sink for one of those — so it had no sinks and discarded everything written to it.

Two warnings went that way, and both matter more than most: the one naming a config key that was ignored because it is misspelled, and the one saying a v1 file was translated to v2. The first is the expensive one. `checkKeys` detects the misspelling and builds the warning; the backup then runs against a default the operator did not choose, exit code 0, nothing printed.

## Changes

- Build the bootstrap logger on stderr instead of on sinks derived from a configuration that has not been read yet. stderr rather than stdout because a command's own output goes to stdout — `config migrate` writes the generated v2 file there, and a warning landing in it would corrupt the file being generated.
- Drop the `zap.AddCallerSkip(1)` that logger was built with. The package-level `Warn` and friends already add one for their own frame, and the logger `InitLogger` builds adds none, so the extra skip attributed every warning to the caller of the function that logged it — the unknown-key warning was reported at `loader/load.go:53` rather than `v2/load.go:37`. Invisible until now, since nothing this logger wrote was reaching anyone.
- Add `internal/log/log_test.go`, which had no tests. Two cases: the logger writes to stderr, and it reports the line that logged.

## Verification

Reverting either half of the fix fails the corresponding test — checked, because the first version of the call-site test passed either way. It asserted only the file name, and an extra caller skip lands on the test helper, which is in that same file; it now asserts the exact line.

End to end, on a v2 file with two misspelled keys, and on a v1 file:

```console
$ milvus-backup config show --config typo.yaml 2>&1 >/dev/null
[WARN] [v2/load.go:37] ["cfg: unknown v2 config file key \"milvus.storage.bucketnaem\", ignoring it"]
[WARN] [v2/load.go:37] ["cfg: unknown v2 config file key \"milvus.storage.bukcetname\", ignoring it"]

$ milvus-backup config show --config v1.yaml 2>&1 >/dev/null
[WARN] [loader/load.go:77] ["cfg: loaded a v1 configuration and translated it to v2; run `milvus-backup config migrate` to convert the file itself"] [path=v1.yaml]
```

Both now report the line that actually logged them. stdout is unchanged in both runs, and a clean v2 config produces no new output. `go test --race ./...` and `golangci-lint run ./...` pass.

## Notes

Warnings raised before `InitLogger` go to stderr and not to a configured log file, since the file is named by the configuration still being read. For a deployment logging to a file, these two lines land in stderr — container logs — rather than that file. Buffering them for replay after initialization would fix that, and is worth doing if it turns out to matter; it is more machinery than a startup warning seemed to justify here.

Fixes #1110
