### PR TITLE
client: add snapshot export rpcs and drop the unused pin rpcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.205
 	github.com/imroc/req/v3 v3.59.0
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260727091820-f95888a4df32
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260729035609-9f7d27f3eb7f
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-20260728030618-14564e26159c
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/samber/lo v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260727091820-f95888a4df32 h1:k/PgOJknox0nM2mp1XxhvJsVvjzoxwsaE52NHnpdE0Q=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260727091820-f95888a4df32/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260729035609-9f7d27f3eb7f h1:RQTIWNpsWmzQfVhSZgdGEYlOxCpdKbPzI1uuDJ4ghe4=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260729035609-9f7d27f3eb7f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/milvus-io/milvus/pkg/v3 v3.0.0-20260728030618-14564e26159c h1:mdkUttDRkjKZg49GuFmtQXVhEOhpdP6RldcdEJ4nD7g=
 github.com/milvus-io/milvus/pkg/v3 v3.0.0-20260728030618-14564e26159c/go.mod h1:cBwzQXJwXvk69b+4NJ218LMX5Dsg27zV7pIvAIraA8Q=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -157,8 +157,10 @@ type Grpc interface {
 	CreateSnapshot(ctx context.Context, db, collName, snapshotName string, compactionProtection time.Duration) error
 	DropSnapshot(ctx context.Context, db, collName, snapshotName string) error
 	DescribeSnapshot(ctx context.Context, db, collName, snapshotName string) (*milvuspb.DescribeSnapshotResponse, error)
-	PinSnapshotData(ctx context.Context, db, collName, snapshotName string, ttl time.Duration) (int64, error)
-	UnpinSnapshotData(ctx context.Context, pinID int64) error
+	ExportSnapshot(ctx context.Context, input ExportSnapshotInput) (int64, error)
+	GetExportSnapshotState(ctx context.Context, jobID int64) (*milvuspb.ExportSnapshotInfo, error)
+	RestoreExternalSnapshot(ctx context.Context, input RestoreExternalSnapshotInput) (int64, error)
+	GetRestoreSnapshotState(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error)
 }
 
 const (
@@ -1159,7 +1161,8 @@ func (g *GrpcClient) CreateSnapshot(ctx context.Context, db, collName, snapshotN
 }
 
 // DropSnapshot deletes a snapshot. The server rejects the call while the snapshot has active
-// pins, so unpin before dropping.
+// pins, and an export job holds one until it reaches a terminal state, so drop only once the
+// export is done with the snapshot.
 func (g *GrpcClient) DropSnapshot(ctx context.Context, db, collName, snapshotName string) error {
 	if !g.HasFeature(Snapshot) {
 		return errSnapshotUnsupported
@@ -1193,50 +1196,122 @@ func (g *GrpcClient) DescribeSnapshot(ctx context.Context, db, collName, snapsho
 	return resp, nil
 }
 
-// PinSnapshotData takes a lease on a snapshot and returns the pin id to release it with. While a
-// pin is active the snapshot cannot be dropped — not by DropSnapshot, and not by the cascade that
-// runs when the collection itself is dropped — which keeps the referenced binlogs safe from GC
-// for the whole copy window.
+// ExportSnapshotInput describes one snapshot export.
 //
-// ttl must be at least one second. The wire field is in seconds and treats 0 as "never expires",
-// which would leave a snapshot that no API can release if the caller dies before unpinning, so a
-// zero or sub-second duration is rejected here rather than silently sent.
-func (g *GrpcClient) PinSnapshotData(ctx context.Context, db, collName, snapshotName string, ttl time.Duration) (int64, error) {
+// TargetPath is the root prefix the bundle is written under, either an object key in the
+// instance bucket or a complete storage URI.
+//
+// ExternalSpec is an optional storage-config JSON for the target, of which only the extfs
+// section is read. Leave it empty to have Milvus write with its own object-storage credential
+// and rely on bucket policy to authorize the target. Either way the server rejects a copy that
+// crosses providers or endpoints, since it is executed as a provider-side copy.
+type ExportSnapshotInput struct {
+	DB             string
+	CollectionName string
+	SnapshotName   string
+	TargetPath     string
+	ExternalSpec   string
+}
+
+// ExportSnapshot copies a snapshot into a self-contained bundle — metadata, segment manifests and
+// the data files they reference — and returns the id of the job doing the copying. Nothing has
+// been copied when this returns: the call durably accepts the job and nothing more. Poll
+// GetExportSnapshotState for progress and for the metadata uri that restore needs.
+//
+// The server keeps the source snapshot pinned until the job is terminal, so the referenced files
+// stay safe from GC for the whole copy window without the caller holding a pin of its own.
+func (g *GrpcClient) ExportSnapshot(ctx context.Context, input ExportSnapshotInput) (int64, error) {
 	if !g.HasFeature(Snapshot) {
 		return 0, errSnapshotUnsupported
 	}
 
-	ttlSeconds := int64(ttl.Seconds())
-	if ttlSeconds <= 0 {
-		return 0, fmt.Errorf("client: snapshot pin ttl must be at least one second, got %s", ttl)
+	ctx = g.newCtxWithDB(ctx, input.DB)
+	in := &milvuspb.ExportSnapshotRequest{
+		Name:           input.SnapshotName,
+		CollectionName: input.CollectionName,
+		TargetS3Path:   input.TargetPath,
+		ExternalSpec:   input.ExternalSpec,
 	}
-
-	ctx = g.newCtxWithDB(ctx, db)
-	in := &milvuspb.PinSnapshotDataRequest{
-		CollectionName: collName,
-		Name:           snapshotName,
-		TtlSeconds:     ttlSeconds,
-	}
-	resp, err := g.srv.PinSnapshotData(ctx, in)
+	resp, err := g.srv.ExportSnapshot(ctx, in)
 	if err := checkResponse(resp, err); err != nil {
-		return 0, fmt.Errorf("client: pin snapshot data failed: %w", err)
+		return 0, fmt.Errorf("client: export snapshot failed: %w", err)
 	}
 
-	return resp.GetPinId(), nil
+	return resp.GetJobId(), nil
 }
 
-// UnpinSnapshotData releases a pin. It is idempotent: unpinning an id that was already released
-// or has expired succeeds.
-func (g *GrpcClient) UnpinSnapshotData(ctx context.Context, pinID int64) error {
+// GetExportSnapshotState reports how an export job is doing. A job that failed comes back through
+// the returned info — its state and reason — not as an error; the error return covers the state
+// query itself. SnapshotMetadataUri is populated only once the job reaches the completed state,
+// and TotalBytes only then accounts for the whole bundle.
+func (g *GrpcClient) GetExportSnapshotState(ctx context.Context, jobID int64) (*milvuspb.ExportSnapshotInfo, error) {
 	if !g.HasFeature(Snapshot) {
-		return errSnapshotUnsupported
+		return nil, errSnapshotUnsupported
 	}
 
 	ctx = g.newCtx(ctx)
-	resp, err := g.srv.UnpinSnapshotData(ctx, &milvuspb.UnpinSnapshotDataRequest{PinId: pinID})
+	in := &milvuspb.GetExportSnapshotStateRequest{JobId: jobID}
+	resp, err := g.srv.GetExportSnapshotState(ctx, in)
 	if err := checkResponse(resp, err); err != nil {
-		return fmt.Errorf("client: unpin snapshot data failed: %w", err)
+		return nil, fmt.Errorf("client: get export snapshot state failed: %w", err)
 	}
 
-	return nil
+	return resp.GetInfo(), nil
+}
+
+// RestoreExternalSnapshotInput describes one restore from an exported bundle.
+//
+// TargetCollectionName must not already exist in the target db — the restore creates it.
+//
+// SnapshotMetadataURI must be a complete URI with a scheme and a host; an object key is rejected
+// before the server reads anything. Query parameters and fragments are rejected too, so presigned
+// and SAS URLs cannot stand in for credentials — use ExternalSpec for those. The path has to keep
+// the snapshots/{collectionID}/metadata/{snapshotID}.json shape the bundle was written with,
+// because the server derives the bundle root from that anchor.
+//
+// ExternalSpec carries the source credentials under the same rules as the export side.
+type RestoreExternalSnapshotInput struct {
+	DB                   string
+	TargetCollectionName string
+	SnapshotMetadataURI  string
+	ExternalSpec         string
+}
+
+// RestoreExternalSnapshot restores a collection from a bundle in object storage instead of from
+// the target cluster's own snapshot registry, and returns the id of the job doing the work. Like
+// the export side it only accepts the job; poll GetRestoreSnapshotState for the outcome.
+func (g *GrpcClient) RestoreExternalSnapshot(ctx context.Context, input RestoreExternalSnapshotInput) (int64, error) {
+	if !g.HasFeature(Snapshot) {
+		return 0, errSnapshotUnsupported
+	}
+
+	ctx = g.newCtxWithDB(ctx, input.DB)
+	in := &milvuspb.RestoreExternalSnapshotRequest{
+		TargetCollectionName: input.TargetCollectionName,
+		SnapshotMetadataUri:  input.SnapshotMetadataURI,
+		ExternalSpec:         input.ExternalSpec,
+	}
+	resp, err := g.srv.RestoreExternalSnapshot(ctx, in)
+	if err := checkResponse(resp, err); err != nil {
+		return 0, fmt.Errorf("client: restore external snapshot failed: %w", err)
+	}
+
+	return resp.GetJobId(), nil
+}
+
+// GetRestoreSnapshotState reports how a restore job is doing. As on the export side, a failed job
+// is reported through the returned info rather than as an error.
+func (g *GrpcClient) GetRestoreSnapshotState(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error) {
+	if !g.HasFeature(Snapshot) {
+		return nil, errSnapshotUnsupported
+	}
+
+	ctx = g.newCtx(ctx)
+	in := &milvuspb.GetRestoreSnapshotStateRequest{JobId: jobID}
+	resp, err := g.srv.GetRestoreSnapshotState(ctx, in)
+	if err := checkResponse(resp, err); err != nil {
+		return nil, fmt.Errorf("client: get restore snapshot state failed: %w", err)
+	}
+
+	return resp.GetInfo(), nil
 }

--- a/internal/client/milvus/grpc_mock.go
+++ b/internal/client/milvus/grpc_mock.go
@@ -1157,6 +1157,72 @@ func (_c *MockGrpc_DropSnapshot_Call) RunAndReturn(run func(ctx context.Context,
 	return _c
 }
 
+// ExportSnapshot provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) ExportSnapshot(ctx context.Context, input ExportSnapshotInput) (int64, error) {
+	ret := _mock.Called(ctx, input)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExportSnapshot")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ExportSnapshotInput) (int64, error)); ok {
+		return returnFunc(ctx, input)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ExportSnapshotInput) int64); ok {
+		r0 = returnFunc(ctx, input)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ExportSnapshotInput) error); ok {
+		r1 = returnFunc(ctx, input)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_ExportSnapshot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExportSnapshot'
+type MockGrpc_ExportSnapshot_Call struct {
+	*mock.Call
+}
+
+// ExportSnapshot is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input ExportSnapshotInput
+func (_e *MockGrpc_Expecter) ExportSnapshot(ctx any, input any) *MockGrpc_ExportSnapshot_Call {
+	return &MockGrpc_ExportSnapshot_Call{Call: _e.mock.On("ExportSnapshot", ctx, input)}
+}
+
+func (_c *MockGrpc_ExportSnapshot_Call) Run(run func(ctx context.Context, input ExportSnapshotInput)) *MockGrpc_ExportSnapshot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 ExportSnapshotInput
+		if args[1] != nil {
+			arg1 = args[1].(ExportSnapshotInput)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_ExportSnapshot_Call) Return(n int64, err error) *MockGrpc_ExportSnapshot_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockGrpc_ExportSnapshot_Call) RunAndReturn(run func(ctx context.Context, input ExportSnapshotInput) (int64, error)) *MockGrpc_ExportSnapshot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Flush provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) Flush(ctx context.Context, db string, collName string) (*milvuspb.FlushResponse, error) {
 	ret := _mock.Called(ctx, db, collName)
@@ -1361,6 +1427,74 @@ func (_c *MockGrpc_GetBulkInsertState_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// GetExportSnapshotState provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) GetExportSnapshotState(ctx context.Context, jobID int64) (*milvuspb.ExportSnapshotInfo, error) {
+	ret := _mock.Called(ctx, jobID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExportSnapshotState")
+	}
+
+	var r0 *milvuspb.ExportSnapshotInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (*milvuspb.ExportSnapshotInfo, error)); ok {
+		return returnFunc(ctx, jobID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) *milvuspb.ExportSnapshotInfo); ok {
+		r0 = returnFunc(ctx, jobID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.ExportSnapshotInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, jobID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_GetExportSnapshotState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExportSnapshotState'
+type MockGrpc_GetExportSnapshotState_Call struct {
+	*mock.Call
+}
+
+// GetExportSnapshotState is a helper method to define mock.On call
+//   - ctx context.Context
+//   - jobID int64
+func (_e *MockGrpc_Expecter) GetExportSnapshotState(ctx any, jobID any) *MockGrpc_GetExportSnapshotState_Call {
+	return &MockGrpc_GetExportSnapshotState_Call{Call: _e.mock.On("GetExportSnapshotState", ctx, jobID)}
+}
+
+func (_c *MockGrpc_GetExportSnapshotState_Call) Run(run func(ctx context.Context, jobID int64)) *MockGrpc_GetExportSnapshotState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_GetExportSnapshotState_Call) Return(exportSnapshotInfo *milvuspb.ExportSnapshotInfo, err error) *MockGrpc_GetExportSnapshotState_Call {
+	_c.Call.Return(exportSnapshotInfo, err)
+	return _c
+}
+
+func (_c *MockGrpc_GetExportSnapshotState_Call) RunAndReturn(run func(ctx context.Context, jobID int64) (*milvuspb.ExportSnapshotInfo, error)) *MockGrpc_GetExportSnapshotState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLoadingProgress provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) GetLoadingProgress(ctx context.Context, db string, collName string, partitionNames ...string) (int64, error) {
 	var tmpRet mock.Arguments
@@ -1518,6 +1652,74 @@ func (_c *MockGrpc_GetPersistentSegmentInfo_Call) Return(persistentSegmentInfos 
 }
 
 func (_c *MockGrpc_GetPersistentSegmentInfo_Call) RunAndReturn(run func(ctx context.Context, db string, collName string) ([]*milvuspb.PersistentSegmentInfo, error)) *MockGrpc_GetPersistentSegmentInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRestoreSnapshotState provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) GetRestoreSnapshotState(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error) {
+	ret := _mock.Called(ctx, jobID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRestoreSnapshotState")
+	}
+
+	var r0 *milvuspb.RestoreSnapshotInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (*milvuspb.RestoreSnapshotInfo, error)); ok {
+		return returnFunc(ctx, jobID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) *milvuspb.RestoreSnapshotInfo); ok {
+		r0 = returnFunc(ctx, jobID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.RestoreSnapshotInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, jobID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_GetRestoreSnapshotState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRestoreSnapshotState'
+type MockGrpc_GetRestoreSnapshotState_Call struct {
+	*mock.Call
+}
+
+// GetRestoreSnapshotState is a helper method to define mock.On call
+//   - ctx context.Context
+//   - jobID int64
+func (_e *MockGrpc_Expecter) GetRestoreSnapshotState(ctx any, jobID any) *MockGrpc_GetRestoreSnapshotState_Call {
+	return &MockGrpc_GetRestoreSnapshotState_Call{Call: _e.mock.On("GetRestoreSnapshotState", ctx, jobID)}
+}
+
+func (_c *MockGrpc_GetRestoreSnapshotState_Call) Run(run func(ctx context.Context, jobID int64)) *MockGrpc_GetRestoreSnapshotState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_GetRestoreSnapshotState_Call) Return(restoreSnapshotInfo *milvuspb.RestoreSnapshotInfo, err error) *MockGrpc_GetRestoreSnapshotState_Call {
+	_c.Call.Return(restoreSnapshotInfo, err)
+	return _c
+}
+
+func (_c *MockGrpc_GetRestoreSnapshotState_Call) RunAndReturn(run func(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error)) *MockGrpc_GetRestoreSnapshotState_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1987,90 +2189,6 @@ func (_c *MockGrpc_ListIndex_Call) RunAndReturn(run func(ctx context.Context, db
 	return _c
 }
 
-// PinSnapshotData provides a mock function for the type MockGrpc
-func (_mock *MockGrpc) PinSnapshotData(ctx context.Context, db string, collName string, snapshotName string, ttl time.Duration) (int64, error) {
-	ret := _mock.Called(ctx, db, collName, snapshotName, ttl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PinSnapshotData")
-	}
-
-	var r0 int64
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, time.Duration) (int64, error)); ok {
-		return returnFunc(ctx, db, collName, snapshotName, ttl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, time.Duration) int64); ok {
-		r0 = returnFunc(ctx, db, collName, snapshotName, ttl)
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, time.Duration) error); ok {
-		r1 = returnFunc(ctx, db, collName, snapshotName, ttl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockGrpc_PinSnapshotData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PinSnapshotData'
-type MockGrpc_PinSnapshotData_Call struct {
-	*mock.Call
-}
-
-// PinSnapshotData is a helper method to define mock.On call
-//   - ctx context.Context
-//   - db string
-//   - collName string
-//   - snapshotName string
-//   - ttl time.Duration
-func (_e *MockGrpc_Expecter) PinSnapshotData(ctx any, db any, collName any, snapshotName any, ttl any) *MockGrpc_PinSnapshotData_Call {
-	return &MockGrpc_PinSnapshotData_Call{Call: _e.mock.On("PinSnapshotData", ctx, db, collName, snapshotName, ttl)}
-}
-
-func (_c *MockGrpc_PinSnapshotData_Call) Run(run func(ctx context.Context, db string, collName string, snapshotName string, ttl time.Duration)) *MockGrpc_PinSnapshotData_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		var arg4 time.Duration
-		if args[4] != nil {
-			arg4 = args[4].(time.Duration)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-		)
-	})
-	return _c
-}
-
-func (_c *MockGrpc_PinSnapshotData_Call) Return(n int64, err error) *MockGrpc_PinSnapshotData_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *MockGrpc_PinSnapshotData_Call) RunAndReturn(run func(ctx context.Context, db string, collName string, snapshotName string, ttl time.Duration) (int64, error)) *MockGrpc_PinSnapshotData_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ReplicateMessage provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) ReplicateMessage(ctx context.Context, channelName string) (string, error) {
 	ret := _mock.Called(ctx, channelName)
@@ -2133,6 +2251,72 @@ func (_c *MockGrpc_ReplicateMessage_Call) Return(s string, err error) *MockGrpc_
 }
 
 func (_c *MockGrpc_ReplicateMessage_Call) RunAndReturn(run func(ctx context.Context, channelName string) (string, error)) *MockGrpc_ReplicateMessage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RestoreExternalSnapshot provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) RestoreExternalSnapshot(ctx context.Context, input RestoreExternalSnapshotInput) (int64, error) {
+	ret := _mock.Called(ctx, input)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RestoreExternalSnapshot")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, RestoreExternalSnapshotInput) (int64, error)); ok {
+		return returnFunc(ctx, input)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, RestoreExternalSnapshotInput) int64); ok {
+		r0 = returnFunc(ctx, input)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, RestoreExternalSnapshotInput) error); ok {
+		r1 = returnFunc(ctx, input)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_RestoreExternalSnapshot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RestoreExternalSnapshot'
+type MockGrpc_RestoreExternalSnapshot_Call struct {
+	*mock.Call
+}
+
+// RestoreExternalSnapshot is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input RestoreExternalSnapshotInput
+func (_e *MockGrpc_Expecter) RestoreExternalSnapshot(ctx any, input any) *MockGrpc_RestoreExternalSnapshot_Call {
+	return &MockGrpc_RestoreExternalSnapshot_Call{Call: _e.mock.On("RestoreExternalSnapshot", ctx, input)}
+}
+
+func (_c *MockGrpc_RestoreExternalSnapshot_Call) Run(run func(ctx context.Context, input RestoreExternalSnapshotInput)) *MockGrpc_RestoreExternalSnapshot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 RestoreExternalSnapshotInput
+		if args[1] != nil {
+			arg1 = args[1].(RestoreExternalSnapshotInput)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_RestoreExternalSnapshot_Call) Return(n int64, err error) *MockGrpc_RestoreExternalSnapshot_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockGrpc_RestoreExternalSnapshot_Call) RunAndReturn(run func(ctx context.Context, input RestoreExternalSnapshotInput) (int64, error)) *MockGrpc_RestoreExternalSnapshot_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2264,63 +2448,6 @@ func (_c *MockGrpc_ShowPartitions_Call) Return(showPartitionsResponse *milvuspb.
 }
 
 func (_c *MockGrpc_ShowPartitions_Call) RunAndReturn(run func(ctx context.Context, db string, collName string) (*milvuspb.ShowPartitionsResponse, error)) *MockGrpc_ShowPartitions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UnpinSnapshotData provides a mock function for the type MockGrpc
