### PR TITLE
log: drop the unused rate limiter and use atomic.Pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133
-	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/vbauerster/mpb/v8 v8.12.1
 	go.etcd.io/etcd/client/v3 v3.7.0
 	go.uber.org/atomic v1.11.0
@@ -49,6 +48,7 @@ require (
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.8.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect

--- a/internal/log/global.go
+++ b/internal/log/global.go
@@ -59,39 +59,6 @@ func Fatal(msg string, fields ...zap.Field) {
 	L().WithOptions(zap.AddCallerSkip(1)).Fatal(msg, fields...)
 }
 
-// RatedDebug print logs at debug level
-// it limit log print to avoid too many logs
-// return true if log successfully
-func RatedDebug(cost float64, msg string, fields ...zap.Field) bool {
-	if R().CheckCredit(cost) {
-		L().Debug(msg, fields...)
-		return true
-	}
-	return false
-}
-
-// RatedInfo print logs at info level
-// it limit log print to avoid too many logs
-// return true if log successfully
-func RatedInfo(cost float64, msg string, fields ...zap.Field) bool {
-	if R().CheckCredit(cost) {
-		L().Info(msg, fields...)
-		return true
-	}
-	return false
-}
-
-// RatedWarn print logs at warn level
-// it limit log print to avoid too many logs
-// return true if log successfully
-func RatedWarn(cost float64, msg string, fields ...zap.Field) bool {
-	if R().CheckCredit(cost) {
-		L().Warn(msg, fields...)
-		return true
-	}
-	return false
-}
-
 // With creates a child logger and adds structured context to it.
 // Fields added to the child don't affect the parent, and vice versa.
 func With(fields ...zap.Field) *zap.Logger {
@@ -100,10 +67,10 @@ func With(fields ...zap.Field) *zap.Logger {
 
 // SetLevel alters the logging level.
 func SetLevel(l zapcore.Level) {
-	_globalP.Load().(*ZapProperties).Level.SetLevel(l)
+	_globalP.Load().Level.SetLevel(l)
 }
 
 // GetLevel gets the logging level.
 func GetLevel() zapcore.Level {
-	return _globalP.Load().(*ZapProperties).Level.Level()
+	return _globalP.Load().Level.Level()
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -35,7 +35,6 @@ import (
 	"os"
 	"sync/atomic"
 
-	"github.com/uber/jaeger-client-go/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -43,17 +42,17 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/progressbar"
 )
 
-var _globalL, _globalP, _globalS, _globalR atomic.Value
+var (
+	_globalL atomic.Pointer[zap.Logger]
+	_globalP atomic.Pointer[ZapProperties]
+	_globalS atomic.Pointer[zap.SugaredLogger]
+)
 
 func init() {
 	l, p := newStdLogger()
 	_globalL.Store(l)
 	_globalP.Store(p)
-	s := _globalL.Load().(*zap.Logger).Sugar()
-	_globalS.Store(s)
-
-	r := utils.NewRateLimiter(1.0, 60.0)
-	_globalR.Store(r)
+	_globalS.Store(l.Sugar())
 }
 
 // InitLogger replaces the global logger with one built from conf. The caller
@@ -134,18 +133,13 @@ func newStdLogger() (*zap.Logger, *ZapProperties) {
 // L returns the global Logger, which can be reconfigured with ReplaceGlobals.
 // It's safe for concurrent use.
 func L() *zap.Logger {
-	return _globalL.Load().(*zap.Logger)
+	return _globalL.Load()
 }
 
 // S returns the global SugaredLogger, which can be reconfigured with
 // ReplaceGlobals. It's safe for concurrent use.
 func S() *zap.SugaredLogger {
-	return _globalS.Load().(*zap.SugaredLogger)
-}
-
-// R returns utils.ReconfigurableRateLimiter.
-func R() *utils.ReconfigurableRateLimiter {
-	return _globalR.Load().(*utils.ReconfigurableRateLimiter)
+	return _globalS.Load()
 }
 
 // ReplaceGlobals replaces the global Logger and SugaredLogger.


### PR DESCRIPTION
## Summary

`RatedDebug`, `RatedInfo` and `RatedWarn` arrived with the log package when it was copied from Milvus in 117d95f, and nothing in this repository has ever called them. They are the only readers of `R()`, which is the only reader of the rate limiter global, so the whole chain is unreachable. All of it is exported, which is why the `unused` check never had anything to say about it.

With that gone, the three globals that remain all hold pointers, so `atomic.Value` bought nothing `atomic.Pointer[T]` does not, and cost a type assertion at every read.

## Changes

- Delete `RatedDebug`, `RatedInfo`, `RatedWarn`, `R()` and the `_globalR` it reads, along with the `jaeger-client-go/utils` import they needed.
- Declare the remaining three globals as `atomic.Pointer[T]` and drop the five type assertions their readers needed, in `L()`, `S()` and the two level accessors in `global.go`.
- In `init`, call `Sugar()` on the logger already in hand rather than storing it and loading it back to reach the same value.

## Notes

`jaeger-client-go` moves from a direct requirement to an indirect one rather than leaving `go.mod`. It stays in the build graph because `milvus/pkg/v2/log` imports the same package, reached from here through `core/restore/secondary`, so no packages stop compiling — this drops our own dependency on it, not the dependency.

One semantic difference worth naming rather than leaving for someone to find: `atomic.Value` panics on a nil `Store`, `atomic.Pointer` accepts it. A nil logger would now fail at first use instead of at the store that caused it. Nothing stores nil today — the only writer is `ReplaceGlobals`, and the one caller that can fail, `InitLogger`, panics on the error before reaching it.

## Verification

`go build ./...`, `go test --race ./...` and `golangci-lint run ./...` pass, and the built binary still resolves and prints a configuration. The deleted names were checked for callers across the module including tests; outside their own definitions the only remaining mentions were their own doc comments.

/kind improvement
