### PR TITLE
restore: make the segments merged into one import job configurable

### DIFF
--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -138,6 +138,10 @@ restore:
     # should be less than milvus's config dataCoord.import.maxImportJobNum
     importJobs: 768
 
+  # max number of segments merged into one import job,
+  # should be less than milvus's config dataCoord.import.maxImportFileNumPerReq
+  maxSegmentsPerImportJob: 256
+
   # keep temporary files during restore, only use to debug
   keepTempFiles: false
 

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	_bulkInsertTimeout             = 60 * time.Minute
-	_bulkInsertCheckInterval       = 3 * time.Second
-	_bulkInsertRestfulAPIChunkSize = 256
+	_bulkInsertTimeout       = 60 * time.Minute
+	_bulkInsertCheckInterval = 3 * time.Second
 )
 
 type tearDownFn func(ctx context.Context) error
@@ -52,6 +51,10 @@ type collTask struct {
 	keepTempFiles bool
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
+
+	// maxSegsPerImportJob is how many segments at most are merged into one
+	// import job, because Milvus limits how many files one request may carry.
+	maxSegsPerImportJob int
 
 	backupDir     string
 	backupStorage storage.Client
@@ -90,6 +93,8 @@ type collTaskArgs struct {
 	backupDir     string
 	keepTempFiles bool
 	streaming     bool
+
+	maxSegsPerImportJob int
 
 	backupStorage storage.Client
 	milvusStorage storage.Client
@@ -133,6 +138,8 @@ func newCollTask(args collTaskArgs) *collTask {
 		streaming:     args.streaming,
 		keepTempFiles: args.keepTempFiles,
 		backupDir:     args.backupDir,
+
+		maxSegsPerImportJob: args.maxSegsPerImportJob,
 
 		backupStorage: args.backupStorage,
 		milvusStorage: args.milvusStorage,
@@ -610,7 +617,7 @@ func (ct *collTask) notL0SegBatchesWithGroupID(ctx context.Context, notL0Segs []
 
 		// because the restful api has a limitation on the number of segments in one request,
 		// we need to chunk the segments into multiple batches
-		chunkedSegs := lo.Chunk(segs, _bulkInsertRestfulAPIChunkSize)
+		chunkedSegs := lo.Chunk(segs, ct.maxSegsPerImportJob)
 		for _, chunk := range chunkedSegs {
 			dirs := make([]partitionDir, 0, len(chunk))
 			for _, seg := range chunk {
@@ -668,7 +675,7 @@ func (ct *collTask) l0SegmentBatches(l0Segs []*backuppb.SegmentBackupInfo) ([]ba
 
 	chunkSize := 1
 	if ct.grpcCli.HasFeature(milvus.MultiL0InOneJob) {
-		chunkSize = _bulkInsertRestfulAPIChunkSize
+		chunkSize = ct.maxSegsPerImportJob
 	}
 
 	var batches []batch

--- a/core/restore/coll_task_test.go
+++ b/core/restore/coll_task_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func newTestCollTask() *collTask {
-	return &collTask{logger: zap.NewNop(), option: &Option{}}
+	return &collTask{logger: zap.NewNop(), option: &Option{}, maxSegsPerImportJob: 256}
 }
 
 func TestGetFailedReason(t *testing.T) {
@@ -165,6 +165,24 @@ func TestL0SegmentBatches(t *testing.T) {
 				require.Empty(t, dir.insertLogDir)
 				require.NotEmpty(t, dir.deltaLogDir)
 			}
+		}
+	})
+
+	// Each vchannel holds 5 segments, so a limit of 2 splits it into 2+2+1.
+	t.Run("MaxSegsPerImportJob", func(t *testing.T) {
+		ct := newTestCollTask()
+		ct.collBackup = &backuppb.CollectionBackupInfo{CollectionId: 1}
+		ct.maxSegsPerImportJob = 2
+		grpcCli := milvus.NewMockGrpc(t)
+		grpcCli.EXPECT().HasFeature(milvus.MultiL0InOneJob).Return(true).Once()
+		ct.grpcCli = grpcCli
+
+		batches, err := ct.l0SegmentBatches(segs)
+		assert.NoError(t, err)
+		assert.Len(t, batches, 6)
+
+		for _, b := range batches {
+			require.LessOrEqual(t, len(b.partitionDirs), 2)
 		}
 	})
 }

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -288,6 +288,8 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 			bulkInsertSem: t.bulkInsertSem,
 			grpcCli:       t.grpc,
 			restfulCli:    t.restful,
+
+			maxSegsPerImportJob: t.args.Params.Restore.MaxSegmentsPerImportJob.Val,
 		}
 
 		tasks = append(tasks, newCollTask(args))

--- a/docs/user_guide/mul_seg_restore.md
+++ b/docs/user_guide/mul_seg_restore.md
@@ -25,3 +25,12 @@ To enable the v2 restore mode, use the `--use_v2_restore` flag:
 To enable the v2 restore mode, set the `use_v2_restore` field to `true` in the request body:
 
 ![mul_seg_restore](./figs/mul_seg_restore.png)
+
+## How many Segments are merged
+
+At most 256 Segments go into one BulkInsert job by default. Milvus rejects a request carrying more files than `dataCoord.import.maxImportFileNumPerReq` allows, so a deployment that lowered that limit has to lower this one to match:
+
+```yaml
+restore:
+  maxSegmentsPerImportJob: 256
+```

--- a/internal/cfg/v2/cfg.go
+++ b/internal/cfg/v2/cfg.go
@@ -308,7 +308,13 @@ type RestoreConcurrencyConfig struct {
 }
 
 type RestoreConfig struct {
-	Concurrency   RestoreConcurrencyConfig
+	Concurrency RestoreConcurrencyConfig
+
+	// MaxSegmentsPerImportJob caps how many segments are merged into one import
+	// job. Milvus limits how many files a single import request may carry, so a
+	// deployment that lowered that limit has to lower this one as well.
+	MaxSegmentsPerImportJob param.Value[int]
+
 	KeepTempFiles param.Value[bool]
 }
 
@@ -319,12 +325,14 @@ func newRestoreConfig() RestoreConfig {
 			// Should be less than the Milvus dataCoord.import.maxImportJobNum.
 			ImportJobs: param.Value[int]{Default: 768, Keys: []string{"restore.concurrency.importJobs"}, EnvKeys: []string{"RESTORE_CONCURRENCY_IMPORT_JOBS"}},
 		},
-		KeepTempFiles: param.Value[bool]{Default: false, Keys: []string{"restore.keepTempFiles"}, EnvKeys: []string{"RESTORE_KEEP_TEMP_FILES"}},
+		// Should be less than the Milvus dataCoord.import.maxImportFileNumPerReq.
+		MaxSegmentsPerImportJob: param.Value[int]{Default: 256, Keys: []string{"restore.maxSegmentsPerImportJob"}},
+		KeepTempFiles:           param.Value[bool]{Default: false, Keys: []string{"restore.keepTempFiles"}, EnvKeys: []string{"RESTORE_KEEP_TEMP_FILES"}},
 	}
 }
 
 func (c *RestoreConfig) Resolve(s *param.Source) error {
-	return param.Resolve(s, &c.Concurrency.Collections, &c.Concurrency.ImportJobs, &c.KeepTempFiles)
+	return param.Resolve(s, &c.Concurrency.Collections, &c.Concurrency.ImportJobs, &c.MaxSegmentsPerImportJob, &c.KeepTempFiles)
 }
 
 // TransferConfig is the object transfer policy shared by backup, restore,

--- a/internal/cfg/v2/load_test.go
+++ b/internal/cfg/v2/load_test.go
@@ -38,6 +38,7 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, "files", c.Milvus.Storage.RootPath.Val)
 
 	assert.True(t, c.Backup.PauseGC.Val)
