### PR TITLE
l0compact: decode descriptor extras as a heterogeneous map

### DIFF
--- a/internal/l0compact/deltalog.go
+++ b/internal/l0compact/deltalog.go
@@ -117,7 +117,7 @@ func WriteDeltalog(entries []DeleteEntry, kind StorageKind, t PKType) ([]byte, e
 			return nil, err
 		}
 		// json variant: PayloadDataType = String(20), field id 0, no version extra.
-		return BuildV1Envelope(eventDelete, 20, 0, map[string]string{}, payload)
+		return BuildV1Envelope(eventDelete, 20, 0, map[string]any{}, payload)
 	default:
 		return nil, fmt.Errorf("l0compact: unknown storage kind %d", kind)
 	}

--- a/internal/l0compact/deltalog_test.go
+++ b/internal/l0compact/deltalog_test.go
@@ -61,7 +61,7 @@ func TestDeltalogV1MultiFieldRead(t *testing.T) {
 	// multi-field variant: envelope with version=MULTI_FIELD wrapping a 2-col parquet.
 	payload, err := WriteParquetPKTs([]PrimaryKey{{Type: PKInt64, Int: 9}}, []uint64{3}, PKInt64)
 	require.NoError(t, err)
-	blob, err := BuildV1Envelope(eventDelete, 5 /*Int64*/, 0, map[string]string{"version": "MULTI_FIELD"}, payload)
+	blob, err := BuildV1Envelope(eventDelete, 5 /*Int64*/, 0, map[string]any{"version": "MULTI_FIELD"}, payload)
 	require.NoError(t, err)
 	out, err := ReadDeltalog(blob, KindV1, PKInt64)
 	require.NoError(t, err)

--- a/internal/l0compact/envelope.go
+++ b/internal/l0compact/envelope.go
@@ -33,7 +33,10 @@ const dataEventFixPartSize = 16 // {StartTimestamp, EndTimestamp uint64}
 type descriptor struct {
 	CollectionID, PartitionID, SegmentID, FieldID int64
 	PayloadDataType                               int32
-	Extras                                        map[string]string
+	// Extras is milvus' descriptor extra map. Its values are heterogeneous:
+	// insert binlogs carry nullable as a bool next to string entries such as
+	// original_size, so it cannot be decoded into map[string]string.
+	Extras map[string]any
 }
 
 type v1Event struct {
@@ -79,7 +82,7 @@ func parseV1Envelope(blob []byte) (descriptor, []v1Event, error) {
 	if _, err := readFull(r, extraBytes); err != nil {
 		return descriptor{}, nil, fmt.Errorf("l0compact: read extras: %w", err)
 	}
-	d.Extras = map[string]string{}
+	d.Extras = map[string]any{}
 	if extraLen > 0 {
 		if err := json.Unmarshal(extraBytes, &d.Extras); err != nil {
 			return descriptor{}, nil, fmt.Errorf("l0compact: unmarshal extras: %w", err)
@@ -115,7 +118,7 @@ func parseV1Envelope(blob []byte) (descriptor, []v1Event, error) {
 }
 
 // BuildV1Envelope wraps a single parquet payload as a v1 binlog file with one data event.
-func BuildV1Envelope(typeCode int8, payloadType int32, fieldID int64, extras map[string]string, payload []byte) ([]byte, error) {
+func BuildV1Envelope(typeCode int8, payloadType int32, fieldID int64, extras map[string]any, payload []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	_ = binary.Write(&buf, endian, v1Magic)
 

--- a/internal/l0compact/envelope_test.go
+++ b/internal/l0compact/envelope_test.go
@@ -12,7 +12,7 @@ type envHeaderArgs struct {
 	typeCode    int8
 	payloadType int32
 	fieldID     int64
-	extras      map[string]string
+	extras      map[string]any
 }
 
 // buildV1Envelope wraps payload in a v1 envelope using the exported
@@ -30,7 +30,7 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 		typeCode:    eventDelete,
 		payloadType: 20, // String
 		fieldID:     0,
-		extras:      map[string]string{},
+		extras:      map[string]any{},
 	}, payload)
 
 	desc, events, err := parseV1Envelope(blob)
@@ -40,4 +40,45 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 	require.Len(t, events, 1)
 	assert.Equal(t, payload, events[0].Payload)
 	assert.NotContains(t, desc.Extras, "version", "json variant should have no MULTI_FIELD version")
+}
+
+// Milvus stores nullable in the descriptor extras as a bool, next to string
+// entries such as original_size, so the extra map is heterogeneous. See
+// NewInsertBinlogWriter in milvus' internal/storage/binlog_writer.go.
+func TestEnvelopeNonStringExtras(t *testing.T) {
+	payload := []byte("PARQUET-BYTES-STANDIN")
+	blob := buildV1Envelope(t, envHeaderArgs{
+		typeCode:    eventInsert,
+		payloadType: 5, // Int64
+		fieldID:     100,
+		extras: map[string]any{
+			"original_size": "12345",
+			"nullable":      true,
+		},
+	}, payload)
+
+	desc, events, err := parseV1Envelope(blob)
+	require.NoError(t, err)
+	assert.Equal(t, "12345", desc.Extras["original_size"])
+	assert.Equal(t, true, desc.Extras["nullable"])
+	require.Len(t, events, 1)
+	assert.Equal(t, payload, events[0].Payload)
+}
+
+// A bool-valued extra must not stop ReadDeltalog from recognizing the
+// MULTI_FIELD marker, which decides how the payload is decoded.
+func TestEnvelopeVersionExtraAmongNonStrings(t *testing.T) {
+	blob := buildV1Envelope(t, envHeaderArgs{
+		typeCode:    eventDelete,
+		payloadType: 5,
+		fieldID:     0,
+		extras: map[string]any{
+			"version":  "MULTI_FIELD",
+			"nullable": false,
+		},
+	}, []byte("PARQUET-BYTES-STANDIN"))
+
+	desc, _, err := parseV1Envelope(blob)
+	require.NoError(t, err)
+	assert.Equal(t, "MULTI_FIELD", desc.Extras["version"])
 }

--- a/internal/l0compact/insertpk_test.go
+++ b/internal/l0compact/insertpk_test.go
@@ -34,7 +34,7 @@ func buildSingleInt64Parquet(t *testing.T, vals []int64) []byte {
 func TestReadInsertPKV1(t *testing.T) {
 	// v1 insert: envelope (Insert event, PayloadDataType=Int64) wrapping a single Int64 column parquet.
 	payload := buildSingleInt64Parquet(t, []int64{11, 22}) // helper in test file
-	blob, err := BuildV1Envelope(eventInsert, 5, 100, map[string]string{}, payload)
+	blob, err := BuildV1Envelope(eventInsert, 5, 100, map[string]any{}, payload)
 	require.NoError(t, err)
 	pks, err := ReadInsertPK([][]byte{blob}, KindV1, 100, PKInt64)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`l0compact` fails on every backup taken from Milvus 2.5 with:

```
Error: l0compact: unmarshal extras: json: cannot unmarshal bool into Go value of type string
```

The descriptor extras of a v1 binlog are not a string-to-string map. Milvus writes `nullable`
as a bool next to string entries such as `original_size`:

```go
// milvus internal/storage/binlog_writer.go, NewInsertBinlogWriter
// store nullable in extra for compatible
descriptorEvent.AddExtra(nullableKey, nullable) // bool
```

so the JSON is `{"original_size":"12345","nullable":true}`, while `envelope.go` decoded it into
`map[string]string`. `ReadInsertPK` reaches that decode for every `KindV1` segment, so the
command is unusable against 2.5. Milvus 2.6 stores insert logs as bare parquet and takes the
`KindV2` branch, never touching the v1 envelope parser — which is why only the 2.5 matrix
failed.

Typing the field as `map[string]any` is what the wire format actually carries. The sole
consumer compares `Extras["version"]` against `MULTI_FIELD`; comparing an `any` to a string is
still an equality on the dynamic value, so that keeps working.

This has broken the nightly `test-backup-restore-api (2.5, L2)` job on every run since
2026-07-17 — all 8 `test_l0compact.py` cases, never green since the feature landed.

## Changes

- envelope: decode descriptor extras as `map[string]any`, with a note on why they are mixed
- envelope: `BuildV1Envelope` takes the same type, keeping the writer symmetric with the reader
- test: cover extras carrying a bool, and a `version` marker sitting next to one

Both new tests fail on `main` with the exact error above and pass with the fix.

issue: #1127
