### PR TITLE
milvus: detect the server version from every string it reports

### DIFF
--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -58,11 +59,22 @@ type featureTuple struct {
 	Flag        FeatureFlag
 }
 
-// _latestDevVersion is used as a fallback when the server returns a version string
-// that is not a strict MAJOR.MINOR.PATCH semver (e.g. "master-20260226-abcdef" or
-// "2.6-20260404-31fb3fc" from dev builds). It ensures lower-bound constraints (>= X)
-// pass while upper-bound constraints (< Y) correctly fail.
+// _latestDevVersion is used as a fallback when none of the strings the server reports about
+// itself contains a version at all, e.g. the build tags "master-20260226-abcdef" or
+// "unknown-20260608-7ea6e3526", which carry only a branch name, a build date and a commit.
+// It ensures lower-bound constraints (>= X) pass while upper-bound constraints (< Y)
+// correctly fail.
 var _latestDevVersion = semver.MustParse("99.0.0")
+
+// _headOfLinePatch stands in for the patch level of a version that is only known down to
+// MAJOR.MINOR: the "2.6" in the dev build tag "2.6-20260404-31fb3fc", or in the vendor
+// description "Zilliz Cloud Vector Database(Compatible with Milvus 2.6)". Such a server sits
+// somewhere on the 2.6 line and is far more likely to be at its head than at 2.6.0, so it is
+// treated as the newest patch of that line.
+//
+// Unlike _latestDevVersion this still fails the constraints of every other line, which is what
+// keeps ReplicateMessage ("< 2.6.0-0") enabled on a 2.5 dev build and disabled on a 2.6 one.
+const _headOfLinePatch = 9999
 
 var _featureTuples = []featureTuple{
 	{Constraints: lo.Must(semver.NewConstraint(">= 2.4.3-0")), Flag: DescribeDatabase},
@@ -428,7 +440,7 @@ func (g *GrpcClient) checkFeature(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("client: get version: %w", err)
 	}
-	sem := g.parseVersionForFeature(ver)
+	sem := g.parseVersionForFeature(g.serverVersion, ver)
 
 	for _, tuple := range _featureTuples {
 		if tuple.Constraints.Check(sem) {
@@ -442,29 +454,95 @@ func (g *GrpcClient) checkFeature(ctx context.Context) error {
 	return nil
 }
 
-// parseVersionForFeature parses a server version for feature constraint checking.
+// releaseVersion parses ver as an exact MAJOR.MINOR.PATCH release version.
 //
-// It strips an optional leading "v" (Milvus releases report build tags like "v2.2.16")
-// and then uses StrictNewVersion, which requires MAJOR.MINOR.PATCH. This deliberately
-// rejects dev build tags like "2.6-20260404-31fb3fc" or "master-20260226-abcdef" so
-// they fall through to _latestDevVersion.
+// It strips an optional leading "v" (Milvus releases report build tags like "v2.2.16") and
+// then uses StrictNewVersion. This deliberately rejects dev build tags like
+// "2.6-20260404-31fb3fc" or "master-20260226-abcdef", leaving them to embeddedVersion.
 //
 // The lenient semver.NewVersion cannot be used here because it parses
 // "2.6-20260404-31fb3fc" as "2.6.0-20260404-31fb3fc" — a prerelease of 2.6.0 — which
 // compares LESS than 2.6.x and silently disables features on dev builds.
-func (g *GrpcClient) parseVersionForFeature(ver string) *semver.Version {
+func releaseVersion(ver string) (*semver.Version, bool) {
 	v := strings.TrimPrefix(ver, "v")
 	// Collapse four-part hotfix versions to their release base, e.g. "2.3.22.6" -> "2.3.22".
 	if parts := strings.SplitN(v, ".", 4); len(parts) == 4 {
 		v = strings.Join(parts[:3], ".")
 	}
+
 	sem, err := semver.StrictNewVersion(v)
 	if err != nil {
-		g.logger.Warn("cannot parse server version as strict semver, treat as latest dev build",
-			zap.String("version", ver), zap.Error(err))
-		return _latestDevVersion
+		return nil, false
 	}
-	return sem
+
+	return sem, true
+}
+
+// _versionPattern recovers MAJOR.MINOR[.PATCH] from a string that is not a version itself.
+// It matches only at the start of the string, for dev build tags like "2.6-20260404-31fb3fc",
+// or right after "Milvus", for vendor descriptions like
+// "Zilliz Cloud Vector Database(Compatible with Milvus 2.6)". Anchoring both alternatives is
+// what keeps an unrelated number elsewhere in a product name from being read as the server
+// version.
+var _versionPattern = regexp.MustCompile(`(?i)(?:^|milvus[ _-]*)v?(\d+)\.(\d+)(?:\.(\d+))?`)
+
+// embeddedVersion recovers a version embedded in a string that is not a release version
+// itself, such as a dev build tag or a vendor product description. A match that stops at
+// MAJOR.MINOR resolves to the head of that line, see _headOfLinePatch.
+func embeddedVersion(ver string) (*semver.Version, bool) {
+	match := _versionPattern.FindStringSubmatch(ver)
+	if match == nil {
+		return nil, false
+	}
+
+	major, err := strconv.ParseUint(match[1], 10, 64)
+	if err != nil {
+		return nil, false
+	}
+	minor, err := strconv.ParseUint(match[2], 10, 64)
+	if err != nil {
+		return nil, false
+	}
+
+	patch := uint64(_headOfLinePatch)
+	if match[3] != "" {
+		if patch, err = strconv.ParseUint(match[3], 10, 64); err != nil {
+			return nil, false
+		}
+	}
+
+	return semver.New(major, minor, patch, "", ""), true
+}
+
+// parseVersionForFeature picks the version to check feature constraints against out of every
+// string the server reports about itself.
+//
+// Connect and GetVersion answer with the same build tag on open source Milvus, but not on
+// hosted ones: Zilliz Cloud answers Connect with a product description that names the Milvus
+// line ("... (Compatible with Milvus 2.6)") and GetVersion with an internal build tag that
+// carries no version at all ("unknown-20260608-7ea6e3526"). Taking all of them means the one
+// source that does know the version is used. An exact release version wins over an embedded
+// one no matter which call reported it.
+func (g *GrpcClient) parseVersionForFeature(vers ...string) *semver.Version {
+	for _, ver := range vers {
+		if sem, ok := releaseVersion(ver); ok {
+			g.logger.Info("check features against the server release version",
+				zap.String("version", ver), zap.String("resolved", sem.String()))
+			return sem
+		}
+	}
+
+	for _, ver := range vers {
+		if sem, ok := embeddedVersion(ver); ok {
+			g.logger.Info("the server does not report a release version, check features against the version embedded in it",
+				zap.String("version", ver), zap.String("resolved", sem.String()))
+			return sem
+		}
+	}
+
+	g.logger.Warn("the server reports no version at all, treat it as the latest dev build",
+		zap.Strings("versions", vers))
+	return _latestDevVersion
 }
 
 func (g *GrpcClient) CreateDatabase(ctx context.Context, dbName string) error {

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -194,63 +195,124 @@ func TestReplicateMessageConstraint(t *testing.T) {
 	}
 }
 
+// Real strings observed from a Zilliz Cloud instance: Connect reports the product
+// description, GetVersion reports an internal build tag whose branch could not be resolved
+// at build time and therefore reads "unknown".
+const (
+	_cloudDesc     = "Zilliz Cloud Vector Database(Compatible with Milvus 2.6)"
+	_cloudBuildTag = "unknown-20260608-7ea6e3526"
+)
+
 func TestGrpcClient_parseVersionForFeature(t *testing.T) {
 	tests := []struct {
 		name           string
-		version        string
+		versions       []string
 		wantConstraint string
 		wantPass       bool
 	}{
 		// Strict semver: real release versions match constraints based on actual values.
-		{"Release2.6.0_NoMultiL0", "2.6.0", ">= 2.6.5-0", false},
-		{"Release2.6.5_HasMultiL0", "2.6.5", ">= 2.6.5-0", true},
-		{"Release2.6.11_HasFlushAll", "2.6.11", ">= 2.6.11-0", true},
-		{"Release2.6.10_NoFlushAll", "2.6.10", ">= 2.6.11-0", false},
+		{"Release2.6.0_NoMultiL0", []string{"2.6.0"}, ">= 2.6.5-0", false},
+		{"Release2.6.5_HasMultiL0", []string{"2.6.5"}, ">= 2.6.5-0", true},
+		{"Release2.6.11_HasFlushAll", []string{"2.6.11"}, ">= 2.6.11-0", true},
+		{"Release2.6.10_NoFlushAll", []string{"2.6.10"}, ">= 2.6.11-0", false},
 
 		// Milvus releases report build tags with a leading "v" (e.g. "v2.2.16").
 		// Without v-prefix stripping these would fall back to _latestDevVersion and
 		// incorrectly enable features the old release does not implement (e.g.
 		// DescribeDatabase on v2.2.16, which then crashes with Unimplemented).
-		{"VPrefixV2.2.16_NoDescribeDatabase", "v2.2.16", ">= 2.4.3-0", false},
-		{"VPrefixV2.3.22_NoDescribeDatabase", "v2.3.22", ">= 2.4.3-0", false},
-		{"VPrefixV2.4.23_HasDescribeDatabase", "v2.4.23", ">= 2.4.3-0", true},
-		{"VPrefixV2.5.20_NoMultiL0", "v2.5.20", ">= 2.6.5-0", false},
-		{"VPrefixV2.6.5_HasMultiL0", "v2.6.5", ">= 2.6.5-0", true},
-		{"VPrefixV2.5.20_HasReplicateMessage", "v2.5.20", ">= 2.5.0-0, < 2.6.0-0", true},
+		{"VPrefixV2.2.16_NoDescribeDatabase", []string{"v2.2.16"}, ">= 2.4.3-0", false},
+		{"VPrefixV2.3.22_NoDescribeDatabase", []string{"v2.3.22"}, ">= 2.4.3-0", false},
+		{"VPrefixV2.4.23_HasDescribeDatabase", []string{"v2.4.23"}, ">= 2.4.3-0", true},
+		{"VPrefixV2.5.20_NoMultiL0", []string{"v2.5.20"}, ">= 2.6.5-0", false},
+		{"VPrefixV2.6.5_HasMultiL0", []string{"v2.6.5"}, ">= 2.6.5-0", true},
+		{"VPrefixV2.5.20_HasReplicateMessage", []string{"v2.5.20"}, ">= 2.5.0-0, < 2.6.0-0", true},
 
 		// Four-part versions collapse to their release base. Without the collapse
 		// these fail StrictNewVersion, fall back to _latestDevVersion, and wrongly
 		// enable features the underlying release does not implement.
 		// "v2.4.0.1-gpu-beta" and "v2.4.0.2-gpu-beta" are real milvusdb/milvus tags;
 		// the trailing component (with its prerelease suffix) is dropped to "2.4.0".
-		{"FourPartV2.4.0.1GpuBeta_NoMultiL0", "v2.4.0.1-gpu-beta", ">= 2.6.5-0", false},
-		{"FourPartV2.4.0.1GpuBeta_NoDescribeDatabase", "v2.4.0.1-gpu-beta", ">= 2.4.3-0", false},
-		{"FourPartV2.3.22.6_NoMultiL0", "v2.3.22.6", ">= 2.6.5-0", false},
-		{"FourPartV2.6.5.3_HasMultiL0", "v2.6.5.3", ">= 2.6.5-0", true},
+		{"FourPartV2.4.0.1GpuBeta_NoMultiL0", []string{"v2.4.0.1-gpu-beta"}, ">= 2.6.5-0", false},
+		{"FourPartV2.4.0.1GpuBeta_NoDescribeDatabase", []string{"v2.4.0.1-gpu-beta"}, ">= 2.4.3-0", false},
+		{"FourPartV2.3.22.6_NoMultiL0", []string{"v2.3.22.6"}, ">= 2.6.5-0", false},
+		{"FourPartV2.6.5.3_HasMultiL0", []string{"v2.6.5.3"}, ">= 2.6.5-0", true},
 
-		// Dev RC tag: must be treated as latest dev (and pass all >= constraints).
-		// Without StrictNewVersion this regresses: lenient parser turns it into
-		// 2.6.0-20260404-31fb3fc, which is LESS than 2.6.5-0 and disables features.
-		{"DevTag2.6_HasMultiL0", "2.6-20260404-31fb3fc", ">= 2.6.5-0", true},
-		{"DevTag2.6_HasFlushAll", "2.6-20260404-31fb3fc", ">= 2.6.11-0", true},
-		{"DevTag2.6_HasGC", "2.6-20260404-31fb3fc", ">= 2.6.8-0", true},
+		// Dev build tag: the branch names the line, so it resolves to the head of that line
+		// and passes every constraint within it. Without StrictNewVersion this regresses:
+		// the lenient parser turns it into 2.6.0-20260404-31fb3fc, which is LESS than
+		// 2.6.5-0 and disables features.
+		{"DevTag2.6_HasMultiL0", []string{"2.6-20260404-31fb3fc"}, ">= 2.6.5-0", true},
+		{"DevTag2.6_HasFlushAll", []string{"2.6-20260404-31fb3fc"}, ">= 2.6.11-0", true},
+		{"DevTag2.6_HasGC", []string{"2.6-20260404-31fb3fc"}, ">= 2.6.8-0", true},
+		{"DevTag2.6_NoReplicateMessage", []string{"2.6-20260404-31fb3fc"}, ">= 2.5.0-0, < 2.6.0-0", false},
 
-		// Master tag: also treated as latest dev.
-		{"MasterTag_HasFlushAll", "master-20260226-abcdef", ">= 2.6.11-0", true},
+		// A dev build of the 2.5 line must stay inside it. Resolving it to _latestDevVersion
+		// instead wrongly disables ReplicateMessage, the one feature with an upper bound.
+		{"DevTag2.5_HasReplicateMessage", []string{"2.5-20260404-31fb3fc"}, ">= 2.5.0-0, < 2.6.0-0", true},
+		{"DevTag2.5_NoFlushAll", []string{"2.5-20260404-31fb3fc"}, ">= 2.6.11-0", false},
 
-		// Empty string: also falls back to dev.
-		{"Empty_HasFlushAll", "", ">= 2.6.11-0", true},
+		// Zilliz Cloud answers Connect with a product description naming the Milvus line and
+		// GetVersion with a build tag that has no version in it at all. The description is
+		// the only source that knows anything, so it decides.
+		{"CloudDesc_HasFlushAll", []string{_cloudDesc, _cloudBuildTag}, ">= 2.6.11-0", true},
+		{"CloudDesc_HasDescribeDatabase", []string{_cloudDesc, _cloudBuildTag}, ">= 2.4.3-0", true},
+		{"CloudDesc_NoReplicateMessage", []string{_cloudDesc, _cloudBuildTag}, ">= 2.5.0-0, < 2.6.0-0", false},
+		{"CloudDesc_DoesNotLeakPastTheLine", []string{_cloudDesc, _cloudBuildTag}, ">= 2.7.0-0", false},
+
+		// The version must be read from the Milvus line, not from a number that happens to
+		// appear earlier in the product name.
+		{"CloudDescWithProductVersion_NoReplicateMessage", []string{"Zilliz Cloud 3.0 Vector Database(Compatible with Milvus 2.5)"}, ">= 2.5.0-0, < 2.6.0-0", true},
+
+		// A release version wins over an embedded one whichever call reported it.
+		{"ReleaseBeatsDescription", []string{_cloudDesc, "2.6.10"}, ">= 2.6.11-0", false},
+		{"ReleaseBeatsDescriptionReversed", []string{"2.6.10", _cloudDesc}, ">= 2.6.11-0", false},
+
+		// Build tags that carry only a branch, a date and a commit: nothing to parse.
+		{"UnknownBranchTag_HasFlushAll", []string{_cloudBuildTag}, ">= 2.6.11-0", true},
+		{"MasterTag_HasFlushAll", []string{"master-20260226-abcdef"}, ">= 2.6.11-0", true},
+
+		// Empty strings: also fall back to dev.
+		{"Empty_HasFlushAll", []string{""}, ">= 2.6.11-0", true},
+		{"AllEmpty_HasFlushAll", []string{"", ""}, ">= 2.6.11-0", true},
 	}
 
 	cli := &GrpcClient{logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sem := cli.parseVersionForFeature(tt.version)
+			sem := cli.parseVersionForFeature(tt.versions...)
 			constraint, err := semver.NewConstraint(tt.wantConstraint)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPass, constraint.Check(sem))
 		})
 	}
+}
+
+func TestEmbeddedVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"MinorOnlyResolvesToHeadOfLine", "2.6-20260404-31fb3fc", "2.6.9999"},
+		{"DescriptionMinorOnly", _cloudDesc, "2.6.9999"},
+		{"DescriptionWithPatchKeepsPatch", "Zilliz Cloud Vector Database(Compatible with Milvus 2.5.8)", "2.5.8"},
+		{"NoSeparatorBeforeVersion", "milvus2.6", "2.6.9999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sem, ok := embeddedVersion(tt.version)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, sem.String())
+		})
+	}
+
+	t.Run("NoVersionAtAll", func(t *testing.T) {
+		for _, ver := range []string{_cloudBuildTag, "master-20260226-abcdef", ""} {
+			_, ok := embeddedVersion(ver)
+			assert.False(t, ok, ver)
+		}
+	})
 }
 
 func TestGrpcClient_GetVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