+	assert.Equal(t, 256, c.Restore.MaxSegmentsPerImportJob.Val)
 	assert.Equal(t, TransferAuto, c.Transfer.Mode.Val)
 	assert.Equal(t, int64(500), c.Transfer.MultipartCopyThresholdMiB.Val)
 }
@@ -67,6 +68,7 @@ func TestLoad_CompleteFile(t *testing.T) {
 	assert.Equal(t, 8, c.Backup.Concurrency.Collections.Val)
 	assert.False(t, c.Backup.PauseGC.Val)
 	assert.Equal(t, 3, c.Restore.Concurrency.Collections.Val)
+	assert.Equal(t, 128, c.Restore.MaxSegmentsPerImportJob.Val)
 	assert.True(t, c.Restore.KeepTempFiles.Val)
 	assert.Equal(t, TransferStreaming, c.Transfer.Mode.Val)
 	assert.Equal(t, "an-api-key", c.Cloud.APIKey.Val)

--- a/internal/cfg/v2/testdata/complete.yaml
+++ b/internal/cfg/v2/testdata/complete.yaml
@@ -68,6 +68,7 @@ restore:
   concurrency:
     collections: 3
     importJobs: 64
+  maxSegmentsPerImportJob: 128
   keepTempFiles: true
 
 transfer:

--- a/internal/cfg/v2/validate.go
+++ b/internal/cfg/v2/validate.go
@@ -91,6 +91,7 @@ func (c *RestoreConfig) validate() error {
 	return errors.Join(
 		validatePositive(&c.Concurrency.Collections),
 		validatePositive(&c.Concurrency.ImportJobs),
+		validatePositive(&c.MaxSegmentsPerImportJob),
 	)
 }
 

--- a/internal/cfg/v2/validate_test.go
+++ b/internal/cfg/v2/validate_test.go
@@ -169,6 +169,11 @@ func TestValidate_Concurrency(t *testing.T) {
 			wantErr: "restore.concurrency.importJobs: invalid value -1",
 		},
 		{
+			name:    "RestoreMaxSegmentsPerImportJob",
+			yaml:    "restore:\n  maxSegmentsPerImportJob: 0\n",
+			wantErr: "restore.maxSegmentsPerImportJob: invalid value 0",
+		},
+		{
 			name:    "TransferConcurrency",
 			yaml:    "transfer:\n  concurrency: 0\n",
 			wantErr: "transfer.concurrency: invalid value 0",


### PR DESCRIPTION
## Summary

The number of segments merged into one BulkInsert job was hard coded to 256. Milvus rejects an import request carrying more files than `dataCoord.import.maxImportFileNumPerReq` allows, so a deployment that lowered that limit had no way to restore. It is now the v2 config key `restore.maxSegmentsPerImportJob`, defaulting to the previous 256. The v1 schema does not gain a counterpart: a v1 file translates to the v2 default.

Fixes #1066

## Changes
- add `restore.maxSegmentsPerImportJob` to the v2 config, validated as positive
- pass it into the collection restore task, replacing the `_bulkInsertRestfulAPIChunkSize` constant
- document it in `configs/backup.yaml` and the multi-segment merged restore guide