### PR TITLE
test: regenerate the stale mocks with the current mockery

### DIFF
--- a/core/restore/collMapper_mock.go
+++ b/core/restore/collMapper_mock.go
@@ -62,7 +62,7 @@ type MockCollMapper_TagetNS_Call struct {
 
 // TagetNS is a helper method to define mock.On call
 //   - ns namespace.NS
-func (_e *MockCollMapper_Expecter) TagetNS(ns interface{}) *MockCollMapper_TagetNS_Call {
+func (_e *MockCollMapper_Expecter) TagetNS(ns any) *MockCollMapper_TagetNS_Call {
 	return &MockCollMapper_TagetNS_Call{Call: _e.mock.On("TagetNS", ns)}
 }
 

--- a/internal/client/milvus/manage_mock.go
+++ b/internal/client/milvus/manage_mock.go
@@ -71,7 +71,7 @@ type MockManage_GetEZK_Call struct {
 // GetEZK is a helper method to define mock.On call
 //   - ctx context.Context
 //   - dbName string
-func (_e *MockManage_Expecter) GetEZK(ctx interface{}, dbName interface{}) *MockManage_GetEZK_Call {
+func (_e *MockManage_Expecter) GetEZK(ctx any, dbName any) *MockManage_GetEZK_Call {
 	return &MockManage_GetEZK_Call{Call: _e.mock.On("GetEZK", ctx, dbName)}
 }
 
@@ -143,9 +143,9 @@ type MockManage_PauseGC_Call struct {
 // PauseGC is a helper method to define mock.On call
 //   - ctx context.Context
 //   - opts ...Option[pauseGCOption]
-func (_e *MockManage_Expecter) PauseGC(ctx interface{}, opts ...interface{}) *MockManage_PauseGC_Call {
+func (_e *MockManage_Expecter) PauseGC(ctx any, opts ...any) *MockManage_PauseGC_Call {
 	return &MockManage_PauseGC_Call{Call: _e.mock.On("PauseGC",
-		append([]interface{}{ctx}, opts...)...)}
+		append([]any{ctx}, opts...)...)}
 }
 
 func (_c *MockManage_PauseGC_Call) Run(run func(ctx context.Context, opts ...Option[pauseGCOption])) *MockManage_PauseGC_Call {
@@ -209,9 +209,9 @@ type MockManage_ResumeGC_Call struct {
 // ResumeGC is a helper method to define mock.On call
 //   - ctx context.Context
 //   - opts ...Option[resumeGCOpt]
-func (_e *MockManage_Expecter) ResumeGC(ctx interface{}, opts ...interface{}) *MockManage_ResumeGC_Call {
+func (_e *MockManage_Expecter) ResumeGC(ctx any, opts ...any) *MockManage_ResumeGC_Call {
 	return &MockManage_ResumeGC_Call{Call: _e.mock.On("ResumeGC",
-		append([]interface{}{ctx}, opts...)...)}
+		append([]any{ctx}, opts...)...)}
 }
 
 func (_c *MockManage_ResumeGC_Call) Run(run func(ctx context.Context, opts ...Option[resumeGCOpt])) *MockManage_ResumeGC_Call {

--- a/internal/storage/client_mock.go
+++ b/internal/storage/client_mock.go
@@ -71,7 +71,7 @@ type MockClient_BucketExist_Call struct {
 // BucketExist is a helper method to define mock.On call
 //   - ctx context.Context
 //   - prefix string
-func (_e *MockClient_Expecter) BucketExist(ctx interface{}, prefix interface{}) *MockClient_BucketExist_Call {
+func (_e *MockClient_Expecter) BucketExist(ctx any, prefix any) *MockClient_BucketExist_Call {
 	return &MockClient_BucketExist_Call{Call: _e.mock.On("BucketExist", ctx, prefix)}
 }
 
@@ -172,7 +172,7 @@ type MockClient_CopyObject_Call struct {
 // CopyObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - i CopyObjectInput
-func (_e *MockClient_Expecter) CopyObject(ctx interface{}, i interface{}) *MockClient_CopyObject_Call {
+func (_e *MockClient_Expecter) CopyObject(ctx any, i any) *MockClient_CopyObject_Call {
 	return &MockClient_CopyObject_Call{Call: _e.mock.On("CopyObject", ctx, i)}
 }
 
@@ -228,7 +228,7 @@ type MockClient_CreateBucket_Call struct {
 
 // CreateBucket is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockClient_Expecter) CreateBucket(ctx interface{}) *MockClient_CreateBucket_Call {
+func (_e *MockClient_Expecter) CreateBucket(ctx any) *MockClient_CreateBucket_Call {
 	return &MockClient_CreateBucket_Call{Call: _e.mock.On("CreateBucket", ctx)}
 }
 
@@ -280,7 +280,7 @@ type MockClient_DeleteObject_Call struct {
 // DeleteObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - key string
-func (_e *MockClient_Expecter) DeleteObject(ctx interface{}, key interface{}) *MockClient_DeleteObject_Call {
+func (_e *MockClient_Expecter) DeleteObject(ctx any, key any) *MockClient_DeleteObject_Call {
 	return &MockClient_DeleteObject_Call{Call: _e.mock.On("DeleteObject", ctx, key)}
 }
 
@@ -348,7 +348,7 @@ type MockClient_GetObject_Call struct {
 // GetObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - key string
-func (_e *MockClient_Expecter) GetObject(ctx interface{}, key interface{}) *MockClient_GetObject_Call {
+func (_e *MockClient_Expecter) GetObject(ctx any, key any) *MockClient_GetObject_Call {
 	return &MockClient_GetObject_Call{Call: _e.mock.On("GetObject", ctx, key)}
 }
 
@@ -414,7 +414,7 @@ type MockClient_HeadObject_Call struct {
 // HeadObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - key string
-func (_e *MockClient_Expecter) HeadObject(ctx interface{}, key interface{}) *MockClient_HeadObject_Call {
+func (_e *MockClient_Expecter) HeadObject(ctx any, key any) *MockClient_HeadObject_Call {
 	return &MockClient_HeadObject_Call{Call: _e.mock.On("HeadObject", ctx, key)}
 }
 
@@ -483,7 +483,7 @@ type MockClient_ListPrefix_Call struct {
 //   - ctx context.Context
 //   - prefix string
 //   - recursive bool
-func (_e *MockClient_Expecter) ListPrefix(ctx interface{}, prefix interface{}, recursive interface{}) *MockClient_ListPrefix_Call {
+func (_e *MockClient_Expecter) ListPrefix(ctx any, prefix any, recursive any) *MockClient_ListPrefix_Call {
 	return &MockClient_ListPrefix_Call{Call: _e.mock.On("ListPrefix", ctx, prefix, recursive)}
 }
 
@@ -545,7 +545,7 @@ type MockClient_UploadObject_Call struct {
 // UploadObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - i UploadObjectInput
-func (_e *MockClient_Expecter) UploadObject(ctx interface{}, i interface{}) *MockClient_UploadObject_Call {
+func (_e *MockClient_Expecter) UploadObject(ctx any, i any) *MockClient_UploadObject_Call {
 	return &MockClient_UploadObject_Call{Call: _e.mock.On("UploadObject", ctx, i)}
 }
 


### PR DESCRIPTION
## Summary

Three mock files were generated by an older mockery than the rest of the tree. Every `make gen-mock` run rewrote their expecter helpers from `interface{}` to `any`, so any PR that regenerated mocks for its own reasons picked up unrelated churn in these files and had to revert them by hand.

Regenerating them is a no-op for behaviour — `interface{}` and `any` are the same type — but it means the next PR that touches a mocked interface shows only its own diff.

## Changes

- Regenerate `core/restore/collMapper_mock.go`, `internal/client/milvus/manage_mock.go` and `internal/storage/client_mock.go` with mockery v3.7.1, the version the rest of the generated mocks already use.

`go build`, `go vet` and the full unit suite pass unchanged.

/kind improvement