Feature detection used a single source, the `GetVersion` RPC, and a single parser, strict
semver. On Zilliz Cloud that source answers `unknown-20260608-7ea6e3526` — a build date and a
commit, no version — so the client fell back to `_latestDevVersion` (99.0.0) and enabled every
version-gated feature. The `Connect` response names the Milvus line in the same session
("Zilliz Cloud Vector Database(Compatible with Milvus 2.6)") but was discarded.

The feature check now considers every string the server reports about itself and understands a
version that is only known down to MAJOR.MINOR.

issue: #1115

## Changes

- Split `parseVersionForFeature` into `releaseVersion` (strict semver, unchanged logic) and
  `embeddedVersion` (recovers `MAJOR.MINOR[.PATCH]` from a dev build tag or a vendor product
  description). Matching runs in two passes over the candidates, so an exact release version
  always wins over an embedded one no matter which call reported it.
- Pass the `Connect` build tags alongside the `GetVersion` result, so the source that does
  know the version decides.
- Add `_headOfLinePatch`: a version known only to MAJOR.MINOR resolves to the head of that
  line instead of jumping above every constraint. This also fixes `ReplicateMessage`
  (`>= 2.5.0-0, < 2.6.0-0`) being wrongly disabled on 2.5 dev builds such as
  `2.5-20260404-31fb3fc`, which previously resolved to 99.0.0 and failed the upper bound.
- `_latestDevVersion` now applies only when no candidate contains a version at all, e.g.
  `master-20260226-abcdef` or `unknown-20260608-7ea6e3526`.
- The version regex is anchored to the start of the string or to a `Milvus` prefix, so a
  number elsewhere in a product name is not read as the server version.
