### PR TITLE
restore: allow non-binding max_shard_num on snapshot restores

### DIFF
--- a/core/restore/coll_snapshot_task.go
+++ b/core/restore/coll_snapshot_task.go
@@ -24,8 +24,9 @@ type collSnapshotTask struct {
 	collBackup *backuppb.CollectionBackupInfo
 	targetNS   namespace.NS
 
-	source    snapshotSource
-	dropExist bool
+	source      snapshotSource
+	dropExist   bool
+	maxShardNum int32
 
 	pollInterval time.Duration
 
@@ -41,8 +42,9 @@ type collSnapshotTaskArgs struct {
 	collBackup *backuppb.CollectionBackupInfo
 	targetNS   namespace.NS
 
-	source    snapshotSource
-	dropExist bool
+	source      snapshotSource
+	dropExist   bool
+	maxShardNum int32
 
 	grpcCli milvus.Grpc
 	taskMgr *taskmgr.Mgr
@@ -66,8 +68,9 @@ func newCollSnapshotTask(args collSnapshotTaskArgs) *collSnapshotTask {
 		collBackup: args.collBackup,
 		targetNS:   args.targetNS,
 
-		source:    args.source,
-		dropExist: args.dropExist,
+		source:      args.source,
+		dropExist:   args.dropExist,
+		maxShardNum: args.maxShardNum,
 
 		pollInterval: _snapshotPollInterval,
 
@@ -100,6 +103,20 @@ func (ct *collSnapshotTask) Execute(ctx context.Context) error {
 
 func (ct *collSnapshotTask) privateExecute(ctx context.Context) error {
 	ct.logger.Info("start restore collection from snapshot")
+
+	// Milvus creates the collection from the schema in the bundle, so the shard count
+	// cannot be capped here. max_shard_num is only a bound: it changes nothing while it
+	// is not smaller than the bundle's shard count, so only a request that would actually
+	// cap shards is refused.
+	if ct.maxShardNum > 0 {
+		if shardNum := ct.collBackup.GetShardsNum(); shardNum > ct.maxShardNum {
+			return fmt.Errorf("restore: collection has %d shards, exceeding max_shard_num=%d; the snapshot path cannot cap the shard count",
+				shardNum, ct.maxShardNum)
+		}
+		ct.logger.Info("max_shard_num does not bind, keeping the bundle's shard count",
+			zap.Int32("shard_num", ct.collBackup.GetShardsNum()),
+			zap.Int32("max_shard_num", ct.maxShardNum))
+	}
 
 	metadataURI, err := ct.source.metadataURI(ct.collBackup.GetSnapshotBackup().GetMetadataPath())
 	if err != nil {

--- a/core/restore/coll_snapshot_task_test.go
+++ b/core/restore/coll_snapshot_task_test.go
@@ -128,4 +128,30 @@ func TestCollSnapshotTask_Execute(t *testing.T) {
 		task.collBackup.SnapshotBackup = nil
 		assert.Error(t, task.Execute(context.Background()))
 	})
+
+	// max_shard_num is a bound, not an exact value: a cap no smaller than the bundle's
+	// shard count changes nothing, so it is accepted and the restore proceeds.
+	t.Run("MaxShardNumSatisfied", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.collBackup.ShardsNum = 2
+		task.maxShardNum = 4
+		require.NoError(t, task.Execute(context.Background()))
+	})
+
+	// Milvus creates the collection from the bundle, so a cap that would actually bind
+	// cannot be honored: nothing is submitted and the collection is reported failed.
+	t.Run("MaxShardNumBinds", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.collBackup.ShardsNum = 8
+		task.maxShardNum = 4
+		err := task.Execute(context.Background())
+		assert.ErrorContains(t, err, "exceeding max_shard_num")
+	})
 }

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -234,9 +234,6 @@ func checkSnapshotSupport(plan *Plan, opt *Option) error {
 	if opt.MetaOnly {
 		unsupported = append(unsupported, "meta_only")
 	}
-	if opt.MaxShardNum != 0 {
-		unsupported = append(unsupported, "max_shard_num")
-	}
 	if opt.TruncateBinlogByTs {
 		unsupported = append(unsupported, "truncate_binlog_by_ts")
 	}
@@ -373,13 +370,14 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 
 		if t.format == meta.FormatSnapshot {
 			tasks = append(tasks, newCollSnapshotTask(collSnapshotTaskArgs{
-				taskID:     t.args.TaskID,
-				collBackup: collBackup,
-				targetNS:   targetNS,
-				source:     t.snapshotSource,
-				dropExist:  t.args.Option.DropExistCollection,
-				grpcCli:    t.grpc,
-				taskMgr:    t.args.TaskMgr,
+				taskID:      t.args.TaskID,
+				collBackup:  collBackup,
+				targetNS:    targetNS,
+				source:      t.snapshotSource,
+				dropExist:   t.args.Option.DropExistCollection,
+				maxShardNum: t.args.Option.MaxShardNum,
+				grpcCli:     t.grpc,
+				taskMgr:     t.args.TaskMgr,
 			}))
 			continue
 		}

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -87,7 +87,6 @@ func TestCheckSnapshotSupport(t *testing.T) {
 	}{
 		{"SkipCreateCollection", &Plan{}, &Option{SkipCreateCollection: true}},
 		{"MetaOnly", &Plan{}, &Option{MetaOnly: true}},
-		{"MaxShardNum", &Plan{}, &Option{MaxShardNum: 4}},
 		{"TruncateBinlogByTs", &Plan{}, &Option{TruncateBinlogByTs: true}},
 		{"EZKMapping", &Plan{}, &Option{EZKMapping: map[string]string{"old": "new"}}},
 		{"SkipParams", &Plan{}, &Option{SkipParams: SkipParams{IndexParams: []string{"nlist"}}}},


### PR DESCRIPTION
## Summary
Restoring a snapshot-format backup currently rejects the `max_shard_num` option outright, even when the requested cap is no smaller than the bundle's shard count and therefore changes nothing. This PR relaxes the check to be per-collection: `max_shard_num` is refused only when it would actually cap shards, which the snapshot path cannot do because Milvus creates the collection from the schema in the bundle.

## Changes
- `checkSnapshotSupport` no longer refuses `max_shard_num` for snapshot-format restores
- `collSnapshotTask` gains a per-collection check that fails the collection only when `max_shard_num` would bind, and logs an info line when the cap is accepted as a no-op
- tests cover both the satisfied-cap and the binding-cap paths

/kind improvement
