### PR TITLE
ci: forward the milvus management port so backup can pause gc

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -884,11 +884,13 @@ jobs:
             kubectl get pods
             kubectl port-forward service/milvus-backup 19530 >/dev/null 2>&1 &
             kubectl port-forward service/milvus-backup-minio 9000  >/dev/null 2>&1 &
+            kubectl port-forward service/milvus-backup 9091 >/dev/null 2>&1 &
             kubectl port-forward service/milvus-restore 19531:19530 >/dev/null 2>&1 &
             kubectl port-forward service/milvus-restore-minio 9010:9000  >/dev/null 2>&1 &
             sleep 10
             nc -vz 127.0.0.1 19530
             nc -vz 127.0.0.1 9000
+            nc -vz 127.0.0.1 9091
             nc -vz 127.0.0.1 19531
             nc -vz 127.0.0.1 9010
             sleep 10

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -183,9 +183,11 @@ jobs:
             kubectl get pods
             kubectl port-forward service/milvus-backup 19530 >/dev/null 2>&1 &
             kubectl port-forward service/milvus-backup-minio 9000  >/dev/null 2>&1 &
+            kubectl port-forward service/milvus-backup 9091 >/dev/null 2>&1 &
             sleep 10
             nc -vz 127.0.0.1 19530
             nc -vz 127.0.0.1 9000
+            nc -vz 127.0.0.1 9091
             sleep 10
             kubectl get pods -n default | grep milvus-backup
           fi

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -75,9 +75,11 @@ jobs:
             kubectl get pods
             kubectl port-forward service/milvus-backup 19530 >/dev/null 2>&1 &
             kubectl port-forward service/milvus-backup-minio 9000  >/dev/null 2>&1 &
+            kubectl port-forward service/milvus-backup 9091 >/dev/null 2>&1 &
             sleep 10
             nc -vz 127.0.0.1 19530
             nc -vz 127.0.0.1 9000
+            nc -vz 127.0.0.1 9091
             sleep 10
             kubectl get pods -n default | grep milvus-backup
           fi


### PR DESCRIPTION
## Summary

Every helm-deployed CI job logs `Pause GC failed ... dial tcp [::1]:9091: connect: connection refused`
on every backup. The milvus chart already exposes port 9091 (the `metrics` port) on
`service/milvus-backup`, but the workflows only port-forward 19530 and 9000, so
`milvus.management.endpoint` (default `http://localhost:9091`) has nothing to talk to.

The result is that GC is never actually paused in these jobs, so the CI never exercises the
paused-GC path and backups run against a cluster that is free to compact and GC underneath them.

Forwarding 9091 alongside the existing ports is enough; no config change is needed because the
default endpoint already points at `localhost:9091`.

Verified against the 2026-07-26 nightly run:

- docker-compose jobs (`docker-compose.yml` maps `9091:9091`) — 43 `pause gc success`, 0 failures.
- helm jobs (no forward) — `Pause GC failed` on every backup.

`helm template` confirms `service/milvus-backup` already publishes 9091, so nothing on the chart
side needs to change.

## Changes

- nightly.yaml: forward 9091 in the `test-backup-restore-with-custom-config` helm deploy
- main.yaml: forward 9091 in the helm RBAC deploy
- perf.yaml: forward 9091 in the helm deploy
- check the new port with `nc -vz` next to the existing readiness checks

/kind improvement
