### PR TITLE
storage: support gcp and gcpnative providers in the snapshot path

### DIFF
--- a/internal/storage/snapshot.go
+++ b/internal/storage/snapshot.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -13,9 +14,10 @@ import (
 // do it: a uri naming the object, and an extfs spec authorizing access to it. Export and
 // restore describe the same store in opposite directions, so both build them from here.
 
-// SnapshotURI names key in cfg's bucket, in one of the two shapes Milvus parses:
+// SnapshotURI names key in cfg's bucket, in one of the shapes Milvus parses:
 // minio://<endpoint>/<bucket>/<key> puts the endpoint in the host, s3://<bucket>/<key> leaves
-// Milvus to derive it from cloud_provider and region.
+// Milvus to derive it from cloud_provider and region, and gcs://<bucket>/<key> names a native
+// GCS store, whose provider the scheme alone decides.
 //
 // The configured endpoint wins whenever there is one, because derivation only ever produces
 // the canonical public endpoint — wrong for a deployment reached over an internal or
@@ -27,6 +29,12 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 	}
 	if _, err := snapshotCloudProvider(cfg.Provider); err != nil {
 		return "", err
+	}
+
+	// Native GCS is reached through its own client, not an S3-compatible endpoint, so the
+	// scheme names it and neither endpoint nor region is needed. The bucket is global.
+	if cfg.Provider == v2.ProviderGCPNative {
+		return fmt.Sprintf("gcs://%s/%s", cfg.Bucket, key), nil
 	}
 
 	if host := endpointHost(cfg.Endpoint); host != "" {
@@ -72,6 +80,12 @@ func SnapshotExternalSpec(cfg Config) (string, error) {
 		if cfg.Credential.IAMEndpoint != "" {
 			extfs["iam_endpoint"] = cfg.Credential.IAMEndpoint
 		}
+	case GCPCredJSON:
+		data, err := os.ReadFile(cfg.Credential.GCPCredJSON)
+		if err != nil {
+			return "", fmt.Errorf("storage: read gcp credential file: %w", err)
+		}
+		extfs["credential_json"] = string(data)
 	default:
 		return "", fmt.Errorf("storage: snapshot external spec cannot carry %s credentials", cfg.Credential.Type)
 	}
@@ -101,6 +115,10 @@ func snapshotCloudProvider(provider string) (string, error) {
 		return "aliyun", nil
 	case v2.ProviderHwc:
 		return "huawei", nil
+	case v2.ProviderGCP:
+		return "gcp", nil
+	case v2.ProviderGCPNative:
+		return "gcpnative", nil
 	default:
 		return "", fmt.Errorf("storage: milvus snapshots do not support %s storage", provider)
 	}

--- a/internal/storage/snapshot_test.go
+++ b/internal/storage/snapshot_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +27,7 @@ func TestSnapshotURI(t *testing.T) {
 			{"Aliyun", v2.ProviderAliyun, "oss-cn-hangzhou.aliyuncs.com", "minio://oss-cn-hangzhou.aliyuncs.com/backup-bucket/backup/mybackup"},
 			{"Huawei", v2.ProviderHwc, "obs.cn-north-4.myhuaweicloud.com", "minio://obs.cn-north-4.myhuaweicloud.com/backup-bucket/backup/mybackup"},
 			{"AWS", v2.ProviderAWS, "s3.us-west-2.amazonaws.com", "minio://s3.us-west-2.amazonaws.com/backup-bucket/backup/mybackup"},
+			{"GCP", v2.ProviderGCP, "storage.googleapis.com", "minio://storage.googleapis.com/backup-bucket/backup/mybackup"},
 		}
 
 		for _, tt := range tests {
@@ -43,6 +46,24 @@ func TestSnapshotURI(t *testing.T) {
 		got, err := SnapshotURI(cfg, "backup/mybackup")
 		require.NoError(t, err)
 		assert.Equal(t, "s3://backup-bucket/backup/mybackup", got)
+	})
+
+	// GCP without an endpoint is an S3-family store, so Milvus derives the GCS endpoint
+	// from cloud_provider and region the same way it does for AWS.
+	t.Run("GCPNoEndpointUsesS3SchemeWithRegion", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderGCP, Bucket: "backup-bucket", Region: "us-west1"}
+		got, err := SnapshotURI(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup", got)
+	})
+
+	// Native GCS is not an S3-family store: the gcs:// scheme alone tells Milvus which
+	// client to build, so neither endpoint nor region is needed.
+	t.Run("GCPNativeUsesGcsScheme", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderGCPNative, Bucket: "backup-bucket"}
+		got, err := SnapshotURI(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "gcs://backup-bucket/backup/mybackup", got)
 	})
 
 	// Every provider Milvus can derive an endpoint for needs the region to do it, so
