### PR TITLE
cfg: keep v2 environment variables for credentials only

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Use values that match the Milvus deployment. In common installations, the storag
 | `milvus.storage.bucketName` | `a-bucket` | `milvus-bucket` |
 | `milvus.storage.rootPath` | `files` | `file` |
 
-Configuration values can also be supplied through [environment variables](docs/user_guide/env_variables.md) or overridden with `--set`:
+Credentials can also be supplied through [environment variables](docs/user_guide/env_variables.md), and any value can be overridden for a single run with `--set`:
 
 ```shell
 milvus-backup --set MILVUS_USER=root --set MILVUS_PASSWORD=Milvus list
+milvus-backup --set milvus.grpc.address=milvus-proxy list
 ```
 
 Run `milvus-backup config show` to print the resolved configuration along with where each value came from.
@@ -83,7 +84,7 @@ Configuration files carry a `configVersion`. A file written before it existed st
 milvus-backup config migrate --config backup.yaml -o backup-v2.yaml
 ```
 
-The migration report is written to stderr and lists everything that needs a decision, such as a secret that has to move to a renamed environment variable. The converted file goes to stdout, or to `-o`.
+The migration report is written to stderr and lists everything that needs a decision, such as a secret that has to move to a renamed environment variable, or a v1 variable whose parameter now belongs in the file. The converted file goes to stdout, or to `-o`.
 
 ## Command-line usage
 

--- a/docs/user_guide/env_variables.md
+++ b/docs/user_guide/env_variables.md
@@ -1,13 +1,13 @@
 # Milvus Backup: Environment Variables
 
-Every configuration parameter can also be set through an environment variable, which is the usual way to keep credentials out of the configuration file.
+Credentials can be set through an environment variable, which keeps them out of the configuration file. Every other parameter is named by its configuration key alone, and `--set` overrides it for a single run.
 
 ## How to use environment variables
 
 Set them in your shell before running Milvus Backup:
 
 ```bash
-export MILVUS_GRPC_PORT=29530
+export MILVUS_PASSWORD=Milvus
 ./milvus-backup server
 ```
 
@@ -17,36 +17,19 @@ A value is resolved from the first source that provides it:
 --set  >  environment variable  >  config file  >  default
 ```
 
-`--set` accepts either spelling, so `--set MILVUS_USER=root` and `--set milvus.user=root` do the same thing.
+`--set` takes a config key, and for the credentials below either spelling: `--set MILVUS_USER=root` and `--set milvus.user=root` do the same thing. Anything else has to be spelled as its config key — `--set milvus.grpc.port=29530`.
 
