### PR TITLE
ci: test backup and restore of a local-storage milvus

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -263,6 +263,176 @@ jobs:
         run: |
           python example/verify_data.py
 
+  test-backup-restore-local-storage:
+    needs: unit-test-go
+    # Milvus standalone with COMMON_STORAGETYPE=local keeps its data on the
+    # local filesystem (localStorage.path, default /var/lib/milvus/data). This
+    # job proves milvus-backup can read that directory directly and back it up
+    # to MinIO, then restores into a fresh MinIO-backed Milvus (issue #964).
+    name: Backup and restore local storage Milvus
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image_tag: [v2.5.20, 2.6-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - uses: actions/setup-go@v7
+        name: Set up Go ${{ env.go-version }}
+        with:
+          go-version: ${{ env.go-version }}
+          cache: true
+
+      - name: Build
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          go get
+          go build
+
+      - name: Install dependency
+        timeout-minutes: 5
+        working-directory: tests
+        shell: bash
+        run: |
+          pip install -r requirements.txt --trusted-host https://test.pypi.org
+
+      - name: Milvus deploy with local storage
+        timeout-minutes: 15
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
+          yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          mkdir -p volumes/etcd volumes/minio volumes/milvus
+          sudo chmod -R 777 volumes
+          sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml up -d --wait
+          sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml ps -a
+
+      - name: Export docker-compose status after deploy
+        if: ${{ always() }}
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          echo "=== Docker Compose Status ==="
+          sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml ps -a || true
+          echo "=== Standalone Container Full Logs ==="
+          sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml logs standalone || true
+          echo "=== All Containers Status ==="
+          sudo docker ps -a || true
+
+      - name: Prepare data
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          python example/prepare_data.py
+
+      - name: Fix permissions after data preparation
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          # The container writes binlogs as root; the backup binary runs as the
+          # runner user and reads the local directory directly.
+          sudo chmod -R 777 volumes
+
+      - name: List milvus local data before backup
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          sudo apt-get install -y tree > /dev/null 2>&1 || true
+          echo "=== milvus local data tree (before backup) ==="
+          sudo tree volumes/milvus/data | head -500
+
+      - name: Configure backup.yaml for local storage
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          yq -i '.log.level = "debug"' configs/backup.yaml
+          yq -i '.milvus.storage.provider = "local"' configs/backup.yaml
+          # Host directory backing Milvus localStorage.path (mounted at
+          # /var/lib/milvus in the container).
+          yq -i '.milvus.storage.rootPath = "deployment/standalone/volumes/milvus/data"' configs/backup.yaml
+          yq -i '.milvus.storage.bucketName = ""' configs/backup.yaml
+          cat configs/backup.yaml
+
+      - name: Backup
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          ./milvus-backup check
+          ./milvus-backup list
+          ./milvus-backup create -n my_backup
+          ./milvus-backup list
+
+      - name: List MinIO files after backup
+        if: ${{ always() }}
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          echo "=== MinIO volume tree (after backup) ==="
+          sudo tree volumes/minio/ -I '.minio.sys' | head -500
+
+      - name: Save Backup
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          sudo cp -r deployment/standalone/volumes/minio/a-bucket/backup local-backup
+
+      - name: Uninstall Milvus
+        timeout-minutes: 5
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml down
+          sudo rm -rf volumes
+
+      - name: Configure backup.yaml for MinIO target
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          yq -i '.milvus.storage.provider = "minio"' configs/backup.yaml
+          yq -i '.milvus.storage.rootPath = "files"' configs/backup.yaml
+          yq -i '.milvus.storage.bucketName = "a-bucket"' configs/backup.yaml
+          cat configs/backup.yaml
+
+      - name: Deploy target Milvus with MinIO storage
+        timeout-minutes: 15
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag 2.6-latest) && echo $tag
+          yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          mkdir -p volumes/etcd volumes/minio volumes/milvus
+          sudo chmod -R 777 volumes
+          sudo docker compose -f docker-compose.yml up -d --wait
+          sudo docker compose -f docker-compose.yml ps -a
+
+      - name: Copy Backup to target MinIO
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          sudo mkdir -p deployment/standalone/volumes/minio/a-bucket/backup
+          sudo cp -r local-backup/my_backup deployment/standalone/volumes/minio/a-bucket/backup
+
+      - name: Restore backup
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          ./milvus-backup restore -n my_backup -s _recover
+
+      - name: Verify data
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          python example/verify_data.py
+
   test-backup-restore-after-upgrade:
     needs: unit-test-go
     name: Backup and restore after upgrade

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Both storage sections describe a backend the same way, and `backup.storage` inhe
 | [backup-azure.yaml](configs/backup-azure.yaml) | Azure Blob Storage with an account key |
 | [backup-iam.yaml](configs/backup-iam.yaml) | AWS S3 with an instance role, no keys in the file |
 | [backup-local.yaml](configs/backup-local.yaml) | Milvus on MinIO, backups on a local disk |