-func (_mock *MockGrpc) UnpinSnapshotData(ctx context.Context, pinID int64) error {
-	ret := _mock.Called(ctx, pinID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UnpinSnapshotData")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) error); ok {
-		r0 = returnFunc(ctx, pinID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockGrpc_UnpinSnapshotData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnpinSnapshotData'
-type MockGrpc_UnpinSnapshotData_Call struct {
-	*mock.Call
-}
-
-// UnpinSnapshotData is a helper method to define mock.On call
-//   - ctx context.Context
-//   - pinID int64
-func (_e *MockGrpc_Expecter) UnpinSnapshotData(ctx any, pinID any) *MockGrpc_UnpinSnapshotData_Call {
-	return &MockGrpc_UnpinSnapshotData_Call{Call: _e.mock.On("UnpinSnapshotData", ctx, pinID)}
-}
-
-func (_c *MockGrpc_UnpinSnapshotData_Call) Run(run func(ctx context.Context, pinID int64)) *MockGrpc_UnpinSnapshotData_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 int64
-		if args[1] != nil {
-			arg1 = args[1].(int64)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockGrpc_UnpinSnapshotData_Call) Return(err error) *MockGrpc_UnpinSnapshotData_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockGrpc_UnpinSnapshotData_Call) RunAndReturn(run func(ctx context.Context, pinID int64) error) *MockGrpc_UnpinSnapshotData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -457,16 +457,32 @@ func TestGrpcClient_SnapshotUnsupported(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 
-	t.Run("PinSnapshotData", func(t *testing.T) {
+	t.Run("ExportSnapshot", func(t *testing.T) {
 		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: 0}
-		pinID, err := cli.PinSnapshotData(ctx, "db", "coll", "snap", time.Hour)
+		jobID, err := cli.ExportSnapshot(ctx, ExportSnapshotInput{DB: "db", CollectionName: "coll", SnapshotName: "snap"})
 		assert.ErrorIs(t, err, errSnapshotUnsupported)
-		assert.Zero(t, pinID)
+		assert.Zero(t, jobID)
 	})
 
-	t.Run("UnpinSnapshotData", func(t *testing.T) {
+	t.Run("GetExportSnapshotState", func(t *testing.T) {
 		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: 0}
-		assert.ErrorIs(t, cli.UnpinSnapshotData(ctx, 42), errSnapshotUnsupported)
+		info, err := cli.GetExportSnapshotState(ctx, 42)
+		assert.ErrorIs(t, err, errSnapshotUnsupported)
+		assert.Nil(t, info)
+	})
+
+	t.Run("RestoreExternalSnapshot", func(t *testing.T) {
+		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: 0}
+		jobID, err := cli.RestoreExternalSnapshot(ctx, RestoreExternalSnapshotInput{DB: "db", TargetCollectionName: "coll"})
+		assert.ErrorIs(t, err, errSnapshotUnsupported)
+		assert.Zero(t, jobID)
+	})
+
+	t.Run("GetRestoreSnapshotState", func(t *testing.T) {
+		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: 0}
+		info, err := cli.GetRestoreSnapshotState(ctx, 42)
+		assert.ErrorIs(t, err, errSnapshotUnsupported)
+		assert.Nil(t, info)
 	})
 }
 
@@ -538,67 +554,6 @@ func TestGrpcClient_DescribeSnapshot(t *testing.T) {
 	})
 }
 
