### PR TITLE
backup: add a snapshot strategy that exports bundles

### DIFF
--- a/core/backup/coll_snapshot_task.go
+++ b/core/backup/coll_snapshot_task.go
@@ -1,0 +1,201 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+	"github.com/zilliztech/milvus-backup/internal/log"
+	"github.com/zilliztech/milvus-backup/internal/namespace"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+const (
+	_snapshotPollInterval = 3 * time.Second
+
+	// A drop right after the export job goes terminal can still be rejected: DataCoord
+	// releases the pin it took for the copy on its own reconcile tick, not inline with
+	// the state change the poll observed.
+	_snapshotDropRetry    = 10
+	_snapshotDropInterval = time.Second
+)
+
+type collSnapshotTask struct {
+	taskID string
+
+	ns           namespace.NS
+	snapshotName string
+	target       snapshotTarget
+
+	pollInterval time.Duration
+
+	grpc milvus.Grpc
+
+	taskMgr     *taskmgr.Mgr
+	metaBuilder *metaBuilder
+
+	logger *zap.Logger
+}
+
+func newCollSnapshotTask(ns namespace.NS, snapshotName string, target snapshotTarget, args collTaskArgs) *collSnapshotTask {
+	logger := log.L().With(
+		zap.String("task_id", args.TaskID),
+		zap.String("ns", ns.String()),
+		zap.String("snapshot_name", snapshotName))
+
+	return &collSnapshotTask{
+		taskID:       args.TaskID,
+		ns:           ns,
+		snapshotName: snapshotName,
+		target:       target,
+		pollInterval: _snapshotPollInterval,
+		grpc:         args.Grpc,
+		taskMgr:      args.TaskMgr,
+		metaBuilder:  args.MetaBuilder,
+		logger:       logger,
+	}
+}
+
+// Execute freezes the collection into a snapshot, has Milvus copy it into the backup
+// directory, and records where the bundle landed. No bytes move through this process.
+func (st *collSnapshotTask) Execute(ctx context.Context) error {
+	st.logger.Info("start to backup collection with snapshot")
+	st.taskMgr.UpdateBackupTask(st.taskID, taskmgr.SetBackupCollDMLPrepare(st.ns))
+
+	// Compaction protection is left off: the snapshot holds its files against GC for
+	// as long as it exists, and it exists only for this export.
+	if err := st.grpc.CreateSnapshot(ctx, st.ns.DBName(), st.ns.CollName(), st.snapshotName, 0); err != nil {
+		return fmt.Errorf("backup: create snapshot: %w", err)
+	}
+	defer st.dropSnapshot(ctx)
+
+	// The snapshot's own boundary, read before the export so a failed export still
+	// leaves nothing behind to interpret.
+	desc, err := st.grpc.DescribeSnapshot(ctx, st.ns.DBName(), st.ns.CollName(), st.snapshotName)
+	if err != nil {
+		return fmt.Errorf("backup: describe snapshot: %w", err)
+	}
+
+	jobID, err := st.grpc.ExportSnapshot(ctx, milvus.ExportSnapshotInput{
+		DB:             st.ns.DBName(),
+		CollectionName: st.ns.CollName(),
+		SnapshotName:   st.snapshotName,
+		TargetPath:     st.target.Path,
+		ExternalSpec:   st.target.ExternalSpec,
+	})
+	if err != nil {
+		return fmt.Errorf("backup: export snapshot: %w", err)
+	}
+	st.logger.Info("snapshot export job accepted", zap.Int64("job_id", jobID))
+
+	info, err := st.waitExport(ctx, jobID)
+	if err != nil {
+		return err
+	}
+
+	metadataPath, err := st.target.metadataPath(info.GetSnapshotMetadataUri())
+	if err != nil {
+		return err
+	}
+
+	snapshotBackup := &backuppb.SnapshotBackupInfo{
+		MetadataPath: metadataPath,
+		TotalFiles:   info.GetTotalFiles(),
+		TotalBytes:   info.GetTotalBytes(),
+	}
+	if err := st.metaBuilder.addSnapshot(st.ns, snapshotBackup, uint64(desc.GetCreateTs())); err != nil {
+		return fmt.Errorf("backup: add snapshot meta: %w", err)
+	}
+
+	st.taskMgr.UpdateBackupTask(st.taskID, taskmgr.SetBackupCollDMLDone(st.ns))
+	st.logger.Info("backup collection with snapshot done",
+		zap.String("metadata_path", metadataPath),
+		zap.Int64("total_files", info.GetTotalFiles()),
+		zap.Int64("total_bytes", info.GetTotalBytes()))
+
+	return nil
+}
+
+// waitExport polls the export job until it is done. A job that failed comes back
+// through the info rather than as an error from the state query, so both are checked.
+func (st *collSnapshotTask) waitExport(ctx context.Context, jobID int64) (*milvuspb.ExportSnapshotInfo, error) {
+	ticker := time.NewTicker(st.pollInterval)
+	defer ticker.Stop()
+
+	// The job reports files, not bytes: total_bytes is only known once the bundle is
+	// published. Progress is a ratio either way, and nothing outside the task manager
+	// reads these as a size.
+	var reportedTotal, copied int64
+	for {
+		info, err := st.grpc.GetExportSnapshotState(ctx, jobID)
+		if err != nil {
+			return nil, fmt.Errorf("backup: get export snapshot state: %w", err)
+		}
+
+		if total := info.GetTotalFiles(); total != reportedTotal {
+			reportedTotal = total
+			st.taskMgr.UpdateBackupTask(st.taskID, taskmgr.SetBackupCollDMLExecuting(st.ns, total))
+		}
+		if done := info.GetCopiedFiles(); done > copied {
+			st.taskMgr.UpdateBackupTask(st.taskID, taskmgr.IncBackupCollCopiedSize(st.ns, done-copied, 0))
+			copied = done
+		}
+
+		switch info.GetState() {
+		case milvuspb.ExportSnapshotState_ExportSnapshotCompleted:
+			return info, nil
+		case milvuspb.ExportSnapshotState_ExportSnapshotFailed:
+			return nil, fmt.Errorf("backup: snapshot export job %d failed: %s", jobID, info.GetReason())
+		}
+
+		st.logger.Debug("waiting for snapshot export",
+			zap.Int64("job_id", jobID),
+			zap.Int32("progress", info.GetProgress()),
+			zap.Int64("copied_files", info.GetCopiedFiles()),
+			zap.Int64("total_files", info.GetTotalFiles()))
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("backup: wait snapshot export job %d: %w", jobID, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// dropSnapshot releases the snapshot once the bundle is written. The bundle is
+// self-contained, so nothing that was backed up depends on the snapshot surviving —
+// a snapshot left behind only holds its collection's files against GC.
+func (st *collSnapshotTask) dropSnapshot(ctx context.Context) {
+	// The task's own context may already be canceled by the failure that brought us
+	// here, and the snapshot still has to go.
+	ctx = context.WithoutCancel(ctx)
+
+	for attempt := range _snapshotDropRetry {
+		err := st.grpc.DropSnapshot(ctx, st.ns.DBName(), st.ns.CollName(), st.snapshotName)
+		if err == nil {
+			return
+		}
+
+		st.logger.Warn("drop snapshot failed, will retry",
+			zap.Int("attempt", attempt+1),
+			zap.Error(err))
+
+		timer := time.NewTimer(_snapshotDropInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+
+	// Nothing else can clean this up: the export job that pinned it is gone, and the
+	// backup meta does not record snapshot names.
+	st.logger.Error("could not drop snapshot, it holds its collection's files against gc until removed by hand",
+		zap.String("snapshot_name", st.snapshotName))
+}

--- a/core/backup/coll_snapshot_task_test.go
+++ b/core/backup/coll_snapshot_task_test.go
@@ -1,0 +1,140 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+	"github.com/zilliztech/milvus-backup/internal/namespace"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+func newTestCollSnapshotTask(t *testing.T, ns namespace.NS, grpc milvus.Grpc) (*collSnapshotTask, *metaBuilder) {
+	mgr := taskmgr.NewMgr()
+	require.NoError(t, mgr.AddBackupTask("task-1", "mybackup"))
+	mgr.UpdateBackupTask("task-1", taskmgr.AddBackupCollTasks([]namespace.NS{ns}))
+
+	builder := newMetaBuilder("task-1", "mybackup")
+	builder.addCollection(ns, &backuppb.CollectionBackupInfo{CollectionId: 1, CollectionName: ns.CollName()})
+
+	task := &collSnapshotTask{
+		taskID:       "task-1",
+		ns:           ns,
+		snapshotName: "mbk_mybackup",
+		target:       snapshotTarget{Path: "s3://backup-bucket/backup/mybackup/bundle", Dir: "bundle"},
+		pollInterval: time.Millisecond,
+		grpc:         grpc,
+		taskMgr:      mgr,
+		metaBuilder:  builder,
+		logger:       zap.NewNop(),
+	}
+
+	return task, builder
+}
+
+func TestCollSnapshotTask_Execute(t *testing.T) {
+	ns := namespace.New("db1", "coll1")
+
+	t.Run("Success", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().CreateSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup", time.Duration(0)).Return(nil)
+		cli.EXPECT().DescribeSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").
+			Return(&milvuspb.DescribeSnapshotResponse{CreateTs: 456}, nil)
+		cli.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).
+			RunAndReturn(func(_ context.Context, in milvus.ExportSnapshotInput) (int64, error) {
+				assert.Equal(t, "s3://backup-bucket/backup/mybackup/bundle", in.TargetPath)
+				assert.Equal(t, "mbk_mybackup", in.SnapshotName)
+				return 9001, nil
+			})
+		// One round still executing, so the poll loop is exercised rather than skipped.
+		cli.EXPECT().GetExportSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.ExportSnapshotInfo{
+				State:       milvuspb.ExportSnapshotState_ExportSnapshotExecuting,
+				TotalFiles:  10,
+				CopiedFiles: 4,
+			}, nil).Once()
+		cli.EXPECT().GetExportSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.ExportSnapshotInfo{
+				State:               milvuspb.ExportSnapshotState_ExportSnapshotCompleted,
+				TotalFiles:          10,
+				CopiedFiles:         10,
+				TotalBytes:          4096,
+				SnapshotMetadataUri: "s3://backup-bucket/backup/mybackup/bundle/snapshots/1/metadata/2.json",
+			}, nil).Once()
+		cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").Return(nil).Once()
+
+		task, builder := newTestCollSnapshotTask(t, ns, cli)
+		require.NoError(t, task.Execute(context.Background()))
+
+		coll := builder.data.GetCollectionBackups()[0]
+		assert.Equal(t, "bundle/snapshots/1/metadata/2.json", coll.GetSnapshotBackup().GetMetadataPath())
+		assert.EqualValues(t, 10, coll.GetSnapshotBackup().GetTotalFiles())
+		assert.EqualValues(t, 4096, coll.GetSnapshotBackup().GetTotalBytes())
+		// The collection size comes from the export job, and backup_timestamp from the
+		// snapshot's own boundary rather than a flush response.
+		assert.EqualValues(t, 4096, coll.GetSize())
+		assert.EqualValues(t, 456, coll.GetBackupTimestamp())
+	})
+
+	// A failed job is reported through the info, and the snapshot still has to go.
+	t.Run("FailedJobDropsSnapshot", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().CreateSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup", time.Duration(0)).Return(nil)
+		cli.EXPECT().DescribeSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").
+			Return(&milvuspb.DescribeSnapshotResponse{CreateTs: 456}, nil)
+		cli.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetExportSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.ExportSnapshotInfo{
+				State:  milvuspb.ExportSnapshotState_ExportSnapshotFailed,
+				Reason: "copy failed",
+			}, nil)
+		cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").Return(nil).Once()
+
+		task, builder := newTestCollSnapshotTask(t, ns, cli)
+		err := task.Execute(context.Background())
+		assert.ErrorContains(t, err, "copy failed")
+		assert.Nil(t, builder.data.GetCollectionBackups()[0].GetSnapshotBackup())
+	})
+
+	// A bundle written somewhere other than the target cannot be recorded as a path
+	// relative to the backup directory, so it is an error rather than a bad record.
+	t.Run("MetadataOutsideTarget", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().CreateSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup", time.Duration(0)).Return(nil)
+		cli.EXPECT().DescribeSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").
+			Return(&milvuspb.DescribeSnapshotResponse{}, nil)
+		cli.EXPECT().ExportSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetExportSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.ExportSnapshotInfo{
+				State:               milvuspb.ExportSnapshotState_ExportSnapshotCompleted,
+				SnapshotMetadataUri: "s3://other-bucket/snapshots/1/metadata/2.json",
+			}, nil)
+		cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").Return(nil).Once()
+
+		task, _ := newTestCollSnapshotTask(t, ns, cli)
+		assert.Error(t, task.Execute(context.Background()))
+	})
+}
+
+// DataCoord releases the export's pin on its own reconcile tick, so the first drop
+// after a job completes can still be refused.
+func TestCollSnapshotTask_DropSnapshotRetries(t *testing.T) {
+	ns := namespace.New("db1", "coll1")
+
+	cli := milvus.NewMockGrpc(t)
+	cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").
+		Return(errors.New("snapshot is pinned")).Once()
+	cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").Return(nil).Once()
+
+	task, _ := newTestCollSnapshotTask(t, ns, cli)
+	task.dropSnapshot(context.Background())
+}

