### PR TITLE
ci: set the milvus root path with the chart's values key

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -148,7 +148,9 @@ jobs:
         shell: bash
         working-directory: deployment/${{ matrix.milvus_mode }}
         run: |
-          yq -i '.milvus.storage.rootPath = "${{ matrix.milvus_minio_rootpath }}"' values.yaml
+          # values.yaml holds the milvus helm chart's values, not a milvus-backup config,
+          # so this key is the chart's own spelling and does not track the backup schema.
+          yq -i '.minio.rootPath = "${{ matrix.milvus_minio_rootpath }}"' values.yaml
       - name: Build
         timeout-minutes: 5
         shell: bash


### PR DESCRIPTION
## Summary

`test-backup-restore-with-custom-config` has failed on both `milvus_minio_rootpath: ""` jobs
since the 2026-07-26 nightly, with:

```
backup: log insert_log/<coll>/<part>/<seg>/100/<log> not exist
Error: ... backup: segment <seg> has no insert logs
```

#1105 moved this workflow's yq paths to their v2 spellings. One of them targets
`deployment/standalone/values.yaml`, which is the **milvus helm chart's values**, not a
milvus-backup config. The v1 backup schema borrowed the chart's `minio.*` naming, so one
spelling was valid for both files and the rename looked uniform:

```diff
- yq -i '.minio.rootPath = "..."' values.yaml            # the chart reads this
+ yq -i '.milvus.storage.rootPath = "..."' values.yaml   # the chart ignores this
```

The chart ships no `values.schema.json`, so helm accepted the unknown key silently and milvus
fell back to the chart default `rootPath: file`. Only the `""` half of the matrix noticed —
it points the backup at an empty root path while milvus writes under `file/`, so listing
`insert_log/` returns nothing. The `"file"` half kept passing because it happens to equal the
default, which is why the failure looked intermittent rather than deterministic.

Verified with `helm template` against the chart the workflow installs:

| `values.yaml` key set by yq | rendered milvus `minio.rootPath` |
| --- | --- |
| `milvus.storage.rootPath: ""` / `"file"` | `file` in both cases (key ignored) |
| `minio.rootPath: ""` | *(empty)* |
| `minio.rootPath: "file"` | `file` |

Log evidence from the 2026-07-27 nightly — passing job copies from
`src_key=file/insert_log/...`, while the failing job lists `dir=insert_log/...`.

Worth noting beyond the red X: that half of the matrix has not exercised an empty root path
since 2026-07-25, it has been retesting `file` twice. `nightly.yaml` only runs on a schedule,
so the PR that introduced this was green on its own CI.

## Changes

- nightly.yaml: set the milvus root path through `minio.rootPath`, the key the chart reads
- note next to it that this file follows the chart's schema, not the backup config's

/kind improvement
