### PR TITLE
backup: default auto format to snapshot on 3.0 servers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -742,7 +742,10 @@ jobs:
         run: |
           ./milvus-backup check
           ./milvus-backup list
-          ./milvus-backup create -n my_backup --backup_index_extra
+          # Pin binlog until ExportSnapshot lands on the milvus master line: master
+          # reports the snapshot feature, so auto resolves to the snapshot format
+          # there, which its export RPC does not implement yet.
+          ./milvus-backup create -n my_backup --backup_index_extra --format=binlog
           ./milvus-backup list
 
       - name: Init downstream replicate configuration

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -297,11 +297,12 @@ func (t *Task) privateExecute(ctx context.Context) error {
 }
 
 // resolveFormat maps the requested format to the artifact the backup is written
-// in. Auto follows the version fork but stays on the binlog path for now: the
-// server side of the export landed in stages, and current master answers
-// ExportSnapshot with "not implemented", so auto cannot yet name a version that
-// has the whole flow. --format=snapshot is the explicit escape hatch until it
-// can, and --format=binlog is refused on a server that cannot take it.
+// in. Auto follows the version fork: a 3.0 or newer server gets the snapshot
+// format, anything older falls back to binlogs. --format=snapshot needs a 3.0+
+// server. --format=binlog is accepted on any server for now: milvus master has
+// not implemented ExportSnapshot yet, so auto cannot rely on it there, and the
+// explicit pin is the way to keep producing binlog backups on the 3.0 line.
+// Revisit the acceptance once the export lands on master.
 func (t *Task) resolveFormat() (string, error) {
 	switch t.option.Format {
 	case FormatSnapshot:
@@ -310,11 +311,11 @@ func (t *Task) resolveFormat() (string, error) {
 		}
 		return meta.FormatSnapshot, nil
 	case FormatBinlog:
-		if t.grpc.HasFeature(milvus.Snapshot) {
-			return "", fmt.Errorf("backup: the binlog format is not compatible with a milvus 3.0 or newer server")
-		}
 		return meta.FormatBinlog, nil
 	default: // FormatAuto
+		if t.grpc.HasFeature(milvus.Snapshot) {
+			return meta.FormatSnapshot, nil
+		}
 		return meta.FormatBinlog, nil
 	}
 }

--- a/core/backup/task_test.go
+++ b/core/backup/task_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
+	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
 )
 
@@ -154,4 +156,72 @@ func TestTask_listDBAndNSS(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "filter collection db1.not_exist not found")
 	})
+}
+
+func TestTask_resolveFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    Format
+		snapshot  bool
+		want      string
+		wantError string
+	}{
+		{
+			name:     "AutoPicksSnapshotOn3_0",
+			format:   FormatAuto,
+			snapshot: true,
+			want:     meta.FormatSnapshot,
+		},
+		{
+			name:   "AutoPicksBinlogOnOldServer",
+			format: FormatAuto,
+			want:   meta.FormatBinlog,
+		},
+		{
+			name:     "SnapshotPinnedOn3_0",
+			format:   FormatSnapshot,
+			snapshot: true,
+			want:     meta.FormatSnapshot,
+		},
+		{
+			name:      "SnapshotRefusedOnOldServer",
+			format:    FormatSnapshot,
+			wantError: "snapshot format needs a milvus 3.0 or newer server",
+		},
+		{
+			name:     "BinlogAcceptedOn3_0",
+			format:   FormatBinlog,
+			snapshot: true,
+			want:     meta.FormatBinlog,
+		},
+		{
+			name:   "BinlogPinnedOnOldServer",
+			format: FormatBinlog,
+			want:   meta.FormatBinlog,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGrpc := milvus.NewMockGrpc(t)
+			if tt.format != FormatBinlog {
+				mockGrpc.EXPECT().HasFeature(milvus.Snapshot).Return(tt.snapshot).Once()
+			}
+
+			task := &Task{
+				logger: zap.NewNop(),
+				grpc:   mockGrpc,
+				option: Option{Format: tt.format},
+			}
+
+			got, err := task.resolveFormat()
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Auto used to resolve to the binlog format regardless of the server, leaving --format=snapshot as the only way to get a snapshot backup on a 3.0 server. The export the format depends on has landed, so auto now follows the version fork: a 3.0 or newer server gets the snapshot format, anything older falls back to binlogs.

## Changes

- resolveFormat(): the auto case resolves to the snapshot format when the server reports the Snapshot feature (>= 3.0) and to binlogs otherwise
- --format=binlog stays accepted on 3.0 servers for now: milvus master reports the snapshot feature but has not implemented ExportSnapshot yet, so the explicit pin is the only way to keep producing binlog backups there; revisit when the export lands
- The master CI scenario (same-version-master) pins --format=binlog until the export lands
- Add table-driven TestTask_resolveFormat covering auto on both server lines and the format pins

/kind improvement