--- a/core/backup/coll_strategy.go
+++ b/core/backup/coll_strategy.go
@@ -28,6 +28,7 @@ const (
 	StrategySkipFlush
 	StrategyBulkFlush
 	StrategySerialFlush
+	StrategySnapshot
 )
 
 // concurrencyThrottling:
@@ -124,6 +125,88 @@ func newDMLTasks(nss []namespace.NS, args collTaskArgs) []collTask {
 	}
 
 	return dmlTasks
+}
+
+// snapshotStrategy backs up through Milvus snapshots: milvus-backup orchestrates and
+// Milvus moves the bytes. It needs a 3.0 server, and produces backups in a format only
+// a milvus-backup that understands it can restore.
+type snapshotStrategy struct {
+	nss []namespace.NS
+
+	target     snapshotTarget
+	backupName string
+
+	args collTaskArgs
+
+	logger *zap.Logger
+}
+
+func newSnapshotStrategy(nss []namespace.NS, backupName string, target snapshotTarget, args collTaskArgs) *snapshotStrategy {
+	return &snapshotStrategy{
+		nss:        nss,
+		target:     target,
+		backupName: backupName,
+		args:       args,
+		logger:     log.With(zap.String("task_id", args.TaskID)),
+	}
+}
+
+// snapshotName is what the collection is frozen under while it is exported. Backup
+// names allow a leading digit and snapshot names do not, hence the prefix; the backup
+// name itself is already restricted to letters, digits and underscores.
+func (ss *snapshotStrategy) snapshotName() string { return "mbk_" + ss.backupName }
+
+func (ss *snapshotStrategy) Execute(ctx context.Context) error {
+	ddlTasks := newDDLTasks(ss.nss, ss.args)
+	if err := concurrentExecCollTask(ctx, ss.args.Throttling.CollSem, ddlTasks); err != nil {
+		return fmt.Errorf("backup: execute ddl task %w", err)
+	}
+
+	if err := ss.flushAll(ctx); err != nil {
+		return fmt.Errorf("backup: flush all %w", err)
+	}
+
+	// Each collection creates its snapshot immediately before submitting the export
+	// that pins it, so there is no window where a snapshot sits unpinned waiting its
+	// turn. The collection semaphore bounds how many exports are in flight, which
+	// matters because a job starts its timeout when DataCoord accepts it, not when it
+	// starts copying — anything queued beyond what
+	// dataCoord.snapshot.exportMaxConcurrentJobs can run burns that budget waiting.
+	snapshotTasks := make([]collTask, 0, len(ss.nss))
+	for _, ns := range ss.nss {
+		task := func(ctx context.Context) error {
+			if err := newCollSnapshotTask(ns, ss.snapshotName(), ss.target, ss.args).Execute(ctx); err != nil {
+				ss.args.TaskMgr.UpdateBackupTask(ss.args.TaskID, taskmgr.SetBackupCollFail(ns, err))
+				return fmt.Errorf("backup: execute snapshot task %w", err)
+			}
+
+			ss.args.TaskMgr.UpdateBackupTask(ss.args.TaskID, taskmgr.SetBackupCollSuccess(ns))
+			return nil
+		}
+		snapshotTasks = append(snapshotTasks, task)
+	}
+
+	if err := concurrentExecCollTask(ctx, ss.args.Throttling.CollSem, snapshotTasks); err != nil {
+		return fmt.Errorf("backup: concurrent execute snapshot task %w", err)
+	}
+
+	return nil
+}
+
+// flushAll seals what is still growing. A snapshot admits only the segments below its
+// channel seek positions, so without this it would hold whatever the last automatic
+// flush left behind rather than the collections as they are now.
+//
+// One call covers every collection. A collection whose snapshot is taken well after this
+// is still bounded by its own channel checkpoint at creation time, so writes since the
+// flush are in it only as far as automatic flushing has carried them. How far behind the
+// last collection runs is up to dataCoord.snapshot.exportMaxConcurrentJobs — refreshable,
+// with no upper bound, and 1 until an operator raises it.
+//
+// FlushAll needs no feature check here: it arrived in 2.6.11 and this strategy already
+// requires 3.0.
+func (ss *snapshotStrategy) flushAll(ctx context.Context) error {
+	return flushAllAndRecord(ctx, ss.args, ss.logger)
 }
 
 type metaOnlyStrategy struct {
@@ -303,14 +386,20 @@ func (bf *bulkFlushStrategy) Execute(ctx context.Context) error {
 }
 
 func (bf *bulkFlushStrategy) flushAllAndBackupTS(ctx context.Context) error {
-	bf.logger.Info("start flush all")
+	return flushAllAndRecord(ctx, bf.args, bf.logger)
+}
+
+// flushAllAndRecord seals every collection in the cluster and records what the response
+// says about it: the control and physical channels, and the flush messages per channel.
+func flushAllAndRecord(ctx context.Context, args collTaskArgs, logger *zap.Logger) error {
+	logger.Info("start flush all")
 
 	start := time.Now()
-	resp, err := bf.args.Grpc.FlushAll(ctx)
+	resp, err := args.Grpc.FlushAll(ctx)
 	if err != nil {
 		return fmt.Errorf("backup: flush all %w", err)
 	}
-	bf.logger.Info("flush all done", zap.Any("resp", resp), zap.Duration("cost", time.Since(start)))
+	logger.Info("flush all done", zap.Any("resp", resp), zap.Duration("cost", time.Since(start)))
 
 	pchs := resp.GetClusterInfo().GetPchannels()
 	cch := resp.GetClusterInfo().GetCchannel()
@@ -325,6 +414,6 @@ func (bf *bulkFlushStrategy) flushAllAndBackupTS(ctx context.Context) error {
 		flushAllMsg[pch] = base64.StdEncoding.EncodeToString(byts)
 	}
 
-	bf.args.MetaBuilder.setClusterInfoAndTSS(cch, pchs, flushAllMsg)
+	args.MetaBuilder.setClusterInfoAndTSS(cch, pchs, flushAllMsg)
 	return nil
 }

--- a/core/backup/func.go
+++ b/core/backup/func.go
@@ -44,6 +44,7 @@ var _strategyMap = map[string]Strategy{
 	"skip_flush":   StrategySkipFlush,
 	"bulk_flush":   StrategyBulkFlush,
 	"serial_flush": StrategySerialFlush,
+	"snapshot":     StrategySnapshot,
 }
 
 func SupportStrategy() []string { return lo.Keys(_strategyMap) }

--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -81,6 +81,35 @@ func (builder *metaBuilder) addCollection(ns namespace.NS, collectionBackup *bac
 	}
 }
 