-func TestGrpcClient_PinSnapshotData(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		mockSrv := NewMockMilvusServiceClient(t)
-		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
-
-		var got *milvuspb.PinSnapshotDataRequest
-		mockSrv.EXPECT().PinSnapshotData(mock.Anything, mock.Anything).
-			Run(func(_ context.Context, in *milvuspb.PinSnapshotDataRequest, _ ...grpc.CallOption) { got = in }).
-			Return(&milvuspb.PinSnapshotDataResponse{Status: &commonpb.Status{Code: 0}, PinId: 7}, nil)
-
-		pinID, err := cli.PinSnapshotData(context.Background(), "db", "coll", "snap", 2*time.Hour)
-		require.NoError(t, err)
-		assert.EqualValues(t, 7, pinID)
-		assert.EqualValues(t, 7200, got.GetTtlSeconds())
-	})
-
-	// A zero ttl means "never expires" on the wire, and no API can release such a pin if the
-	// caller dies. Both cases below would round down to zero, so neither may reach the server —
-	// the mock has no expectations, so an RPC would fail the test.
-	t.Run("RejectsZeroTTL", func(t *testing.T) {
-		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: Snapshot}
-
-		pinID, err := cli.PinSnapshotData(context.Background(), "db", "coll", "snap", 0)
-		assert.Error(t, err)
-		assert.Zero(t, pinID)
-	})
-
-	t.Run("RejectsSubSecondTTL", func(t *testing.T) {
-		cli := &GrpcClient{srv: NewMockMilvusServiceClient(t), flags: Snapshot}
-
-		pinID, err := cli.PinSnapshotData(context.Background(), "db", "coll", "snap", 500*time.Millisecond)
-		assert.Error(t, err)
-		assert.Zero(t, pinID)
-	})
-}
-
-func TestGrpcClient_UnpinSnapshotData(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		mockSrv := NewMockMilvusServiceClient(t)
-		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
-
-		var got *milvuspb.UnpinSnapshotDataRequest
-		mockSrv.EXPECT().UnpinSnapshotData(mock.Anything, mock.Anything).
-			Run(func(_ context.Context, in *milvuspb.UnpinSnapshotDataRequest, _ ...grpc.CallOption) { got = in }).
-			Return(&commonpb.Status{Code: 0}, nil)
-
-		require.NoError(t, cli.UnpinSnapshotData(context.Background(), 7))
-		assert.EqualValues(t, 7, got.GetPinId())
-	})
-
-	t.Run("StatusError", func(t *testing.T) {
-		mockSrv := NewMockMilvusServiceClient(t)
-		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
-
-		mockSrv.EXPECT().UnpinSnapshotData(mock.Anything, mock.Anything).
-			Return(&commonpb.Status{Code: 1, Reason: "some error"}, nil)
-
-		assert.Error(t, cli.UnpinSnapshotData(context.Background(), 7))
-	})
-}
-
 func TestGrpcClient_DropSnapshot(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mockSrv := NewMockMilvusServiceClient(t)
@@ -622,5 +577,212 @@ func TestGrpcClient_DropSnapshot(t *testing.T) {
 			Return(&commonpb.Status{Code: 1, Reason: "snapshot is pinned"}, nil)
 
 		assert.Error(t, cli.DropSnapshot(context.Background(), "db", "coll", "snap"))
+	})
+}
+
+func TestGrpcClient_ExportSnapshot(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		var got *milvuspb.ExportSnapshotRequest
+		mockSrv.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in *milvuspb.ExportSnapshotRequest, _ ...grpc.CallOption) { got = in }).
+			Return(&milvuspb.ExportSnapshotResponse{Status: &commonpb.Status{Code: 0}, JobId: 9001}, nil)
+
+		jobID, err := cli.ExportSnapshot(context.Background(), ExportSnapshotInput{
+			DB:             "db",
+			CollectionName: "coll",
+			SnapshotName:   "snap",
+			TargetPath:     "s3://backup-bucket/backup_1",
+			ExternalSpec:   `{"extfs":{"use_iam":true}}`,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 9001, jobID)
+		assert.Equal(t, "coll", got.GetCollectionName())
+		assert.Equal(t, "snap", got.GetName())
+		assert.Equal(t, "s3://backup-bucket/backup_1", got.GetTargetS3Path())
+		assert.Equal(t, `{"extfs":{"use_iam":true}}`, got.GetExternalSpec())
+	})
+
+	// An empty spec is what tells the server to write with its own credential, so it must go out
+	// as an empty field rather than being filled in with anything here.
+	t.Run("NoExternalSpec", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		var got *milvuspb.ExportSnapshotRequest
+		mockSrv.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in *milvuspb.ExportSnapshotRequest, _ ...grpc.CallOption) { got = in }).
+			Return(&milvuspb.ExportSnapshotResponse{Status: &commonpb.Status{Code: 0}, JobId: 9001}, nil)
+
+		_, err := cli.ExportSnapshot(context.Background(), ExportSnapshotInput{
+			DB:             "db",
+			CollectionName: "coll",
+			SnapshotName:   "snap",
+			TargetPath:     "backup_1",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, got.GetExternalSpec())
+	})
+
+	t.Run("StatusError", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		mockSrv.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).
+			Return(&milvuspb.ExportSnapshotResponse{
+				Status: &commonpb.Status{Code: 1, Reason: "target overlaps the source snapshot"},
+			}, nil)
+
+		jobID, err := cli.ExportSnapshot(context.Background(), ExportSnapshotInput{
+			DB:             "db",
+			CollectionName: "coll",
+			SnapshotName:   "snap",
+			TargetPath:     "backup_1",
+		})
+		assert.Error(t, err)
+		assert.Zero(t, jobID)
+	})
+}
+
+func TestGrpcClient_GetExportSnapshotState(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		var got *milvuspb.GetExportSnapshotStateRequest
+		mockSrv.EXPECT().GetExportSnapshotState(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in *milvuspb.GetExportSnapshotStateRequest, _ ...grpc.CallOption) { got = in }).
+			Return(&milvuspb.GetExportSnapshotStateResponse{
+				Status: &commonpb.Status{Code: 0},
+				Info: &milvuspb.ExportSnapshotInfo{
+					JobId:               9001,
+					State:               milvuspb.ExportSnapshotState_ExportSnapshotCompleted,
+					Progress:            100,
+					TotalBytes:          4096,
+					SnapshotMetadataUri: "s3://backup-bucket/backup_1/snapshots/100/metadata/200.json",
+				},
+			}, nil)
+
+		info, err := cli.GetExportSnapshotState(context.Background(), 9001)
+		require.NoError(t, err)
+		assert.EqualValues(t, 9001, got.GetJobId())
+		assert.Equal(t, milvuspb.ExportSnapshotState_ExportSnapshotCompleted, info.GetState())
+		assert.Equal(t, "s3://backup-bucket/backup_1/snapshots/100/metadata/200.json", info.GetSnapshotMetadataUri())
+		assert.EqualValues(t, 4096, info.GetTotalBytes())
+	})
+
+	// A job that failed is a successful state query — the caller has to read the state to see it,
+	// so it must not be flattened into an error here.
+	t.Run("FailedJobIsNotAnError", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		mockSrv.EXPECT().GetExportSnapshotState(mock.Anything, mock.Anything).
+			Return(&milvuspb.GetExportSnapshotStateResponse{
+				Status: &commonpb.Status{Code: 0},
+				Info: &milvuspb.ExportSnapshotInfo{
+					JobId:  9001,
+					State:  milvuspb.ExportSnapshotState_ExportSnapshotFailed,
+					Reason: "copy failed",
+				},
+			}, nil)
+
+		info, err := cli.GetExportSnapshotState(context.Background(), 9001)
+		require.NoError(t, err)
+		assert.Equal(t, milvuspb.ExportSnapshotState_ExportSnapshotFailed, info.GetState())
+		assert.Equal(t, "copy failed", info.GetReason())
+	})
+
+	t.Run("StatusError", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		mockSrv.EXPECT().GetExportSnapshotState(mock.Anything, mock.Anything).
+			Return(&milvuspb.GetExportSnapshotStateResponse{
+				Status: &commonpb.Status{Code: 1, Reason: "job not found"},
+			}, nil)
+
+		info, err := cli.GetExportSnapshotState(context.Background(), 9001)
+		assert.Error(t, err)
+		assert.Nil(t, info)
+	})
+}
+
+func TestGrpcClient_RestoreExternalSnapshot(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		var got *milvuspb.RestoreExternalSnapshotRequest
+		mockSrv.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in *milvuspb.RestoreExternalSnapshotRequest, _ ...grpc.CallOption) { got = in }).
+			Return(&milvuspb.RestoreExternalSnapshotResponse{Status: &commonpb.Status{Code: 0}, JobId: 9002}, nil)
+
+		jobID, err := cli.RestoreExternalSnapshot(context.Background(), RestoreExternalSnapshotInput{
+			DB:                   "db",
+			TargetCollectionName: "coll_restored",
+			SnapshotMetadataURI:  "s3://backup-bucket/backup_1/snapshots/100/metadata/200.json",
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 9002, jobID)
+		assert.Equal(t, "coll_restored", got.GetTargetCollectionName())
+		assert.Equal(t, "s3://backup-bucket/backup_1/snapshots/100/metadata/200.json", got.GetSnapshotMetadataUri())
+	})
+
+	t.Run("StatusError", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		mockSrv.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).
+			Return(&milvuspb.RestoreExternalSnapshotResponse{
+				Status: &commonpb.Status{Code: 1, Reason: "collection already exists"},
+			}, nil)
+
+		jobID, err := cli.RestoreExternalSnapshot(context.Background(), RestoreExternalSnapshotInput{
+			DB:                   "db",
+			TargetCollectionName: "coll_restored",
+			SnapshotMetadataURI:  "s3://backup-bucket/backup_1/snapshots/100/metadata/200.json",
+		})
+		assert.Error(t, err)
+		assert.Zero(t, jobID)
+	})
+}
+
+func TestGrpcClient_GetRestoreSnapshotState(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		var got *milvuspb.GetRestoreSnapshotStateRequest
+		mockSrv.EXPECT().GetRestoreSnapshotState(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in *milvuspb.GetRestoreSnapshotStateRequest, _ ...grpc.CallOption) { got = in }).
+			Return(&milvuspb.GetRestoreSnapshotStateResponse{
+				Status: &commonpb.Status{Code: 0},
+				Info: &milvuspb.RestoreSnapshotInfo{
+					JobId:    9002,
+					State:    milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted,
+					Progress: 100,
+				},
+			}, nil)
+
+		info, err := cli.GetRestoreSnapshotState(context.Background(), 9002)
+		require.NoError(t, err)
+		assert.EqualValues(t, 9002, got.GetJobId())
+		assert.Equal(t, milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted, info.GetState())
+		assert.EqualValues(t, 100, info.GetProgress())
+	})
+
+	t.Run("GrpcError", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		mockSrv.EXPECT().GetRestoreSnapshotState(mock.Anything, mock.Anything).
+			Return(nil, errors.New("grpc error"))
+
+		info, err := cli.GetRestoreSnapshotState(context.Background(), 9002)
+		assert.Error(t, err)
+		assert.Nil(t, info)
 	})
 }