-Environment variables belong to the schema version the configuration file is written in. A file that declares `configVersion: v2` is resolved with the names below; a file written before that is read with the older schema and keeps the older variable names. `milvus-backup config migrate` reports the ones that need renaming, and `milvus-backup config show` prints where each resolved value actually came from.
+`milvus-backup config show` prints where each resolved value actually came from.
+
+## Why credentials only
+
+A credential is the one value that has to come from outside the file. It arrives from a Kubernetes Secret, a CI secret store, or an operator, none of which want to template a configuration file to deliver it.
+
+Every other parameter is safer without a variable. Kubernetes injects one for every Service in the namespace, so a Service named `milvus` becomes `MILVUS_PORT=tcp://10.0.0.1:19530` in every pod — exactly the name a connection parameter would claim, and an environment variable outranks the configuration file. Milvus Backup used to read `MILVUS_PORT`, and the injected value silently replaced the configured one, which was reported twice as a connection failure ([#197](https://github.com/zilliztech/milvus-backup/issues/197), [#617](https://github.com/zilliztech/milvus-backup/issues/617)). Credential names are not at risk, because the injected names always end in `_PORT`, `_HOST` or `_SERVICE_*`.
 
 ## Supported environment variables
 
-- [Log](#log)
-- [Server](#server)
-- [Milvus](#milvus)
-- [Storage](#storage)
-- [Backup, restore and transfer](#backup-restore-and-transfer)
-- [Zilliz Cloud](#zilliz-cloud)
-
-### Log
-
-| Config key | Environment variable |
-|------------|----------------------|
-| `log.level` | `LOG_LEVEL` |
-| `log.console` | `LOG_CONSOLE` |
-| `log.file.path` | `LOG_FILE_PATH` |
-| `log.file.maxSizeMiB` | `LOG_FILE_MAX_SIZE_MIB` |
-| `log.file.maxDays` | `LOG_FILE_MAX_DAYS` |
-| `log.file.maxBackups` | `LOG_FILE_MAX_BACKUPS` |
-
-### Server
-
-| Config key | Environment variable |
-|------------|----------------------|
-| `server.debugMode` | `SERVER_DEBUG_MODE` |
-| `server.swaggerBasePath` | `SERVER_SWAGGER_BASE_PATH` |
+Environment variables belong to the schema version the configuration file is written in. The names below apply to a file that declares `configVersion: v2`; a file written before that is read with the older schema and keeps the older names, which covered far more parameters. `milvus-backup config migrate` converts the file and reports every variable that has to be replaced.
 
 ### Milvus
 
@@ -54,91 +37,48 @@ Environment variables belong to the schema version the configuration file is wri
 |------------|----------------------|
 | `milvus.user` | `MILVUS_USER` |
 | `milvus.password` | `MILVUS_PASSWORD` |
-| `milvus.grpc.address` | `MILVUS_GRPC_ADDRESS` |
-| `milvus.grpc.port` | `MILVUS_GRPC_PORT` |
-| `milvus.grpc.tlsMode` | `MILVUS_GRPC_TLS_MODE` |
-| `milvus.grpc.caCertPath` | `MILVUS_GRPC_CA_CERT_PATH` |
-| `milvus.grpc.serverName` | `MILVUS_GRPC_SERVER_NAME` |
-| `milvus.grpc.mtlsCertPath` | `MILVUS_GRPC_MTLS_CERT_PATH` |
-| `milvus.grpc.mtlsKeyPath` | `MILVUS_GRPC_MTLS_KEY_PATH` |
-| `milvus.rest.endpoint` | `MILVUS_REST_ENDPOINT` |
-| `milvus.management.endpoint` | `MILVUS_MANAGEMENT_ENDPOINT` |
-| `milvus.replicate.rpcChannelName` | `MILVUS_REPLICATE_RPC_CHANNEL_NAME` |
-| `milvus.etcd.endpoints` | `MILVUS_ETCD_ENDPOINTS` |
-| `milvus.etcd.rootPath` | `MILVUS_ETCD_ROOT_PATH` |
-
-`MILVUS_GRPC_TLS_MODE` takes `disabled`, `server` or `mutual`. `MILVUS_ETCD_ENDPOINTS` takes a comma-separated list.
 
 ### Storage
 
-Both storage sections take the same parameters: `MILVUS_STORAGE_` describes the storage the Milvus deployment uses, and `BACKUP_STORAGE_` the backup destination.
+Both storage sections take the same credentials: `MILVUS_STORAGE_` describes the storage the Milvus deployment uses, and `BACKUP_STORAGE_` the backup destination. Anything the backup side does not set is inherited from the Milvus side.
 
 | Config key | Environment variable |
 |------------|----------------------|
-| `milvus.storage.provider` | `MILVUS_STORAGE_PROVIDER` |
-| `milvus.storage.address` | `MILVUS_STORAGE_ADDRESS` |
-| `milvus.storage.port` | `MILVUS_STORAGE_PORT` |
-| `milvus.storage.region` | `MILVUS_STORAGE_REGION` |
-| `milvus.storage.useSSL` | `MILVUS_STORAGE_USE_SSL` |
 | `milvus.storage.accountName` | `MILVUS_STORAGE_ACCOUNT_NAME` |
-| `milvus.storage.bucketName` | `MILVUS_STORAGE_BUCKET_NAME` |
-| `milvus.storage.rootPath` | `MILVUS_STORAGE_ROOT_PATH` |
-| `milvus.storage.auth.type` | `MILVUS_STORAGE_AUTH_TYPE` |
 | `milvus.storage.auth.accessKeyID` | `MILVUS_STORAGE_AUTH_ACCESS_KEY_ID` |
 | `milvus.storage.auth.secretAccessKey` | `MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY` |
 | `milvus.storage.auth.sessionToken` | `MILVUS_STORAGE_AUTH_SESSION_TOKEN` |
 | `milvus.storage.auth.accountKey` | `MILVUS_STORAGE_AUTH_ACCOUNT_KEY` |
 | `milvus.storage.auth.credentialsFile` | `MILVUS_STORAGE_AUTH_CREDENTIALS_FILE` |
-| `milvus.storage.auth.endpoint` | `MILVUS_STORAGE_AUTH_ENDPOINT` |
-| `backup.storage.provider` | `BACKUP_STORAGE_PROVIDER` |
-| `backup.storage.address` | `BACKUP_STORAGE_ADDRESS` |
-| `backup.storage.port` | `BACKUP_STORAGE_PORT` |
-| `backup.storage.region` | `BACKUP_STORAGE_REGION` |
-| `backup.storage.useSSL` | `BACKUP_STORAGE_USE_SSL` |
 | `backup.storage.accountName` | `BACKUP_STORAGE_ACCOUNT_NAME` |
-| `backup.storage.bucketName` | `BACKUP_STORAGE_BUCKET_NAME` |
-| `backup.storage.rootPath` | `BACKUP_STORAGE_ROOT_PATH` |
-| `backup.storage.auth.type` | `BACKUP_STORAGE_AUTH_TYPE` |
 | `backup.storage.auth.accessKeyID` | `BACKUP_STORAGE_AUTH_ACCESS_KEY_ID` |
 | `backup.storage.auth.secretAccessKey` | `BACKUP_STORAGE_AUTH_SECRET_ACCESS_KEY` |
 | `backup.storage.auth.sessionToken` | `BACKUP_STORAGE_AUTH_SESSION_TOKEN` |
 | `backup.storage.auth.accountKey` | `BACKUP_STORAGE_AUTH_ACCOUNT_KEY` |
 | `backup.storage.auth.credentialsFile` | `BACKUP_STORAGE_AUTH_CREDENTIALS_FILE` |
-| `backup.storage.auth.endpoint` | `BACKUP_STORAGE_AUTH_ENDPOINT` |
 
-Anything the backup side does not set is inherited from the Milvus side, except `BACKUP_STORAGE_ROOT_PATH`, which always defaults to `backup`.
+`*_ACCOUNT_NAME` is the Azure storage account the account key belongs to. `*_AUTH_CREDENTIALS_FILE` is the path to the Google Cloud service account JSON file, not its contents.
 
-`*_PROVIDER` takes one of `local`, `minio`, `s3`, `aws`, `gcp`, `gcpnative`, `azure`, `aliyun`, `tencent` or `hwc`.
-
-`*_AUTH_TYPE` selects which credentials apply. Naming one the chosen type does not use is rejected rather than ignored:
+Which credentials apply is decided by `auth.type` in the configuration file. Naming one the chosen type does not use is rejected rather than ignored:
 
 | Auth type | Credentials it uses |
 |-----------|---------------------|
 | `static` | `*_AUTH_ACCESS_KEY_ID` and `*_AUTH_SECRET_ACCESS_KEY`, optionally `*_AUTH_SESSION_TOKEN` |
 | `sharedKey` | `*_ACCOUNT_NAME` and `*_AUTH_ACCOUNT_KEY` (Azure) |
 | `serviceAccount` | `*_AUTH_CREDENTIALS_FILE` (Google Cloud) |
-| `iam` | optionally `*_AUTH_ENDPOINT` |
+| `iam` | none — optionally `auth.endpoint` in the configuration file |
 | `default` | none — resolved by the provider SDK |
-
-### Backup, restore and transfer
-
-| Config key | Environment variable |
-|------------|----------------------|
-| `backup.concurrency.collections` | `BACKUP_CONCURRENCY_COLLECTIONS` |
-| `backup.concurrency.segments` | `BACKUP_CONCURRENCY_SEGMENTS` |
-| `backup.pauseGC` | `BACKUP_PAUSE_GC` |
-| `restore.concurrency.collections` | `RESTORE_CONCURRENCY_COLLECTIONS` |
-| `restore.concurrency.importJobs` | `RESTORE_CONCURRENCY_IMPORT_JOBS` |
-| `restore.keepTempFiles` | `RESTORE_KEEP_TEMP_FILES` |
-| `transfer.mode` | `TRANSFER_MODE` |
-| `transfer.concurrency` | `TRANSFER_CONCURRENCY` |
-| `transfer.multipartCopyThresholdMiB` | `TRANSFER_MULTIPART_COPY_THRESHOLD_MIB` |
-
-`TRANSFER_MODE` takes `auto`, `direct` or `streaming`. See [storage transfer](transfer.md).
 
 ### Zilliz Cloud
 
 | Config key | Environment variable |
 |------------|----------------------|
-| `zillizCloud.endpoint` | `ZILLIZ_CLOUD_ENDPOINT` |
 | `zillizCloud.apiKey` | `ZILLIZ_CLOUD_API_KEY` |
+
+## Everything else
+
+The remaining parameters live in the configuration file. See [configs/backup.yaml](../../configs/backup.yaml) for the full list with defaults and comments. To change one for a single run, pass its config key to `--set`:
+
+```bash
+./milvus-backup --set milvus.grpc.address=milvus-proxy --set transfer.concurrency=64 list
+```

--- a/internal/cfg/loader/load_test.go
+++ b/internal/cfg/loader/load_test.go
@@ -83,26 +83,27 @@ func TestLoad_V1EnvNamesStillResolve(t *testing.T) {
 }
 
 // A v2 file is resolved with v2 names only, so a v1 variable left set in the
-// environment is inert rather than quietly winning.
+// environment is inert rather than quietly winning. Both names below spell the
+// same credential.
 func TestLoad_V2FileIgnoresV1EnvNames(t *testing.T) {
-	t.Setenv("MILVUS_ADDRESS", "from-v1-env")
-	t.Setenv("MILVUS_GRPC_ADDRESS", "from-v2-env")
+	t.Setenv("MINIO_SECRET_KEY", "from-v1-env")
+	t.Setenv("MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY", "from-v2-env")
 
 	out, err := Load(write(t, "configVersion: v2\n"), nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, "from-v2-env", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, "from-v2-env", out.Milvus.Storage.Auth.SecretAccessKey.Val)
 }
 
 // With no file there is no discriminator to read, and nothing to be backward
 // compatible with either: overrides and env name v2 parameters.
 func TestLoad_NoConfigFileUsesV2Names(t *testing.T) {
-	t.Setenv("MILVUS_GRPC_ADDRESS", "from-v2-env")
+	t.Setenv("MILVUS_PASSWORD", "from-v2-env")
 
-	out, err := Load("", map[string]string{"MILVUS_GRPC_PORT": "19531"})
+	out, err := Load("", map[string]string{"milvus.grpc.port": "19531"})
 	require.NoError(t, err)
 
-	assert.Equal(t, "from-v2-env", out.Milvus.Grpc.Address.Val)
+	assert.Equal(t, "from-v2-env", out.Milvus.Password.Val)
 	assert.Equal(t, 19531, out.Milvus.Grpc.Port.Val)
 }
 

--- a/internal/cfg/migrate/migrate_test.go
+++ b/internal/cfg/migrate/migrate_test.go
@@ -275,13 +275,28 @@ minio:
 }
 
 func TestMigrate_LegacyEnvReport(t *testing.T) {
-	t.Setenv("MILVUS_ADDRESS", "milvus-proxy")
+	// A v1 variable that named a credential is answered with the v2 variable,
+	// and one that named anything else with the config key that replaced it,
+	// since v2 keeps environment variables for credentials only.
+	t.Run("Credential", func(t *testing.T) {
+		t.Setenv("MINIO_SECRET_KEY", "sk")
 
-	_, report := Migrate(loadV1(t, "milvus:\n  user: root\n"))
+		_, report := Migrate(loadV1(t, "milvus:\n  user: root\n"))
 
-	require.Len(t, report.EnvRenames, 1)
-	assert.Equal(t, "MILVUS_ADDRESS", report.EnvRenames[0].From)
-	assert.Contains(t, report.EnvRenames[0].To, "MILVUS_GRPC_ADDRESS")
+		require.Len(t, report.EnvRenames, 1)
+		assert.Equal(t, "MINIO_SECRET_KEY", report.EnvRenames[0].From)
+		assert.Contains(t, report.EnvRenames[0].To, "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY")
+	})
+
+	t.Run("NotACredential", func(t *testing.T) {
+		t.Setenv("MILVUS_ADDRESS", "milvus-proxy")
+
+		_, report := Migrate(loadV1(t, "milvus:\n  user: root\n"))
+
+		require.Len(t, report.EnvRenames, 1)
+		assert.Equal(t, "MILVUS_ADDRESS", report.EnvRenames[0].From)
+		assert.Contains(t, report.EnvRenames[0].To, "milvus.grpc.address config key")
+	})
 }
 
 // Migrating then rendering must produce a file the v2 loader accepts.

--- a/internal/cfg/migrate/report.go
+++ b/internal/cfg/migrate/report.go
@@ -135,7 +135,7 @@ func (r *Report) WriteTo(w io.Writer, srcPath string) {
 	}
 
 	if len(r.EnvRenames) > 0 {
-		fmt.Fprintln(w, "v1 environment variables are set but inert under a v2 config, rename them:")
+		fmt.Fprintln(w, "v1 environment variables are set but inert under a v2 config, replace them with:")
 		for _, er := range r.EnvRenames {
 			fmt.Fprintf(w, "  %s -> %s\n", er.From, er.To)
 		}

--- a/internal/cfg/v2/cfg.go
+++ b/internal/cfg/v2/cfg.go
@@ -3,6 +3,21 @@
 // A configuration file is decoded entirely as one schema version: v2 accepts
 // only v2 keys, environment variables and --set paths, and rejects everything
 // else instead of carrying per-key aliases. See internal/cfg for the v1 schema.
+//
+// Only credentials carry an environment variable. Everything else is named by
+// its config key alone, and --set overrides it for a single run. Two reasons:
+//
+// A credential is the one value that has to come from outside the file. It
+// arrives from a Kubernetes Secret, a CI secret store, or an operator, none of
+// which want to template a config file to deliver it.
+//
+// Everything else is safer without one, because Kubernetes injects a variable
+// for every Service in the namespace: a Service named milvus turns into
+// MILVUS_PORT=tcp://10.0.0.1:19530, which is exactly the shape a connection
+// parameter would claim. v1 named that parameter MILVUS_PORT and had the
+// injected value silently override the config file, reported twice as a
+// connection bug (#197, #617). Credential names are not at risk: the injected
+// names always end in _PORT, _HOST or _SERVICE_*.
 package v2
 
 import (
@@ -132,13 +147,13 @@ type LogConfig struct {
 
 func newLogConfig() LogConfig {
 	return LogConfig{
-		Level:   param.Value[string]{Default: "info", Keys: []string{"log.level"}, EnvKeys: []string{"LOG_LEVEL"}},
-		Console: param.Value[bool]{Default: true, Keys: []string{"log.console"}, EnvKeys: []string{"LOG_CONSOLE"}},
+		Level:   param.Value[string]{Default: "info", Keys: []string{"log.level"}},
+		Console: param.Value[bool]{Default: true, Keys: []string{"log.console"}},
 		File: LogFileConfig{
-			Path:       param.Value[string]{Default: "logs/backup.log", Keys: []string{"log.file.path"}, EnvKeys: []string{"LOG_FILE_PATH"}},
-			MaxSizeMiB: param.Value[int]{Default: 300, Keys: []string{"log.file.maxSizeMiB"}, EnvKeys: []string{"LOG_FILE_MAX_SIZE_MIB"}},
-			MaxDays:    param.Value[int]{Default: 0, Keys: []string{"log.file.maxDays"}, EnvKeys: []string{"LOG_FILE_MAX_DAYS"}},
-			MaxBackups: param.Value[int]{Default: 0, Keys: []string{"log.file.maxBackups"}, EnvKeys: []string{"LOG_FILE_MAX_BACKUPS"}},
+			Path:       param.Value[string]{Default: "logs/backup.log", Keys: []string{"log.file.path"}},
+			MaxSizeMiB: param.Value[int]{Default: 300, Keys: []string{"log.file.maxSizeMiB"}},
+			MaxDays:    param.Value[int]{Default: 0, Keys: []string{"log.file.maxDays"}},
+			MaxBackups: param.Value[int]{Default: 0, Keys: []string{"log.file.maxBackups"}},
 		},
 	}
 }
@@ -155,8 +170,8 @@ type ServerConfig struct {
 
 func newServerConfig() ServerConfig {
 	return ServerConfig{
-		DebugMode:       param.Value[bool]{Default: false, Keys: []string{"server.debugMode"}, EnvKeys: []string{"SERVER_DEBUG_MODE"}},
-		SwaggerBasePath: param.Value[string]{Default: "", Keys: []string{"server.swaggerBasePath"}, EnvKeys: []string{"SERVER_SWAGGER_BASE_PATH"}},
+		DebugMode:       param.Value[bool]{Default: false, Keys: []string{"server.debugMode"}},
+		SwaggerBasePath: param.Value[string]{Default: "", Keys: []string{"server.swaggerBasePath"}},
 	}
 }
 
@@ -226,33 +241,33 @@ func newMilvusConfig() MilvusConfig {
 		Password: param.Value[string]{Default: "", Keys: []string{"milvus.password"}, EnvKeys: []string{"MILVUS_PASSWORD"}, Opts: param.SecretValue},
 
 		Grpc: MilvusGrpcConfig{
-			Address: param.Value[string]{Default: "localhost", Keys: []string{"milvus.grpc.address"}, EnvKeys: []string{"MILVUS_GRPC_ADDRESS"}},
-			Port:    param.Value[int]{Default: 19530, Keys: []string{"milvus.grpc.port"}, EnvKeys: []string{"MILVUS_GRPC_PORT"}},
+			Address: param.Value[string]{Default: "localhost", Keys: []string{"milvus.grpc.address"}},
+			Port:    param.Value[int]{Default: 19530, Keys: []string{"milvus.grpc.port"}},
 
-			TLSMode: param.Value[string]{Default: TLSDisabled, Keys: []string{"milvus.grpc.tlsMode"}, EnvKeys: []string{"MILVUS_GRPC_TLS_MODE"}},
+			TLSMode: param.Value[string]{Default: TLSDisabled, Keys: []string{"milvus.grpc.tlsMode"}},
 
-			CACertPath: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.caCertPath"}, EnvKeys: []string{"MILVUS_GRPC_CA_CERT_PATH"}},
-			ServerName: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.serverName"}, EnvKeys: []string{"MILVUS_GRPC_SERVER_NAME"}},
+			CACertPath: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.caCertPath"}},
+			ServerName: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.serverName"}},
 
-			MTLSCertPath: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.mtlsCertPath"}, EnvKeys: []string{"MILVUS_GRPC_MTLS_CERT_PATH"}},
-			MTLSKeyPath:  param.Value[string]{Default: "", Keys: []string{"milvus.grpc.mtlsKeyPath"}, EnvKeys: []string{"MILVUS_GRPC_MTLS_KEY_PATH"}},
+			MTLSCertPath: param.Value[string]{Default: "", Keys: []string{"milvus.grpc.mtlsCertPath"}},
+			MTLSKeyPath:  param.Value[string]{Default: "", Keys: []string{"milvus.grpc.mtlsKeyPath"}},
 		},
 
 		Rest: MilvusRestConfig{
-			Endpoint: param.Value[string]{Default: "", Keys: []string{"milvus.rest.endpoint"}, EnvKeys: []string{"MILVUS_REST_ENDPOINT"}},
+			Endpoint: param.Value[string]{Default: "", Keys: []string{"milvus.rest.endpoint"}},
 		},
 
 		Management: MilvusManagementConfig{
-			Endpoint: param.Value[string]{Default: "http://localhost:9091", Keys: []string{"milvus.management.endpoint"}, EnvKeys: []string{"MILVUS_MANAGEMENT_ENDPOINT"}},
+			Endpoint: param.Value[string]{Default: "http://localhost:9091", Keys: []string{"milvus.management.endpoint"}},
 		},
 
 		Replicate: MilvusReplicateConfig{
-			RPCChannelName: param.Value[string]{Default: "by-dev-replicate-msg", Keys: []string{"milvus.replicate.rpcChannelName"}, EnvKeys: []string{"MILVUS_REPLICATE_RPC_CHANNEL_NAME"}},
+			RPCChannelName: param.Value[string]{Default: "by-dev-replicate-msg", Keys: []string{"milvus.replicate.rpcChannelName"}},
 		},
 
 		Etcd: MilvusEtcdConfig{
-			Endpoints: param.List{Default: []string{"localhost:2379"}, Keys: []string{"milvus.etcd.endpoints"}, EnvKeys: []string{"MILVUS_ETCD_ENDPOINTS"}},
-			RootPath:  param.Value[string]{Default: "by-dev", Keys: []string{"milvus.etcd.rootPath"}, EnvKeys: []string{"MILVUS_ETCD_ROOT_PATH"}},
+			Endpoints: param.List{Default: []string{"localhost:2379"}, Keys: []string{"milvus.etcd.endpoints"}},
+			RootPath:  param.Value[string]{Default: "by-dev", Keys: []string{"milvus.etcd.rootPath"}},
 		},
 
 		Storage: newStorageConfig("milvus.storage", "MILVUS_STORAGE"),
@@ -291,10 +306,10 @@ func newBackupConfig() BackupConfig {
 	return BackupConfig{
 		Storage: storage,
 		Concurrency: BackupConcurrencyConfig{
-			Collections: param.Value[int]{Default: 4, Keys: []string{"backup.concurrency.collections"}, EnvKeys: []string{"BACKUP_CONCURRENCY_COLLECTIONS"}},
-			Segments:    param.Value[int]{Default: 1024, Keys: []string{"backup.concurrency.segments"}, EnvKeys: []string{"BACKUP_CONCURRENCY_SEGMENTS"}},
+			Collections: param.Value[int]{Default: 4, Keys: []string{"backup.concurrency.collections"}},
+			Segments:    param.Value[int]{Default: 1024, Keys: []string{"backup.concurrency.segments"}},
 		},
-		PauseGC: param.Value[bool]{Default: true, Keys: []string{"backup.pauseGC"}, EnvKeys: []string{"BACKUP_PAUSE_GC"}},
+		PauseGC: param.Value[bool]{Default: true, Keys: []string{"backup.pauseGC"}},
 	}
 }
 
@@ -321,13 +336,13 @@ type RestoreConfig struct {
 func newRestoreConfig() RestoreConfig {
 	return RestoreConfig{
 		Concurrency: RestoreConcurrencyConfig{
-			Collections: param.Value[int]{Default: 2, Keys: []string{"restore.concurrency.collections"}, EnvKeys: []string{"RESTORE_CONCURRENCY_COLLECTIONS"}},
+			Collections: param.Value[int]{Default: 2, Keys: []string{"restore.concurrency.collections"}},
 			// Should be less than the Milvus dataCoord.import.maxImportJobNum.
-			ImportJobs: param.Value[int]{Default: 768, Keys: []string{"restore.concurrency.importJobs"}, EnvKeys: []string{"RESTORE_CONCURRENCY_IMPORT_JOBS"}},
+			ImportJobs: param.Value[int]{Default: 768, Keys: []string{"restore.concurrency.importJobs"}},
 		},
 		// Should be less than the Milvus dataCoord.import.maxImportFileNumPerReq.
 		MaxSegmentsPerImportJob: param.Value[int]{Default: 256, Keys: []string{"restore.maxSegmentsPerImportJob"}},
-		KeepTempFiles:           param.Value[bool]{Default: false, Keys: []string{"restore.keepTempFiles"}, EnvKeys: []string{"RESTORE_KEEP_TEMP_FILES"}},
+		KeepTempFiles:           param.Value[bool]{Default: false, Keys: []string{"restore.keepTempFiles"}},
 	}
 }
 
@@ -348,9 +363,9 @@ type TransferConfig struct {
 
 func newTransferConfig() TransferConfig {
 	return TransferConfig{
-		Mode:                      param.Value[string]{Default: TransferAuto, Keys: []string{"transfer.mode"}, EnvKeys: []string{"TRANSFER_MODE"}},
-		Concurrency:               param.Value[int]{Default: 128, Keys: []string{"transfer.concurrency"}, EnvKeys: []string{"TRANSFER_CONCURRENCY"}},
-		MultipartCopyThresholdMiB: param.Value[int64]{Default: 500, Keys: []string{"transfer.multipartCopyThresholdMiB"}, EnvKeys: []string{"TRANSFER_MULTIPART_COPY_THRESHOLD_MIB"}},
+		Mode:                      param.Value[string]{Default: TransferAuto, Keys: []string{"transfer.mode"}},
+		Concurrency:               param.Value[int]{Default: 128, Keys: []string{"transfer.concurrency"}},
+		MultipartCopyThresholdMiB: param.Value[int64]{Default: 500, Keys: []string{"transfer.multipartCopyThresholdMiB"}},
 	}
 }
 
@@ -367,7 +382,7 @@ type CloudConfig struct {
 
 func newCloudConfig() CloudConfig {
 	return CloudConfig{
-		Endpoint: param.Value[string]{Default: "https://api.cloud.zilliz.com", Keys: []string{"zillizCloud.endpoint"}, EnvKeys: []string{"ZILLIZ_CLOUD_ENDPOINT"}},
+		Endpoint: param.Value[string]{Default: "https://api.cloud.zilliz.com", Keys: []string{"zillizCloud.endpoint"}},
 		APIKey:   param.Value[string]{Default: "", Keys: []string{"zillizCloud.apiKey"}, EnvKeys: []string{"ZILLIZ_CLOUD_API_KEY"}, Opts: param.SecretValue},
 	}
 }

--- a/internal/cfg/v2/legacy.go
+++ b/internal/cfg/v2/legacy.go
@@ -75,49 +75,53 @@ var legacyKeys = map[string]string{
 // Environment variables and --set paths are schema-versioned too, so a v1 name
 // is reported the same way a v1 config key is.
 //
+// v2 keeps an environment variable for credentials only, so a v1 name that
+// configured anything else is answered with the config key that replaced it:
+// there is nothing left to export.
+//
 // Keys are lower-cased, matching how --set keys are looked up.
 var legacyEnvKeys = map[string]string{
-	"milvus_address":          "MILVUS_GRPC_ADDRESS",
-	"milvus_port":             "MILVUS_GRPC_PORT",
-	"milvus_tls_mode":         "MILVUS_GRPC_TLS_MODE, with 0, 1, 2 written as disabled, server, mutual",
-	"milvus_ca_cert_path":     "MILVUS_GRPC_CA_CERT_PATH",
-	"milvus_server_name":      "MILVUS_GRPC_SERVER_NAME",
-	"milvus_mtls_cert_path":   "MILVUS_GRPC_MTLS_CERT_PATH",
-	"milvus_mtls_key_path":    "MILVUS_GRPC_MTLS_KEY_PATH",
-	"milvus_rpc_channel_name": "MILVUS_REPLICATE_RPC_CHANNEL_NAME",
+	"milvus_address":          "the milvus.grpc.address config key",
+	"milvus_port":             "the milvus.grpc.port config key",
+	"milvus_tls_mode":         "the milvus.grpc.tlsMode config key, with 0, 1, 2 written as disabled, server, mutual",
+	"milvus_ca_cert_path":     "the milvus.grpc.caCertPath config key",
+	"milvus_server_name":      "the milvus.grpc.serverName config key",
+	"milvus_mtls_cert_path":   "the milvus.grpc.mtlsCertPath config key",
+	"milvus_mtls_key_path":    "the milvus.grpc.mtlsKeyPath config key",
+	"milvus_rpc_channel_name": "the milvus.replicate.rpcChannelName config key",
 
-	"minio_address":      "MILVUS_STORAGE_ADDRESS",
-	"minio_port":         "MILVUS_STORAGE_PORT",
-	"minio_region":       "MILVUS_STORAGE_REGION",
-	"minio_use_ssl":      "MILVUS_STORAGE_USE_SSL",
-	"minio_bucket_name":  "MILVUS_STORAGE_BUCKET_NAME",
-	"minio_root_path":    "MILVUS_STORAGE_ROOT_PATH",
+	"minio_address":      "the milvus.storage.address config key",
+	"minio_port":         "the milvus.storage.port config key",
+	"minio_region":       "the milvus.storage.region config key",
+	"minio_use_ssl":      "the milvus.storage.useSSL config key",
+	"minio_bucket_name":  "the milvus.storage.bucketName config key",
+	"minio_root_path":    "the milvus.storage.rootPath config key",
 	"minio_access_key":   "MILVUS_STORAGE_AUTH_ACCESS_KEY_ID, or MILVUS_STORAGE_ACCOUNT_NAME for azure",
 	"minio_secret_key":   "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY, or MILVUS_STORAGE_AUTH_ACCOUNT_KEY for azure",
 	"minio_token":        "MILVUS_STORAGE_AUTH_SESSION_TOKEN",
-	"minio_use_iam":      "MILVUS_STORAGE_AUTH_TYPE=iam",
-	"minio_iam_endpoint": "MILVUS_STORAGE_AUTH_ENDPOINT",
+	"minio_use_iam":      "the milvus.storage.auth.type config key, set to iam",
+	"minio_iam_endpoint": "the milvus.storage.auth.endpoint config key",
 	"gcp_key_json":       "MILVUS_STORAGE_AUTH_CREDENTIALS_FILE",
 
-	"minio_backup_address":      "BACKUP_STORAGE_ADDRESS",
-	"minio_backup_port":         "BACKUP_STORAGE_PORT",
-	"minio_backup_region":       "BACKUP_STORAGE_REGION",
-	"minio_backup_use_ssl":      "BACKUP_STORAGE_USE_SSL",
-	"minio_backup_bucket_name":  "BACKUP_STORAGE_BUCKET_NAME",
-	"minio_backup_root_path":    "BACKUP_STORAGE_ROOT_PATH",
+	"minio_backup_address":      "the backup.storage.address config key",
+	"minio_backup_port":         "the backup.storage.port config key",
+	"minio_backup_region":       "the backup.storage.region config key",
+	"minio_backup_use_ssl":      "the backup.storage.useSSL config key",
+	"minio_backup_bucket_name":  "the backup.storage.bucketName config key",
+	"minio_backup_root_path":    "the backup.storage.rootPath config key",
 	"minio_backup_access_key":   "BACKUP_STORAGE_AUTH_ACCESS_KEY_ID, or BACKUP_STORAGE_ACCOUNT_NAME for azure",
 	"minio_backup_secret_key":   "BACKUP_STORAGE_AUTH_SECRET_ACCESS_KEY, or BACKUP_STORAGE_AUTH_ACCOUNT_KEY for azure",
 	"minio_backup_token":        "BACKUP_STORAGE_AUTH_SESSION_TOKEN",
-	"minio_backup_use_iam":      "BACKUP_STORAGE_AUTH_TYPE=iam",
-	"minio_backup_iam_endpoint": "BACKUP_STORAGE_AUTH_ENDPOINT",
+	"minio_backup_use_iam":      "the backup.storage.auth.type config key, set to iam",
+	"minio_backup_iam_endpoint": "the backup.storage.auth.endpoint config key",
 	"backup_gcp_key_json":       "BACKUP_STORAGE_AUTH_CREDENTIALS_FILE",
 
-	"backup_parallelism_copydata":           "TRANSFER_CONCURRENCY",
-	"backup_parallelism_backup_collection":  "BACKUP_CONCURRENCY_COLLECTIONS",
-	"backup_parallelism_restore_collection": "RESTORE_CONCURRENCY_COLLECTIONS",
-	"backup_keep_temp_files":                "RESTORE_KEEP_TEMP_FILES",
-	"backup_gc_pause_enable":                "BACKUP_PAUSE_GC",
-	"backup_gc_pause_address":               "MILVUS_MANAGEMENT_ENDPOINT",
+	"backup_parallelism_copydata":           "the transfer.concurrency config key",
+	"backup_parallelism_backup_collection":  "the backup.concurrency.collections config key",
+	"backup_parallelism_restore_collection": "the restore.concurrency.collections config key",
+	"backup_keep_temp_files":                "the restore.keepTempFiles config key",
+	"backup_gc_pause_enable":                "the backup.pauseGC config key",
+	"backup_gc_pause_address":               "the milvus.management.endpoint config key",
 }
 
 // Migration returns what replaced key in v2, and whether key is a known v1

--- a/internal/cfg/v2/load_test.go
+++ b/internal/cfg/v2/load_test.go
@@ -166,11 +166,19 @@ func TestCheckKeys(t *testing.T) {
 		assert.Contains(t, joined, "milvus.storage.port")
 	})
 
+	// A v1 variable that configured something other than a credential is
+	// answered with a config key: v2 has no environment variable to rename it to.
 	t.Run("V1Override", func(t *testing.T) {
 		w := warningsFor(t, "", map[string]string{"MILVUS_ADDRESS": "localhost"})
 		require.Len(t, w, 1)
 		assert.Contains(t, w[0], `v1 --set key "MILVUS_ADDRESS"`)
-		assert.Contains(t, w[0], "MILVUS_GRPC_ADDRESS")
+		assert.Contains(t, w[0], "milvus.grpc.address")
+	})
+
+	t.Run("V1CredentialOverride", func(t *testing.T) {
+		w := warningsFor(t, "", map[string]string{"MINIO_SECRET_KEY": "sk"})
+		require.Len(t, w, 1)
+		assert.Contains(t, w[0], "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY")
 	})
 
 	t.Run("UnknownOverride", func(t *testing.T) {
@@ -196,44 +204,77 @@ func TestLoad_UnknownKeysAreIgnored(t *testing.T) {
 	})
 }
 
+// Precedence is exercised on a credential, since those are the only parameters
+// an environment variable can reach.
 func TestLoad_Precedence(t *testing.T) {
-	p := writeYAML(t, "milvus:\n  grpc:\n    port: 12345\n")
+	p := writeYAML(t, "milvus:\n  user: fromfile\n")
 
 	t.Run("ConfigFile", func(t *testing.T) {
 		c, err := Load(p, nil)
 		require.NoError(t, err)
-		assert.Equal(t, 12345, c.Milvus.Grpc.Port.Val)
+		assert.Equal(t, "fromfile", c.Milvus.User.Val)
 	})
 
 	t.Run("EnvOverridesConfigFile", func(t *testing.T) {
-		t.Setenv("MILVUS_GRPC_PORT", "23456")
+		t.Setenv("MILVUS_USER", "fromenv")
 
 		c, err := Load(p, nil)
 		require.NoError(t, err)
-		assert.Equal(t, 23456, c.Milvus.Grpc.Port.Val)
+		assert.Equal(t, "fromenv", c.Milvus.User.Val)
 	})
 
 	t.Run("OverrideOverridesEnv", func(t *testing.T) {
-		t.Setenv("MILVUS_GRPC_PORT", "23456")
+		t.Setenv("MILVUS_USER", "fromenv")
 
-		c, err := Load(p, map[string]string{"MILVUS_GRPC_PORT": "34567"})
+		c, err := Load(p, map[string]string{"MILVUS_USER": "fromset"})
 		require.NoError(t, err)
-		assert.Equal(t, 34567, c.Milvus.Grpc.Port.Val)
+		assert.Equal(t, "fromset", c.Milvus.User.Val)
 	})
 
 	t.Run("OverrideByConfigKey", func(t *testing.T) {
-		c, err := Load(p, map[string]string{"milvus.grpc.port": "45678"})
+		c, err := Load(p, map[string]string{"milvus.user": "frombykey"})
 		require.NoError(t, err)
-		assert.Equal(t, 45678, c.Milvus.Grpc.Port.Val)
+		assert.Equal(t, "frombykey", c.Milvus.User.Val)
 	})
 
 	// A v1 environment variable is not an alias: it names nothing in v2.
 	t.Run("V1EnvIsIgnored", func(t *testing.T) {
 		t.Setenv("MILVUS_PORT", "23456")
 
+		c, err := Load(writeYAML(t, "milvus:\n  grpc:\n    port: 12345\n"), nil)
+		require.NoError(t, err)
+		assert.Equal(t, 12345, c.Milvus.Grpc.Port.Val)
+	})
+}
+
+// Everything that is not a credential is named by its config key alone, so an
+// environment variable spelled after it is inert — including the Kubernetes
+// service variables whose names collide with a connection parameter.
+func TestLoad_EnvIsCredentialsOnly(t *testing.T) {
+	p := writeYAML(t, "milvus:\n  grpc:\n    port: 12345\n")
+
+	t.Run("ConnectionEnvIsIgnored", func(t *testing.T) {
+		t.Setenv("MILVUS_GRPC_PORT", "tcp://10.0.0.1:19530")
+
 		c, err := Load(p, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 12345, c.Milvus.Grpc.Port.Val)
+	})
+
+	t.Run("StorageEnvIsIgnored", func(t *testing.T) {
+		t.Setenv("MILVUS_STORAGE_ADDRESS", "10.0.0.1")
+
+		c, err := Load(p, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", c.Milvus.Storage.Address.Val)
+	})
+
+	t.Run("CredentialEnvApplies", func(t *testing.T) {
+		t.Setenv("MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY", "sk")
+
+		c, err := Load(p, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "sk", c.Milvus.Storage.Auth.SecretAccessKey.Val)
 	})
 }
 
@@ -253,7 +294,7 @@ func TestLoad_EtcdEndpoints(t *testing.T) {
 	})
 
 	t.Run("Override", func(t *testing.T) {
-		c, err := Load("", map[string]string{"MILVUS_ETCD_ENDPOINTS": "a:2379, b:2379"})
+		c, err := Load("", map[string]string{"milvus.etcd.endpoints": "a:2379, b:2379"})
 		require.NoError(t, err)
 		assert.Equal(t, []string{"a:2379", "b:2379"}, c.Milvus.Etcd.Endpoints.Val)
 	})

--- a/internal/cfg/v2/storage.go
+++ b/internal/cfg/v2/storage.go
@@ -47,27 +47,30 @@ type StorageConfig struct {
 	Auth StorageAuthConfig
 }
 
-// newStorageConfig builds a storage section rooted at keyPrefix, with
-// environment variables rooted at envPrefix.
+// newStorageConfig builds a storage section rooted at keyPrefix, with the
+// credential environment variables rooted at envPrefix. Only the credentials
+// carry one: see the package documentation for why.
 func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 	key := func(name string) []string { return []string{keyPrefix + "." + name} }
 	env := func(name string) []string { return []string{envPrefix + "_" + name} }
 
 	return StorageConfig{
-		Provider: param.Value[string]{Default: ProviderMinio, Keys: key("provider"), EnvKeys: env("PROVIDER")},
+		Provider: param.Value[string]{Default: ProviderMinio, Keys: key("provider")},
 
-		Address: param.Value[string]{Default: "localhost", Keys: key("address"), EnvKeys: env("ADDRESS")},
-		Port:    param.Value[int]{Default: 9000, Keys: key("port"), EnvKeys: env("PORT")},
-		Region:  param.Value[string]{Default: "", Keys: key("region"), EnvKeys: env("REGION")},
-		UseSSL:  param.Value[bool]{Default: false, Keys: key("useSSL"), EnvKeys: env("USE_SSL")},
+		Address: param.Value[string]{Default: "localhost", Keys: key("address")},
+		Port:    param.Value[int]{Default: 9000, Keys: key("port")},
+		Region:  param.Value[string]{Default: "", Keys: key("region")},
+		UseSSL:  param.Value[bool]{Default: false, Keys: key("useSSL")},
 
+		// The account name is half of the Azure credential: it is what the
+		// account key belongs to, and deployments hand out the two together.
 		AccountName: param.Value[string]{Default: "", Keys: key("accountName"), EnvKeys: env("ACCOUNT_NAME")},
 
-		BucketName: param.Value[string]{Default: "a-bucket", Keys: key("bucketName"), EnvKeys: env("BUCKET_NAME")},
-		RootPath:   param.Value[string]{Default: "files", Keys: key("rootPath"), EnvKeys: env("ROOT_PATH")},
+		BucketName: param.Value[string]{Default: "a-bucket", Keys: key("bucketName")},
+		RootPath:   param.Value[string]{Default: "files", Keys: key("rootPath")},
 
 		Auth: StorageAuthConfig{
-			Type: param.Value[string]{Default: AuthStatic, Keys: key("auth.type"), EnvKeys: env("AUTH_TYPE")},
+			Type: param.Value[string]{Default: AuthStatic, Keys: key("auth.type")},
 
 			AccessKeyID:     param.Value[string]{Default: "minioadmin", Keys: key("auth.accessKeyID"), EnvKeys: env("AUTH_ACCESS_KEY_ID")},
 			SecretAccessKey: param.Value[string]{Default: "minioadmin", Keys: key("auth.secretAccessKey"), EnvKeys: env("AUTH_SECRET_ACCESS_KEY"), Opts: param.SecretValue},
@@ -77,7 +80,7 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 
 			CredentialsFile: param.Value[string]{Default: "", Keys: key("auth.credentialsFile"), EnvKeys: env("AUTH_CREDENTIALS_FILE")},
 
-			Endpoint: param.Value[string]{Default: "", Keys: key("auth.endpoint"), EnvKeys: env("AUTH_ENDPOINT")},
+			Endpoint: param.Value[string]{Default: "", Keys: key("auth.endpoint")},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

v2 gave every parameter an environment variable — 63 names for 64 config keys, where v1 had 40. Most of them are a liability rather than a feature.

Kubernetes injects a variable for every Service in the namespace, so a Service named `milvus` becomes `MILVUS_PORT=tcp://10.0.0.1:19530` in every pod. That is exactly the name a connection parameter claims, and an environment variable outranks the config file, so the injected value silently replaces the configured one. v1 named that parameter `MILVUS_PORT` and the collision was reported twice as a connection failure — #197 and #617, both closed without addressing the cause.

A credential is different: it has to come from outside the file (a Kubernetes Secret, a CI secret store, an operator), and credential names are not at risk, because the injected names always end in `_PORT`, `_HOST` or `_SERVICE_*`. So v2 keeps an environment variable for credentials only — 15 names — and everything else is named by its config key, overridable per run with `--set milvus.grpc.port=29530`.

Only the v2 schema changes. A v1 file is still resolved with the v1 schema, v1 environment variables included, so no released deployment loses anything: v2 landed after v0.5.16 and has never shipped.

Related to #1107

## Changes
- drop `EnvKeys` from every v2 parameter that is not a credential, and record the reason in the package documentation
- point the v1 environment variable migration table at the config key that replaced each one, and word the migration report as a replacement rather than a rename
- rewrite `docs/user_guide/env_variables.md` around the credentials-only rule, including why
- cover the rule in the loader tests: a connection variable is inert, a credential variable applies