### PR TITLE
ci: close issues stuck waiting on the reporter

### DIFF
--- a/.github/workflows/clear-needs-information.yaml
+++ b/.github/workflows/clear-needs-information.yaml
@@ -1,0 +1,52 @@
+name: Clear needs-information
+
+# `triage/needs-information` is a state bit meaning "waiting on the reporter".
+# Once they answer, the ball is back with us and the label has to come off —
+# otherwise stale.yaml keeps counting down and eventually closes an issue that
+# is actually waiting on a maintainer. Removing it by hand works right up until
+# the day somebody forgets, so it is done here instead.
+#
+# The label is cleared when either:
+#   - the person who opened the issue comments (they are who we were waiting on), or
+#   - anyone outside the org comments (a third party supplying details).
+#
+# A maintainer commenting does not clear it: asking a follow-up question means we
+# are still waiting. `stale` is removed at the same time so the countdown does not
+# linger until the next scheduled run.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  clear:
+    if: >
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.issue.labels.*.name, 'triage/needs-information') &&
+      (
+        github.event.comment.user.login == github.event.issue.user.login ||
+        !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            for (const name of ['triage/needs-information', 'stale']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+                core.info(`removed ${name}`);
+              } catch (err) {
+                // 404 just means the label was not on the issue.
+                if (err.status !== 404) throw err;
+              }
+            }

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,65 @@
+name: Stale
+
+# Closes issues that have been waiting on the reporter for too long.
+#
+# The scope is deliberately narrow: `only-labels` means an issue is touched only
+# while it carries `triage/needs-information`. Design proposals, feature requests
+# and everything else in the backlog are never seen by this workflow, no matter
+# how long they sit. Pull requests are excluded outright via the `-1` settings,
+# so long-lived dependabot PRs are left alone.
+#
+# The label is a state bit meaning "waiting on the reporter". clear-needs-information.yaml
+# removes it as soon as they answer, which takes the issue back out of scope here.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'List what would be marked or closed without changing anything'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: 'triage/needs-information'
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          # Never touch pull requests.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: 'stale'
+          close-issue-reason: 'not_planned'
+          # Load-bearing rather than incidental: any activity drops the `stale`
+          # label and restarts the 30 day clock, which is what lets a maintainer
+          # ask a follow-up question without shortening the reporter's window.
+          remove-stale-when-updated: true
+          debug-only: ${{ inputs.dry-run || false }}
+          stale-issue-message: >
+            This issue has been waiting on additional information for 30 days and
+            will be closed in 14 days if nothing further arrives. If it is still
+            relevant, please add the requested details — that alone keeps it open.
+            A closed issue can be reopened at any time.
+
+
+            See
+            [docs/issue_lifecycle.md](https://github.com/zilliztech/milvus-backup/blob/main/docs/issue_lifecycle.md)
+            for how this works and what resets the timer.
+          close-issue-message: >
+            Closing because the information needed to investigate never arrived.
+            This is not a judgement about whether the problem is real. If it still
+            reproduces, please comment with the requested details and we will
+            reopen it.
+
+
+            See
+            [docs/issue_lifecycle.md](https://github.com/zilliztech/milvus-backup/blob/main/docs/issue_lifecycle.md)
+            for why this was closed and how to bring it back.

--- a/docs/issue_lifecycle.md
+++ b/docs/issue_lifecycle.md
@@ -1,0 +1,67 @@
+# Issue lifecycle
+
+Most issues in this repository have no timer on them. A feature request or a design proposal can sit for a year and nothing will happen to it automatically — it stays open until somebody works on it or closes it deliberately.
+
+There is exactly one automated path, and it applies only to issues that are blocked waiting for information from the person who reported them. This page describes that path in full.
+
+## `triage/needs-information`
+
+A maintainer applies this label when an issue cannot move without something only the reporter can supply — logs, the `backup.yaml` in use, the Milvus and milvus-backup versions, or the steps that reproduce the problem.
+
+The label is a state bit meaning **"waiting on the reporter"**, not a permanent mark. It is removed automatically as soon as they answer.
+
+## The countdown
+
+```mermaid
+stateDiagram-v2
+    [*] --> Waiting: maintainer applies triage/needs-information
+    Waiting --> Stale: 30 days with no activity
+    Stale --> Closed: 14 more days with no activity
+    Stale --> Waiting: any activity
+    Waiting --> [*]: reporter answers, label removed
+    Closed --> Waiting: reopened with the requested details
+```
+
+| Step | Delay | Effect |
+| --- | --- | --- |
+| Marked stale | 30 days after the last activity | Adds the `stale` label and a comment saying what is missing |
+| Closed | 14 days after being marked stale | Closes as `not_planned` with a comment inviting a reopen |
+
+So an issue has 44 days from its last activity before it closes, and it is told at day 30 that the clock is running.
+
+## What resets the countdown
+
+| Who comments | `stale` | `triage/needs-information` | Result |
+| --- | --- | --- | --- |
+| The person who opened the issue | removed | **removed** | Leaves the automation entirely — the ball is back with the maintainers |
+| Anyone outside the organization | removed | **removed** | Same; a third party supplying details also counts |
+| A maintainer | removed | **kept** | Still waiting on the reporter, but the 30 day clock restarts from zero |
+
+The last row is deliberate. A maintainer asking a follow-up question means the issue is still blocked on the reporter, so the label stays — but the reporter gets a fresh 30 days to respond to the new question rather than inheriting whatever was left of the old window.
+
+## What is never touched
+
+The automation is scoped with `only-labels`, which means an issue is considered only while it carries `triage/needs-information`. Everything else is out of reach regardless of age:
+
+- issues without the label, however old
+- feature requests, proposals and design discussions
+- confirmed bugs that are waiting on maintainer work rather than on the reporter
+- pull requests, which are excluded outright
+
+A four-year-old feature request will not be closed by this workflow. That is the point of scoping it to a single label rather than running a general-purpose stale bot.
+
+## If your issue was closed this way
+
+It was closed as `not_planned` rather than `completed`, and that is not a judgement about whether the problem is real. It means the information needed to investigate never arrived.
+
+Comment with the details that were requested and the issue can be reopened — by you, if you opened it, or by any maintainer. Nothing is lost; the history stays intact.
+
+If the problem is still happening but you no longer have the environment that produced it, say so. A fresh issue against a current release is often easier to act on than reviving an old thread.
+
+## For maintainers
+
+Apply `triage/needs-information` at the moment you ask for something. That is the only manual step — you do not need to remove it later, and you do not need to track which issues have gone quiet.
+
+Do not apply it to issues that are waiting on your own work. The label means the reporter owes us something; using it as a general "not now" marker will close issues that were never theirs to answer.
+
+The two workflows implementing this are [`.github/workflows/stale.yaml`](../.github/workflows/stale.yaml) and [`.github/workflows/clear-needs-information.yaml`](../.github/workflows/clear-needs-information.yaml). The stale workflow accepts a `dry-run` input on manual dispatch, which lists what it would mark or close without changing anything.


### PR DESCRIPTION
## Summary

Adds a stale workflow that closes issues which have been waiting on the reporter, plus a companion workflow that clears the label as soon as they answer, plus a doc describing the resulting state machine.

The scope is deliberately narrow. `only-labels` means an issue is touched only while it carries `triage/needs-information` — design proposals, feature requests and the rest of the backlog are never seen by this workflow no matter how long they sit, and pull requests are excluded outright so long-lived dependabot PRs are left alone.

`triage/needs-information` is treated as a state bit meaning "waiting on the reporter", not as a one-way marker. Once the reporter answers, the ball is back with us and the label has to come off — otherwise the countdown keeps running and eventually closes an issue that is actually waiting on a maintainer. Doing that by hand works right up until the day somebody forgets, so `clear-needs-information.yaml` does it instead.

The label is cleared when the person who opened the issue comments, or when anyone outside the org comments. Both conditions are needed: checking only `author_association` would miss an org member replying on their own issue, and checking only the issue author would miss a third party supplying the missing details. A maintainer commenting deliberately does not clear it — asking a follow-up question means we are still waiting — though it does reset the 30 day clock, which is the intended behaviour.

Timings are 30 days to mark stale and a further 14 to close, so 44 days from the last activity. Issues are closed as `not_planned` with a message stating that this is not a judgement about whether the problem is real, and inviting a reopen with the requested details.

`docs/issue_lifecycle.md` writes the whole thing down: what the label means, the timings, which comments reset which clock, what is explicitly out of scope, what to do if your issue was closed this way, and when maintainers should apply the label. Both bot messages link to it, since the people most affected arrive from a GitHub notification rather than by browsing the repository.

## Changes

- add `.github/workflows/stale.yaml`, scoped to `triage/needs-information` via `only-labels`, with pull requests excluded through `days-before-pr-stale/close: -1`
- add `.github/workflows/clear-needs-information.yaml`, removing `triage/needs-information` and `stale` when the reporter or an outside contributor comments
- add `docs/issue_lifecycle.md` documenting the state machine, and link it from the stale and close comments
- set `remove-stale-when-updated` explicitly rather than relying on the default, since the whole reset behaviour depends on it
- expose a `dry-run` input on `workflow_dispatch` so the first run can be verified with `debug-only` before anything is actually closed

/kind improvement