+| [backup-local-milvus.yaml](configs/backup-local-milvus.yaml) | Milvus standalone with local storage (`COMMON_STORAGETYPE=local`), backups on MinIO |
 
 Use values that match the Milvus deployment. In common installations, the storage defaults differ:
 

--- a/configs/backup-local-milvus.yaml
+++ b/configs/backup-local-milvus.yaml
@@ -1,0 +1,46 @@
+# Milvus standalone with local filesystem storage, backed up to MinIO.
+#
+# The Milvus deployment runs with COMMON_STORAGETYPE=local and keeps its data
+# on the local filesystem at localStorage.path (default /var/lib/milvus/data).
+# A local provider has no endpoint and no credentials, so the milvus side names
+# only where the data lives on disk: rootPath is the directory milvus-backup
+# reads directly. When Milvus runs in a container, that is the bind-mounted
+# host directory, not the path Milvus itself uses.
+#
+# The backup storage is independent and can be any remote backend; MinIO is
+# shown here, mirroring a local-to-remote migration (zilliztech/milvus-backup#964).
+configVersion: v2
+
+log:
+  level: info
+  console: true
+
+milvus:
+  user: "root"
+  password: "Milvus"
+
+  grpc:
+    address: localhost
+    port: 19530
+
+  storage:
+    # Supported providers: local, minio, s3, aws, gcp, gcpnative, azure,
+    # aliyun, tencent, hwc.
+    provider: local
+    # The directory that backs Milvus localStorage.path, as milvus-backup sees
+    # it on disk. There is no bucket and no endpoint for local storage.
+    rootPath: "/var/lib/milvus/data"
+    bucketName: ""
+
+backup:
+  storage:
+    provider: minio
+    address: localhost
+    port: 9000
+    bucketName: "a-bucket"
+    rootPath: "backup"
+
+    auth:
+      type: static
+      accessKeyID: minioadmin
+      secretAccessKey: minioadmin

--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -60,6 +60,10 @@ milvus:
   storage:
     # Supported providers: local, minio, s3, aws, gcp, gcpnative, azure,
     # aliyun, tencent, hwc.
+    # local is Milvus standalone with COMMON_STORAGETYPE=local: there is no
+    # bucket or endpoint, and rootPath is the directory backing Milvus
+    # localStorage.path as milvus-backup sees it on disk. See
+    # configs/backup-local-milvus.yaml for a complete example.
     provider: "minio"
     address: localhost
     port: 9000

--- a/deployment/standalone/docker-compose.local.yaml
+++ b/deployment/standalone/docker-compose.local.yaml
@@ -1,0 +1,15 @@
+# Overrides the standalone service to use local filesystem storage instead of
+# MinIO, matching the official docker standalone deployment:
+#   https://milvus.io/docs/install_standalone-docker.md
+#
+# Milvus keeps its data at localStorage.path (default /var/lib/milvus/data),
+# which the base compose maps to ./volumes/milvus on the host. MinIO still runs:
+# the source Milvus ignores it, and milvus-backup uses it as the backup
+# destination.
+#
+# Deploy with:
+#   docker compose -f docker-compose.yml -f docker-compose.local.yaml up -d --wait
+services:
+  standalone:
+    environment:
+      COMMON_STORAGETYPE: local


### PR DESCRIPTION
## Summary

Milvus standalone with `COMMON_STORAGETYPE=local` keeps its data on the local filesystem at `localStorage.path` (default `/var/lib/milvus/data`). The storage plumbing already reads this — `milvus.storage.provider: local` with a `rootPath` pointing at the directory on disk resolves through the `LocalClient`, because every storage key is rebuilt from the configured root path rather than read back from etcd metadata. What was missing is the configuration and proof, so backing up a local-storage Milvus to MinIO was effectively undocumented and untested.

Part of #964

## Changes

- add `configs/backup-local-milvus.yaml`, a sample backing a local-storage Milvus up to MinIO
- add `deployment/standalone/docker-compose.local.yaml`, a compose override that runs the standalone with `COMMON_STORAGETYPE=local`
- add a CI job that backs a local-storage Milvus up to MinIO and restores it into a fresh MinIO-backed Milvus, verifying the data round-trips
- note the local provider in `configs/backup.yaml` and list the new sample in the README