--- a/internal/client/milvus/milvusServiceClient_mock.go
+++ b/internal/client/milvus/milvusServiceClient_mock.go
@@ -5679,6 +5679,89 @@ func (_c *MockMilvusServiceClient_GetComponentStates_Call) RunAndReturn(run func
 	return _c
 }
 
+// GetExportSnapshotState provides a mock function for the type MockMilvusServiceClient
+func (_mock *MockMilvusServiceClient) GetExportSnapshotState(ctx context.Context, in *milvuspb.GetExportSnapshotStateRequest, opts ...grpc.CallOption) (*milvuspb.GetExportSnapshotStateResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, in, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, in)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExportSnapshotState")
+	}
+
+	var r0 *milvuspb.GetExportSnapshotStateResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest, ...grpc.CallOption) (*milvuspb.GetExportSnapshotStateResponse, error)); ok {
+		return returnFunc(ctx, in, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest, ...grpc.CallOption) *milvuspb.GetExportSnapshotStateResponse); ok {
+		r0 = returnFunc(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetExportSnapshotStateResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest, ...grpc.CallOption) error); ok {
+		r1 = returnFunc(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMilvusServiceClient_GetExportSnapshotState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExportSnapshotState'
+type MockMilvusServiceClient_GetExportSnapshotState_Call struct {
+	*mock.Call
+}
+
+// GetExportSnapshotState is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *milvuspb.GetExportSnapshotStateRequest
+//   - opts ...grpc.CallOption
+func (_e *MockMilvusServiceClient_Expecter) GetExportSnapshotState(ctx any, in any, opts ...any) *MockMilvusServiceClient_GetExportSnapshotState_Call {
+	return &MockMilvusServiceClient_GetExportSnapshotState_Call{Call: _e.mock.On("GetExportSnapshotState",
+		append([]any{ctx, in}, opts...)...)}
+}
+
+func (_c *MockMilvusServiceClient_GetExportSnapshotState_Call) Run(run func(ctx context.Context, in *milvuspb.GetExportSnapshotStateRequest, opts ...grpc.CallOption)) *MockMilvusServiceClient_GetExportSnapshotState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *milvuspb.GetExportSnapshotStateRequest
+		if args[1] != nil {
+			arg1 = args[1].(*milvuspb.GetExportSnapshotStateRequest)
+		}
+		var arg2 []grpc.CallOption
+		var variadicArgs []grpc.CallOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]grpc.CallOption)
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMilvusServiceClient_GetExportSnapshotState_Call) Return(getExportSnapshotStateResponse *milvuspb.GetExportSnapshotStateResponse, err error) *MockMilvusServiceClient_GetExportSnapshotState_Call {
+	_c.Call.Return(getExportSnapshotStateResponse, err)
+	return _c
+}
+
+func (_c *MockMilvusServiceClient_GetExportSnapshotState_Call) RunAndReturn(run func(ctx context.Context, in *milvuspb.GetExportSnapshotStateRequest, opts ...grpc.CallOption) (*milvuspb.GetExportSnapshotStateResponse, error)) *MockMilvusServiceClient_GetExportSnapshotState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetFlushAllState provides a mock function for the type MockMilvusServiceClient
 func (_mock *MockMilvusServiceClient) GetFlushAllState(ctx context.Context, in *milvuspb.GetFlushAllStateRequest, opts ...grpc.CallOption) (*milvuspb.GetFlushAllStateResponse, error) {
 	var tmpRet mock.Arguments


### PR DESCRIPTION
## Summary

Adds the four snapshot RPCs the Milvus 3.0 backup path needs to move bytes: `ExportSnapshot`, `GetExportSnapshotState`, `RestoreExternalSnapshot` and `GetRestoreSnapshotState`, and removes the two that turned out to have no caller. #1120 added the create/drop/describe half; this settles the rest of the client surface. Plumbing only — nothing calls these yet, and everything stays behind the existing `Snapshot` feature flag, so a pre-3.0 server keeps taking the current path.

Export and restore are both asynchronous: the RPC durably accepts a job and returns its id, and the metadata URI that restore needs is published through the job state once the export completes. So each side is a submit plus a poll rather than one blocking call.

`PinSnapshotData` / `UnpinSnapshotData` go away. #1120 added them in case the backup path had to hold a snapshot open across the copy, and it does not: DataCoord pins the source snapshot inside `ExportSnapshot`'s submit path — before the job record is persisted — and releases it only when the job is terminal, so the queue wait is covered as well, which matters given `exportMaxConcurrentJobs` defaults to 1. A pin is not what keeps files from being GC'd either; that is inherent to the snapshot existing. It only additionally survives `DropSnapshot` and the cascade behind `DropCollection`. Create a snapshot immediately before submitting its export and there is no window left for a caller-held pin to cover.

The server half is milvus-io/milvus#50978, which is still open — nothing here runs end to end until it lands. The proto half does not depend on it: the async export job APIs are already on `milvus-proto` master (milvus-io/milvus-proto#644), which is what this bumps `go-api/v3` for. Field 2 of `ExportSnapshotResponse` (`snapshot_metadata_uri`) is deprecated and unset; job id is field 3.

Related to #1119

## Changes

- bump `milvus-proto/go-api/v3` to `v3.0.0-20260729035609-9f7d27f3eb7f` for the async export job APIs
- add `ExportSnapshot` / `GetExportSnapshotState` / `RestoreExternalSnapshot` / `GetRestoreSnapshotState` to the gRPC client, with `ExportSnapshotInput` and `RestoreExternalSnapshotInput` carrying the target path and the optional external storage spec
- a job that failed is returned through the info, not as an error — the state query succeeded, and reading `state` and `reason` is how the caller learns the job failed, so flattening it would leave no way to tell the two apart
- both calls that take a db send it through the `dbname` header like the rest of this client rather than the request field; Milvus fills that header into both request types in its database interceptor
- drop `PinSnapshotData` and `UnpinSnapshotData`, which have no caller and no window left to cover
- regenerate the affected mocks
