### PR TITLE
storage: support the azure provider in the snapshot path

### DIFF
--- a/internal/storage/snapshot.go
+++ b/internal/storage/snapshot.go
@@ -31,6 +31,16 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 		return "", err
 	}
 
+	// Azure names its service endpoint in the host and carries the account name in the
+	// extfs access_key_id, so the host is the blob. service endpoint, not the account one.
+	if cfg.Provider == v2.ProviderAzure {
+		host := endpointHost(cfg.Endpoint)
+		if host == "" {
+			return "", fmt.Errorf("storage: snapshot uri for azure needs an endpoint")
+		}
+		return fmt.Sprintf("azure://blob.%s/%s/%s", host, cfg.Bucket, key), nil
+	}
+
 	// Native GCS is reached through its own client, not an S3-compatible endpoint, so the
 	// scheme names it and neither endpoint nor region is needed. The bucket is global.
 	if cfg.Provider == v2.ProviderGCPNative {
@@ -115,6 +125,8 @@ func snapshotCloudProvider(provider string) (string, error) {
 		return "aliyun", nil
 	case v2.ProviderHwc:
 		return "huawei", nil
+	case v2.ProviderAzure:
+		return "azure", nil
 	case v2.ProviderGCP:
 		return "gcp", nil
 	case v2.ProviderGCPNative:

--- a/internal/storage/snapshot_test.go
+++ b/internal/storage/snapshot_test.go
@@ -74,10 +74,26 @@ func TestSnapshotURI(t *testing.T) {
 		assert.ErrorContains(t, err, "region")
 	})
 
-	t.Run("UnsupportedProvider", func(t *testing.T) {
-		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "acct.blob.core.windows.net"}
+	// Azure reaches its containers through the blob. service endpoint, which the tool
+	// config holds without the blob. prefix (its own client prepends it), so the snapshot
+	// uri restores the full service host and leaves the account name to the extfs.
+	t.Run("AzureUsesAzureScheme", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "core.windows.net:443"}
+		got, err := SnapshotURI(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "azure://blob.core.windows.net:443/backup-bucket/backup/mybackup", got)
+	})
+
+	t.Run("AzureNeedsAnEndpoint", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket"}
 		_, err := SnapshotURI(cfg, "backup/mybackup")
-		assert.ErrorContains(t, err, v2.ProviderAzure)
+		assert.ErrorContains(t, err, "endpoint")
+	})
+
+	t.Run("UnsupportedProvider", func(t *testing.T) {
+		cfg := Config{Provider: "madeup", Bucket: "backup-bucket", Endpoint: "acct.blob.core.windows.net"}
+		_, err := SnapshotURI(cfg, "backup/mybackup")
+		assert.ErrorContains(t, err, "madeup")
 	})
 }
 
@@ -104,6 +120,19 @@ func TestSnapshotExternalSpec(t *testing.T) {
 		spec, err := SnapshotExternalSpec(cfg)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"extfs":{"cloud_provider":"aws","iam_endpoint":"http://169.254.169.254","use_iam":"true","use_ssl":"false"}}`, spec)
+	})
+
+	// For azure the static key pair is the account name and the account key: Milvus
+	// reads access_key_id as the storage account, matching what the tool signs with.
+	t.Run("AzureAccountKey", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAzure,
+			Credential: Credential{Type: Static, AK: "azure-account", SK: "azure-key"},
+		}
+
+		spec, err := SnapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"azure","access_key_id":"azure-account","access_key_value":"azure-key","use_ssl":"false"}}`, spec)
 	})
 
 	// The GCP backup pod reaches GCS through workload identity, so the spec asks Milvus


### PR DESCRIPTION
## Summary

Part of #1119: the snapshot export/restore path refused azure storage with `milvus snapshots do not support azure storage` before any snapshot work started. This wires azure onto the value Milvus accepts in `extfs.cloud_provider` and names its service endpoint in the snapshot uri.

## Changes

- `snapshotCloudProvider`: map `azure` -> `"azure"`.
- `SnapshotURI`: emit `azure://blob.<endpoint>/<bucket>/<key>` — the storage account travels in the extfs `access_key_id` (the static key pair already maps `AK=accountName`, `SK=accountKey`), not in the host, matching how Milvus parses azure foreign URIs.
- Tests for the azure uri shapes and the account-key extfs spec.

## Notes

- Related to #1119
- Depends on the Milvus-side external snapshot export/restore flow (milvus-io/milvus#50978) being present on the server.
- Companion to #1139 (gcp/gcpnative support).