@@ -85,6 +106,38 @@ func TestSnapshotExternalSpec(t *testing.T) {
 		assert.JSONEq(t, `{"extfs":{"cloud_provider":"aws","iam_endpoint":"http://169.254.169.254","use_iam":"true","use_ssl":"false"}}`, spec)
 	})
 
+	// The GCP backup pod reaches GCS through workload identity, so the spec asks Milvus
+	// to do the same: cloud_provider gcp puts it in the S3 family, use_iam leaves it to
+	// the node's own credentials.
+	t.Run("GCPIAM", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderGCP,
+			Region:     "us-west1",
+			UseSSL:     true,
+			Credential: Credential{Type: IAM},
+		}
+
+		spec, err := SnapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"gcp","region":"us-west1","use_iam":"true","use_ssl":"true"}}`, spec)
+	})
+
+	// Native GCS is authorized with the service-account json itself, the same file the
+	// gcpnative client reads to talk to the bucket.
+	t.Run("GCPNativeServiceAccount", func(t *testing.T) {
+		saPath := filepath.Join(t.TempDir(), "service-account.json")
+		require.NoError(t, os.WriteFile(saPath, []byte(`{"type":"service_account","project_id":"snapshot-project"}`), 0o600))
+
+		cfg := Config{
+			Provider:   v2.ProviderGCPNative,
+			Credential: Credential{Type: GCPCredJSON, GCPCredJSON: saPath},
+		}
+
+		spec, err := SnapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"gcpnative","credential_json":"{\"type\":\"service_account\",\"project_id\":\"snapshot-project\"}","use_ssl":"false"}}`, spec)
+	})
+
 	// extfs has no session token field, so sending the key pair alone would fail to
 	// authorize with nothing pointing at the cause.
 	t.Run("RejectsSessionToken", func(t *testing.T) {
@@ -94,7 +147,7 @@ func TestSnapshotExternalSpec(t *testing.T) {
 	})
 
 	t.Run("RejectsUnsupportedCredential", func(t *testing.T) {
-		cfg := Config{Provider: v2.ProviderAWS, Credential: Credential{Type: GCPCredJSON}}
+		cfg := Config{Provider: v2.ProviderAWS, Credential: Credential{Type: MinioCredProvider}}
 		_, err := SnapshotExternalSpec(cfg)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
## Summary

Part of #1119: the snapshot export/restore path only mapped the s3-family providers, so any backup whose bucket is GCP storage was refused with `milvus snapshots do not support gcp storage` before any snapshot work started.

This wires the two GCP providers Milvus accepts in `extfs.cloud_provider`:

- `gcp` (S3-family, minio client against `storage.googleapis.com`) -> maps to `"gcp"`, authorized with `use_iam` (workload identity) or access key pair, matching how the backup pod is configured today.
- `gcpnative` (native GCS) -> maps to `"gcpnative"`, emits a `gcs://` uri (the scheme decides the provider family on the Milvus side), and carries the service-account json as `credential_json`.

## Changes

- `snapshotCloudProvider`: add `gcp` and `gcpnative` cases.
- `SnapshotURI`: emit `gcs://<bucket>/<key>` for native GCS.
- `SnapshotExternalSpec`: read the `GCPCredJSON` credential file and send it as `credential_json`.
- Tests for the new URI shapes and extfs specs.

## Notes

- Related to #1119
- Depends on the Milvus-side external snapshot export/restore flow (milvus-io/milvus#50978) being present on the server.
- Azure is wired in a companion PR.