+// setFormat records which format the backup is being written in. Empty, the default,
+// is the binlog format.
+func (builder *metaBuilder) setFormat(format string) {
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	builder.data.Format = format
+}
+
+// addSnapshot attaches a collection's exported bundle. snapshotTs is the snapshot's
+// own boundary as Milvus reports it, which is what backup_timestamp means for this
+// format — the flush response the binlog path reads it from has no counterpart here.
+func (builder *metaBuilder) addSnapshot(ns namespace.NS, snapshot *backuppb.SnapshotBackupInfo, snapshotTs uint64) error {
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	collID := builder.nsToCollID[ns]
+	collBackup, ok := builder.collectionBackups[collID]
+	if !ok {
+		return fmt.Errorf("backup: collection backup not found for namespace %s, collection_id: %d", ns, collID)
+	}
+
+	collBackup.SnapshotBackup = snapshot
+	collBackup.BackupTimestamp = snapshotTs
+	collBackup.Size = snapshot.GetTotalBytes()
+
+	return nil
+}
+
 func (builder *metaBuilder) addPOS(ns namespace.NS, channelCP map[string]string, maxChannelTS uint64, sealTime uint64) error {
 	builder.mu.Lock()
 	defer builder.mu.Unlock()
@@ -281,6 +310,7 @@ func (builder *metaBuilder) buildBackupMeta() ([]byte, error) {
 	info := &backuppb.BackupInfo{
 		Id:              builder.data.GetId(),
 		Name:            builder.data.GetName(),
+		Format:          builder.data.GetFormat(),
 		BackupTimestamp: builder.data.GetBackupTimestamp(),
 		Size:            builder.data.GetSize(),
 		MilvusVersion:   builder.data.GetMilvusVersion(),

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 )
 
@@ -359,4 +361,41 @@ func TestBackupCollectionIDs(t *testing.T) {
 	builder.addCollection(namespace.New("db1", "coll2"), &backuppb.CollectionBackupInfo{CollectionId: 2})
 
 	assert.ElementsMatch(t, []int64{1, 2}, builder.backupCollectionIDs())
+}
+
+func TestAddSnapshot(t *testing.T) {
+	builder := newTestMetaBuilder(t)
+	ns := namespace.New("db1", "coll1")
+
+	snapshot := &backuppb.SnapshotBackupInfo{
+		MetadataPath: "snapshots/1/metadata/2.json",
+		TotalFiles:   3,
+		TotalBytes:   4096,
+	}
+	require.NoError(t, builder.addSnapshot(ns, snapshot, 456))
+
+	coll := builder.data.GetCollectionBackups()[0]
+	assert.Equal(t, "snapshots/1/metadata/2.json", coll.GetSnapshotBackup().GetMetadataPath())
+	// In this format the size is what the export job reported, and backup_timestamp is
+	// the snapshot's own boundary.
+	assert.EqualValues(t, 4096, coll.GetSize())
+	assert.EqualValues(t, 456, coll.GetBackupTimestamp())
+
+	t.Run("UnknownNamespace", func(t *testing.T) {
+		assert.Error(t, builder.addSnapshot(namespace.New("db1", "nope"), snapshot, 456))
+	})
+}
+
+// backup_meta.json is the top-level view, and a reader that fetches only it still has
+// to be able to tell which format the backup is in.
+func TestBuildBackupMetaCarriesFormat(t *testing.T) {
+	builder := newTestMetaBuilder(t)
+	builder.setFormat(meta.FormatSnapshot)
+
+	byts, err := builder.buildBackupMeta()
+	require.NoError(t, err)
+
+	var got backuppb.BackupInfo
+	require.NoError(t, json.Unmarshal(byts, &got))
+	assert.Equal(t, meta.FormatSnapshot, got.GetFormat())
 }

--- a/core/backup/snapshot_target.go
+++ b/core/backup/snapshot_target.go
@@ -1,0 +1,167 @@
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+)
+
+// snapshotTarget says where a collection's bundle is exported to, in the terms
+// ExportSnapshot takes them.
+type snapshotTarget struct {
+	// Path is the bundle root as a complete URI. ExportSnapshot also accepts a bare
+	// object key, but that names a key in Milvus's own bucket, which is not where a
+	// backup goes.
+	Path string
+
+	// Dir is that same root relative to the backup directory.
+	Dir string
+
+	// ExternalSpec carries the credentials for the target, and is empty when Milvus
+	// can reach it with its own.
+	ExternalSpec string
+}
+
+func newSnapshotTarget(milvusCfg, backupCfg storage.Config, backupDir string) (snapshotTarget, error) {
+	uri, err := snapshotTargetPath(backupCfg, mpath.BackupBundleDir(backupDir))
+	if err != nil {
+		return snapshotTarget{}, err
+	}
+	target := snapshotTarget{Path: uri, Dir: mpath.BundleDirName}
+
+	// With no spec Milvus writes with its own credential and lets bucket policy
+	// authorize the target, which is exactly the case when both sides are the same
+	// backend — and it keeps the access key off the wire.
+	if storage.SameBackend(milvusCfg, backupCfg) {
+		return target, nil
+	}
+
+	spec, err := snapshotExternalSpec(backupCfg)
+	if err != nil {
+		return snapshotTarget{}, err
+	}
+	target.ExternalSpec = spec
+
+	return target, nil
+}
+
+// metadataPath turns the absolute uri a finished export reports into a path relative to
+// the backup directory, which is what the backup meta records: an absolute uri would pin
+// the backup to the bucket and prefix it was written to.
+func (t snapshotTarget) metadataPath(metadataURI string) (string, error) {
+	root := strings.TrimSuffix(t.Path, "/") + "/"
+	if !strings.HasPrefix(metadataURI, root) {
+		return "", fmt.Errorf("backup: exported metadata %s is not under the target %s", metadataURI, t.Path)
+	}
+
+	return path.Join(t.Dir, strings.TrimPrefix(metadataURI, root)), nil
+}
+
+// snapshotCloudProvider maps this tool's provider name onto the value Milvus accepts in
+// extfs.cloud_provider, and doubles as the check for whether a provider is supported at
+// all. The value is always sent: Milvus infers one from the URI scheme when it is
+// missing, and its own comment calls that inference a source of silent misconfiguration,
+// since s3:// covers both AWS and a self-hosted store.
+func snapshotCloudProvider(provider string) (string, error) {
+	switch provider {
+	case v2.ProviderS3, v2.ProviderAWS:
+		return "aws", nil
+	case v2.ProviderMinio:
+		return "minio", nil
+	case v2.ProviderTencent:
+		return "tencent", nil
+	case v2.ProviderAliyun:
+		return "aliyun", nil
+	case v2.ProviderHwc:
+		return "huawei", nil
+	default:
+		return "", fmt.Errorf("backup: snapshot export does not support %s backup storage", provider)
+	}
+}
+
+// snapshotTargetPath builds the bundle root URI, in one of the two shapes Milvus parses:
+// minio://<endpoint>/<bucket>/<key> names the endpoint in the host, s3://<bucket>/<key>
+// leaves Milvus to derive it from cloud_provider and region.
+//
+// The configured endpoint wins whenever there is one. Derivation only produces the
+// canonical public endpoint for a provider and region, which is wrong for a deployment
+// reached over an internal or private-link address — and wrong in a way that surfaces as
+// a copy failure rather than a configuration error.
+func snapshotTargetPath(cfg storage.Config, backupDir string) (string, error) {
+	dir := strings.Trim(backupDir, "/")
+	if dir == "" {
+		return "", fmt.Errorf("backup: snapshot export target needs a backup directory")
+	}
+	if _, err := snapshotCloudProvider(cfg.Provider); err != nil {
+		return "", err
+	}
+
+	if host := endpointHost(cfg.Endpoint); host != "" {
+		return fmt.Sprintf("minio://%s/%s/%s", host, cfg.Bucket, dir), nil
+	}
+
+	// No endpoint to name, so Milvus has to derive one, and every provider it can derive
+	// for needs the region to do it.
+	if cfg.Region == "" {
+		return "", fmt.Errorf("backup: snapshot export to %s needs an endpoint or a region", cfg.Provider)
+	}
+
+	return fmt.Sprintf("s3://%s/%s", cfg.Bucket, dir), nil
+}
+
+func endpointHost(endpoint string) string {
+	host := strings.TrimSpace(endpoint)
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+
+	return strings.Trim(host, "/")
+}
+
+// snapshotExternalSpec renders the storage config as the extfs json Milvus expects.
+// It only overrides what it names: the server starts from its own storage config and
+// applies these on top.
+func snapshotExternalSpec(cfg storage.Config) (string, error) {
+	cloudProvider, err := snapshotCloudProvider(cfg.Provider)
+	if err != nil {
+		return "", err
+	}
+
+	extfs := map[string]string{
+		"cloud_provider": cloudProvider,
+		"use_ssl":        strconv.FormatBool(cfg.UseSSL),
+	}
+	if cfg.Region != "" {
+		extfs["region"] = cfg.Region
+	}
+
+	switch cfg.Credential.Type {
+	case storage.Static:
+		// extfs has no session token field, so a temporary credential would be sent
+		// as a permanent one and fail to authorize with nothing pointing at why.
+		if cfg.Credential.Token != "" {
+			return "", fmt.Errorf("backup: snapshot export cannot pass a session token to milvus")
+		}
+		extfs["access_key_id"] = cfg.Credential.AK
+		extfs["access_key_value"] = cfg.Credential.SK
+	case storage.IAM:
+		extfs["use_iam"] = "true"
+		if cfg.Credential.IAMEndpoint != "" {
+			extfs["iam_endpoint"] = cfg.Credential.IAMEndpoint
+		}
+	default:
+		return "", fmt.Errorf("backup: snapshot export cannot pass %s credentials to milvus", cfg.Credential.Type)
+	}
+
+	byts, err := json.Marshal(map[string]any{"extfs": extfs})
+	if err != nil {
+		return "", fmt.Errorf("backup: marshal snapshot external spec: %w", err)
+	}
+
+	return string(byts), nil
+}

--- a/core/backup/snapshot_target_test.go
+++ b/core/backup/snapshot_target_test.go
@@ -1,0 +1,153 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+)
+
+func TestSnapshotTargetPath(t *testing.T) {
+	// The configured endpoint goes in the host, whatever the provider: Milvus uses it
+	// verbatim there, where derivation would only ever produce the canonical public one.
+	t.Run("EndpointGoesInTheURI", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			provider string
+			endpoint string
+			want     string
+		}{
+			{"Minio", v2.ProviderMinio, "minio:9000", "minio://minio:9000/backup-bucket/backup/mybackup"},
+			{"MinioWithScheme", v2.ProviderMinio, "http://minio:9000", "minio://minio:9000/backup-bucket/backup/mybackup"},
+			{"Tencent", v2.ProviderTencent, "cos.ap-guangzhou.myqcloud.com", "minio://cos.ap-guangzhou.myqcloud.com/backup-bucket/backup/mybackup"},
+			{"Aliyun", v2.ProviderAliyun, "oss-cn-hangzhou.aliyuncs.com", "minio://oss-cn-hangzhou.aliyuncs.com/backup-bucket/backup/mybackup"},
+			{"Huawei", v2.ProviderHwc, "obs.cn-north-4.myhuaweicloud.com", "minio://obs.cn-north-4.myhuaweicloud.com/backup-bucket/backup/mybackup"},
+			{"AWS", v2.ProviderAWS, "s3.us-west-2.amazonaws.com", "minio://s3.us-west-2.amazonaws.com/backup-bucket/backup/mybackup"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cfg := storage.Config{Provider: tt.provider, Bucket: "backup-bucket", Endpoint: tt.endpoint}
+				got, err := snapshotTargetPath(cfg, "backup/mybackup")
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
+
+	// Without one, Milvus derives the endpoint from cloud_provider and region.
+	t.Run("NoEndpointLeavesItToMilvus", func(t *testing.T) {
+		cfg := storage.Config{Provider: v2.ProviderS3, Bucket: "backup-bucket", Region: "us-west-2"}
+		got, err := snapshotTargetPath(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup", got)
+	})
+
+	// Every provider Milvus can derive an endpoint for needs the region to do it, so
+	// neither being set is refused here rather than as a copy failure later.
+	t.Run("NeedsAnEndpointOrARegion", func(t *testing.T) {
+		cfg := storage.Config{Provider: v2.ProviderS3, Bucket: "backup-bucket"}
+		_, err := snapshotTargetPath(cfg, "backup/mybackup")
+		assert.ErrorContains(t, err, "region")
+	})
+
+	t.Run("UnsupportedProvider", func(t *testing.T) {
+		cfg := storage.Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "acct.blob.core.windows.net"}
+		_, err := snapshotTargetPath(cfg, "backup/mybackup")
+		assert.ErrorContains(t, err, v2.ProviderAzure)
+	})
+}
+
+func TestSnapshotExternalSpec(t *testing.T) {
+	t.Run("Static", func(t *testing.T) {
+		cfg := storage.Config{
+			Provider:   v2.ProviderTencent,
+			Region:     "ap-guangzhou",
+			UseSSL:     true,
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+
+		spec, err := snapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"tencent","access_key_id":"ak","access_key_value":"sk","region":"ap-guangzhou","use_ssl":"true"}}`, spec)
+	})
+
+	t.Run("IAM", func(t *testing.T) {
+		cfg := storage.Config{
+			Provider:   v2.ProviderAWS,
+			Credential: storage.Credential{Type: storage.IAM, IAMEndpoint: "http://169.254.169.254"},
+		}
+
+		spec, err := snapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"aws","iam_endpoint":"http://169.254.169.254","use_iam":"true","use_ssl":"false"}}`, spec)
+	})
+
+	// extfs has no session token field, so sending the key pair alone would fail to
+	// authorize with nothing pointing at the cause.
+	t.Run("RejectsSessionToken", func(t *testing.T) {
+		cfg := storage.Config{Provider: v2.ProviderAWS, Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk", Token: "token"}}
+		_, err := snapshotExternalSpec(cfg)
+		assert.Error(t, err)
+	})
+
+	t.Run("RejectsUnsupportedCredential", func(t *testing.T) {
+		cfg := storage.Config{Provider: v2.ProviderAWS, Credential: storage.Credential{Type: storage.GCPCredJSON}}
+		_, err := snapshotExternalSpec(cfg)
+		assert.Error(t, err)
+	})
+}
+
+func TestNewSnapshotTarget(t *testing.T) {
+	// Milvus falls back to its own credential when no spec is given, which is what to
+	// rely on when both sides are the same backend — it keeps the key off the wire.
+	t.Run("SameBackendSendsNoSpec", func(t *testing.T) {
+		milvusCfg := storage.Config{
+			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+
+		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "minio://minio:9000/backup-bucket/backup/mybackup/bundle", target.Path)
+		assert.Equal(t, "bundle", target.Dir)
+		assert.Empty(t, target.ExternalSpec)
+	})
+
+	t.Run("OtherBackendSendsSpec", func(t *testing.T) {
+		milvusCfg := storage.Config{Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket"}
+		backupCfg := storage.Config{
+			Provider: v2.ProviderS3, Region: "us-west-2", Bucket: "backup-bucket",
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+
+		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup/bundle", target.Path)
+		assert.Contains(t, target.ExternalSpec, `"access_key_id":"ak"`)
+	})
+}
+
+func TestSnapshotTarget_MetadataPath(t *testing.T) {
+	target := snapshotTarget{Path: "s3://backup-bucket/backup/mybackup/bundle", Dir: "bundle"}
+
+	// What lands in the meta is relative to the backup directory, bundle prefix and
+	// all, so restore can rebuild the uri without knowing this layout.
+	t.Run("RelativeToTheBackupDir", func(t *testing.T) {
+		got, err := target.metadataPath("s3://backup-bucket/backup/mybackup/bundle/snapshots/449577/metadata/449580.json")
+		require.NoError(t, err)
+		assert.Equal(t, "bundle/snapshots/449577/metadata/449580.json", got)
+	})
+
+	// Anything outside the target is not ours to record, and a path relative to the
+	// backup directory could not describe it anyway.
+	t.Run("OutsideTarget", func(t *testing.T) {
+		_, err := target.metadataPath("s3://other-bucket/snapshots/449577/metadata/449580.json")
+		assert.Error(t, err)
+	})
+}

--- a/core/backup/strategy_string.go
+++ b/core/backup/strategy_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[StrategySkipFlush-2]
 	_ = x[StrategyBulkFlush-3]
 	_ = x[StrategySerialFlush-4]
+	_ = x[StrategySnapshot-5]
 }
 
-const _Strategy_name = "StrategyAutoStrategyMetaOnlyStrategySkipFlushStrategyBulkFlushStrategySerialFlush"
+const _Strategy_name = "StrategyAutoStrategyMetaOnlyStrategySkipFlushStrategyBulkFlushStrategySerialFlushStrategySnapshot"
 
-var _Strategy_index = [...]uint8{0, 12, 28, 45, 62, 81}
+var _Strategy_index = [...]uint8{0, 12, 28, 45, 62, 81, 97}
 
 func (i Strategy) String() string {
 	idx := int(i) - 0

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
+	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
@@ -227,8 +228,15 @@ func (t *Task) privateExecute(ctx context.Context) error {
 	}
 	t.metaBuilder.setVersion(version)
 
-	t.gcCtrl.PauseGC(ctx)
-	defer t.gcCtrl.ResumeGC(ctx)
+	t.metaBuilder.setFormat(t.format())
+
+	// Pausing GC is the binlog path's way of holding the files still while they are
+	// copied one by one. A snapshot does that itself, unconditionally and only for the
+	// collection being backed up, so the cluster-wide advisory is not asked for.
+	if t.option.Strategy != StrategySnapshot {
+		t.gcCtrl.PauseGC(ctx)
+		defer t.gcCtrl.ResumeGC(ctx)
+	}
 
 	dbNames, collections, err := t.listDBAndNSS(ctx)
 	if err != nil {
@@ -263,6 +271,28 @@ func (t *Task) privateExecute(ctx context.Context) error {
 
 	t.logger.Info("backup successfully")
 	return nil
+}
+
+func (t *Task) newSnapshotStrategy(nss []namespace.NS, args collTaskArgs) (tasklet.Tasklet, error) {
+	target, err := newSnapshotTarget(t.milvusStorage.Config(), t.backupStorage.Config(), t.backupDir)
+	if err != nil {
+		return nil, err
+	}
+
+	t.logger.Info("use snapshot strategy",
+		zap.String("target_path", target.Path),
+		zap.Bool("external_spec_set", target.ExternalSpec != ""))
+
+	return newSnapshotStrategy(nss, t.option.BackupName, target, args), nil
+}
+
+// format is the value recorded in the backup meta, which the strategy decides.
+func (t *Task) format() string {
+	if t.option.Strategy == StrategySnapshot {
+		return meta.FormatSnapshot
+	}
+
+	return meta.FormatBinlog
 }
 
 func (t *Task) prepare(ctx context.Context) error {
@@ -428,7 +458,18 @@ func (t *Task) selectStrategy(nss []namespace.NS) (tasklet.Tasklet, error) {
 	args := t.newCollTaskArgs()
 
 	switch t.option.Strategy {
+	case StrategySnapshot:
+		if !t.grpc.HasFeature(milvus.Snapshot) {
+			return nil, fmt.Errorf("backup: the snapshot strategy needs a milvus 3.0 or newer server")
+		}
+
+		return t.newSnapshotStrategy(nss, args)
 	case StrategyAuto:
+		// Not the snapshot strategy, even on a server that reports the feature. The
+		// flag is a version constraint, and the server side of the export landed in
+		// stages: Milvus master serves CreateSnapshot and DescribeSnapshot today but
+		// answers ExportSnapshot with "not implemented". Auto can move here once the
+		// export is released and the constraint can name a version that has it.
 		if t.grpc.HasFeature(milvus.FlushAll) {
 			t.logger.Info("use bulk flush strategy")
 			return newBulkFlushStrategy(nss, args), nil
@@ -540,10 +581,17 @@ func (t *Task) writeMeta(ctx context.Context) error {
 	entries := []metaEntry{
 		{Type: mpath.BackupMeta, Fn: t.metaBuilder.buildBackupMeta},
 		{Type: mpath.CollectionMeta, Fn: t.metaBuilder.buildCollectionMeta},
-		{Type: mpath.PartitionMeta, Fn: t.metaBuilder.buildPartitionMeta},
-		{Type: mpath.SegmentMeta, Fn: t.metaBuilder.buildSegmentMeta},
-		{Type: mpath.FullMeta, Fn: t.metaBuilder.buildFullMeta},
 	}
+	// The snapshot format has no segments, so the partition and segment files have
+	// nothing to hold. meta.Write makes the same call for the same reason: writing them
+	// empty would add a read path through levelToTree, which derives a collection's
+	// size by summing segments.
+	if t.format() != meta.FormatSnapshot {
+		entries = append(entries,
+			metaEntry{Type: mpath.PartitionMeta, Fn: t.metaBuilder.buildPartitionMeta},
+			metaEntry{Type: mpath.SegmentMeta, Fn: t.metaBuilder.buildSegmentMeta})
+	}
+	entries = append(entries, metaEntry{Type: mpath.FullMeta, Fn: t.metaBuilder.buildFullMeta})
 
 	for _, entry := range entries {
 		data, err := entry.Fn()

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -116,14 +116,14 @@ func UseStreaming(mode string, src, dest Config) bool {
 	case v2.TransferDirect:
 		return false
 	default:
-		return !sameBackend(src, dest)
+		return !SameBackend(src, dest)
 	}
 }
 
-// sameBackend reports whether two configs name the same backend, i.e. the same
+// SameBackend reports whether two configs name the same backend, i.e. the same
 // provider reached at the same endpoint. Buckets and root paths may differ
 // within one backend, so they are not compared.
-func sameBackend(a, b Config) bool {
+func SameBackend(a, b Config) bool {
 	return a.Provider == b.Provider &&
 		a.Endpoint == b.Endpoint &&
 		a.Region == b.Region &&

--- a/internal/storage/mpath/path.go
+++ b/internal/storage/mpath/path.go
@@ -56,6 +56,14 @@ const (
 	_deltaLogPrefix  = "delta_log"
 )
 
+// BundleDirName is where a snapshot-format backup keeps the bundle Milvus exports:
+// its metadata, its manifests and the data files they reference, under one prefix
+// beside the meta this tool writes.
+const BundleDirName = "bundle"
+
+// BackupBundleDir returns the directory an exported snapshot bundle is written to.
+func BackupBundleDir(backupDir string) string { return path.Join(backupDir, BundleDirName) }
+
 func Join(base string, options ...Option) string {
 	elem := make([]string, 0, 8)
 	elem = append(elem, base)


### PR DESCRIPTION
## Summary

The Milvus 3.0 half of #1119. `strategy=snapshot` freezes each collection into a snapshot, has Milvus export it into the backup directory as a self-contained bundle, and records where the bundle landed. No binlog bytes pass through milvus-backup — it orchestrates and Milvus moves the data.

Per backup: one `FlushAll`. Then per collection: `CreateSnapshot`, `DescribeSnapshot` for the snapshot's own boundary, `ExportSnapshot`, poll `GetExportSnapshotState` until the job is terminal, record the bundle, drop the snapshot.

`StrategyAuto` does not pick this yet, even on a server that reports the snapshot feature. That flag is a version constraint, and the server side landed in stages: Milvus master serves `CreateSnapshot` and `DescribeSnapshot` today but answers `ExportSnapshot` with `service unimplemented`, so routing auto there fails every backup against master — CI caught exactly that. Auto can move once the export is released and the constraint can name a version that has it.

## Why it is shaped this way

**The flush is not redundant.** A snapshot admits only the segments below its channel seek positions, so without one it would hold whatever the last automatic flush left behind rather than the collections as they are now. One `FlushAll` covers all of them, the same call the bulk flush strategy already makes.

The bound this leaves is worth stating: a collection whose snapshot is taken well after the flush is bounded by its own channel checkpoint at creation time, so writes since the flush are in it only as far as automatic flushing has carried them. How far behind the last collection runs depends on `dataCoord.snapshot.exportMaxConcurrentJobs`.

**Each collection creates its snapshot immediately before the export that pins it.** DataCoord takes the pin when it *accepts* the job, not when it starts copying, so a create-then-submit pair leaves no window where a snapshot sits unpinned waiting its turn. The collection semaphore bounds how many exports are in flight, which matters because the timeout starts at accept too: anything queued beyond what `dataCoord.snapshot.exportMaxConcurrentJobs` can run burns that budget waiting. That setting is refreshable and has no upper bound — raising it is the lever if the tail lags — but it is 1 until someone raises it.

**Dropping the snapshot retries.** DataCoord releases the export's pin on its own reconcile tick rather than inline with the state change the poll observed, so the first drop after a job completes can still be refused as pinned.

**GC is not paused on this path.** Pausing it is how the binlog path holds files still while it copies them one by one. A snapshot does that itself, unconditionally, and only for the collection being backed up.

**The bundle goes under a `bundle/` directory of the backup**, so everything Milvus writes — its metadata under `snapshots/`, its manifests, and the data files under `files/` — sits under one prefix beside the `meta/` this tool writes:

```
backup/<name>/
├── meta/{full,backup,collection}_meta.json
└── bundle/
    ├── snapshots/{collID}/metadata/{snapID}.json
    ├── snapshots/{collID}/manifests/{snapID}/{segID}.avro
    └── files/insert_log|delta_log|index_files/...
```

The layout is not baked in anywhere. What the meta records is the metadata path *relative to the backup directory*, so each backup describes where its own bundle is; restore joins the two and never has to know the convention. Moving it later costs one line and leaves existing backups restorable.

**The export target is built from the backup storage config**, in one of the two shapes Milvus parses:

| configured endpoint | URI | endpoint comes from |
|---|---|---|
| yes | `minio://<endpoint>/<bucket>/<key>` | the URI host, verbatim |
| no | `s3://<bucket>/<key>` | Milvus, derived from `cloud_provider` + `region` |

The configured endpoint wins whenever there is one: derivation only produces a provider's canonical public endpoint, which is wrong for a deployment reached over an internal or private-link address — and wrong in a way that surfaces as a copy failure rather than a configuration error. `s3`, `aws`, `minio`, `tencent`, `aliyun` and `hwc` are mapped onto the `cloud_provider` values Milvus accepts; anything else is refused here, where the error can name the provider.

`extfs.cloud_provider` is always sent. Milvus infers one from the URI scheme when it is missing, and its own comment calls that inference a source of silent misconfiguration since `s3://` covers both AWS and a self-hosted store. The rest of the spec is left empty when both sides are the same backend, so Milvus writes with its own credential and the access key stays off the wire.

**The cluster info the flush returns is recorded**, the same way the bulk flush strategy records it — control channel, physical channels, per-channel flush messages — so both formats describe the cluster they came from the same way. Per-collection channel checkpoints are not recorded: a snapshot's boundary is its own channel seek positions, which no API exposes, and the flush response describes where the flush left the channels instead. Anything that depends on those stays off for this format.

Related to #1119

## Changes

- add `StrategySnapshot` and `snapshotStrategy`, plus the per-collection `collSnapshotTask` that drives create → export → poll → record → drop
- build the export target URI and external spec from the backup storage config, and record the bundle's metadata path relative to the backup directory
- record `format` in the meta, and skip the partition and segment meta files for this format, matching what `meta.Write` already does
- export `storage.SameBackend`, which is how the target decides whether Milvus needs credentials of its own

## Notes for review

`writeMeta` in the backup task and `meta.Write` in the meta package now both encode the same layout rule, because the backup task writes its meta through `metaBuilder` rather than through `meta.Write`. They also disagree on what `backup_meta.json` holds — `meta.Write` puts RBAC, databases and flush messages in it, `buildBackupMeta` five scalars. That is pre-existing, and unifying the two writers seems worth its own PR rather than a detour in this one.

A follow-up, once milvus-io/milvus#50978 is released: point `StrategyAuto` at the snapshot strategy on a server that has the export, and refuse `bulk_flush` / `serial_flush` / `skip_flush` there. `meta_only` stays valid — it collects DDL and touches no data.

End to end this needs milvus-io/milvus#50978, still open.
