### PR TITLE
restore: support restoring into a local-storage milvus

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -268,13 +268,16 @@ jobs:
     # Milvus standalone with COMMON_STORAGETYPE=local keeps its data on the
     # local filesystem (localStorage.path, default /var/lib/milvus/data). This
     # job proves milvus-backup can read that directory directly and back it up
-    # to MinIO, then restores into a fresh MinIO-backed Milvus (issue #964).
+    # to MinIO, then restores it into a fresh Milvus backed by MinIO or by local
+    # storage, resolving the restore temp files at the directory the process
+    # sees in the local case (issue #964).
     name: Backup and restore local storage Milvus
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image_tag: [v2.5.20, 2.6-latest]
+        restore_target: [minio, local]
     steps:
       - uses: actions/checkout@v7
 
@@ -393,16 +396,25 @@ jobs:
           sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml down
           sudo rm -rf volumes
 
-      - name: Configure backup.yaml for MinIO target
+      - name: Configure backup.yaml for ${{ matrix.restore_target }} storage target
         timeout-minutes: 1
         shell: bash
         run: |
-          yq -i '.milvus.storage.provider = "minio"' configs/backup.yaml
-          yq -i '.milvus.storage.rootPath = "files"' configs/backup.yaml
-          yq -i '.milvus.storage.bucketName = "a-bucket"' configs/backup.yaml
+          if [ "${{ matrix.restore_target }}" = "local" ]; then
+            yq -i '.milvus.storage.provider = "local"' configs/backup.yaml
+            # Host directory backing the target Milvus localStorage.path, and the
+            # path the container process resolves it at.
+            yq -i '.milvus.storage.rootPath = "deployment/standalone/volumes/milvus/data"' configs/backup.yaml
+            yq -i '.milvus.storage.localPath = "/var/lib/milvus/data"' configs/backup.yaml
+            yq -i '.milvus.storage.bucketName = ""' configs/backup.yaml
+          else
+            yq -i '.milvus.storage.provider = "minio"' configs/backup.yaml
+            yq -i '.milvus.storage.rootPath = "files"' configs/backup.yaml
+            yq -i '.milvus.storage.bucketName = "a-bucket"' configs/backup.yaml
+          fi
           cat configs/backup.yaml
 
-      - name: Deploy target Milvus with MinIO storage
+      - name: Deploy target Milvus with ${{ matrix.restore_target }} storage
         timeout-minutes: 15
         shell: bash
         working-directory: deployment/standalone
@@ -411,8 +423,23 @@ jobs:
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
           mkdir -p volumes/etcd volumes/minio volumes/milvus
           sudo chmod -R 777 volumes
-          sudo docker compose -f docker-compose.yml up -d --wait
-          sudo docker compose -f docker-compose.yml ps -a
+          if [ "${{ matrix.restore_target }}" = "local" ]; then
+            sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml up -d --wait
+            sudo docker compose -f docker-compose.yml -f docker-compose.local.yaml ps -a
+          else
+            sudo docker compose -f docker-compose.yml up -d --wait
+            sudo docker compose -f docker-compose.yml ps -a
+          fi
+
+      - name: Fix permissions for restore
+        if: matrix.restore_target == 'local'
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          # The container initializes its storage directory as root; the restore
+          # binary runs as the runner user and must write restore temp files
+          # into the same directory for the container to import.
+          sudo chmod -R 777 volumes
 
       - name: Copy Backup to target MinIO
         timeout-minutes: 5

--- a/configs/backup-local-milvus.yaml
+++ b/configs/backup-local-milvus.yaml
@@ -32,6 +32,11 @@ milvus:
     rootPath: "/var/lib/milvus/data"
     bucketName: ""
 
+    # Optional: the path the Milvus process itself sees as localStorage.path,
+    # for when it differs from rootPath — e.g. a container bind-mount. Restore
+    # resolves its import paths against it. Empty means the same as rootPath.
+    # localPath: "/var/lib/milvus/data"
+
 backup:
   storage:
     provider: minio

--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -62,8 +62,10 @@ milvus:
     # aliyun, tencent, hwc.
     # local is Milvus standalone with COMMON_STORAGETYPE=local: there is no
     # bucket or endpoint, and rootPath is the directory backing Milvus
-    # localStorage.path as milvus-backup sees it on disk. See
-    # configs/backup-local-milvus.yaml for a complete example.
+    # localStorage.path as milvus-backup sees it on disk. Optional localPath is
+    # the path the Milvus process itself resolves (for a container bind-mount);
+    # restore import paths use it. See configs/backup-local-milvus.yaml for a
+    # complete example.
     provider: "minio"
     address: localhost
     port: 9000

--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
@@ -61,6 +62,13 @@ type collTask struct {
 
 	milvusStorage storage.Client
 
+	// milvusRootPath is where milvus-backup reaches the target's local storage
+	// directory (milvus.storage.rootPath), and milvusLocalPath is what the Milvus
+	// process itself resolves (milvus.storage.localPath, falling back to rootPath).
+	// Both empty unless the target storage provider is local.
+	milvusRootPath  string
+	milvusLocalPath string
+
 	grpcCli    milvus.Grpc
 	restfulCli milvus.Restful
 
@@ -98,6 +106,9 @@ type collTaskArgs struct {
 
 	backupStorage storage.Client
 	milvusStorage storage.Client
+
+	milvusRootPath  string
+	milvusLocalPath string
 
 	copySem       *semaphore.Weighted
 	bulkInsertSem *semaphore.Weighted
@@ -144,6 +155,9 @@ func newCollTask(args collTaskArgs) *collTask {
 		backupStorage: args.backupStorage,
 		milvusStorage: args.milvusStorage,
 
+		milvusRootPath:  args.milvusRootPath,
+		milvusLocalPath: args.milvusLocalPath,
+
 		grpcCli:    args.grpcCli,
 		restfulCli: args.restfulCli,
 
@@ -159,6 +173,51 @@ func newCollTask(args collTaskArgs) *collTask {
 }
 
 func (ct *collTask) TargetNS() namespace.NS { return ct.targetNS }
+
+// isLocal reports whether the restore target keeps its data on the local
+// filesystem, where LocalClient keys are absolute paths and bulk insert paths
+// must be what the Milvus LocalChunkManager resolves directly.
+func (ct *collTask) isLocal() bool {
+	return ct.milvusStorage.Config().Provider == v2.ProviderLocal
+}
+
+// destKey maps a bucket-relative restore key onto the key LocalClient reads and
+// writes. A local target resolves keys against the directory milvus-backup
+// reaches the target's storage at (milvus.storage.rootPath); any other provider
+// keeps the bucket-relative key as-is. A trailing slash is preserved: the copy
+// task maps each object by replacing the source prefix with this key.
+func (ct *collTask) destKey(key string) string {
+	if !ct.isLocal() || key == "" {
+		return key
+	}
+	return joinLocal(ct.milvusRootPath, key)
+}
+
+// importPath maps a bucket-relative restore key onto the path handed to the
+// bulk insert API. A local target needs the path the Milvus process resolves
+// (milvus.storage.localPath, falling back to rootPath), with a trailing slash
+// kept because the LocalChunkManager lists a prefix by globbing it directly;
+// paths already absolute are left alone so a same-directory local backup can be
+// imported without a copy. Any other provider keeps the bucket-relative path
+// as-is.
+func (ct *collTask) importPath(p string) string {
+	if !ct.isLocal() || p == "" {
+		return p
+	}
+	if path.IsAbs(p) {
+		return p
+	}
+	return joinLocal(ct.milvusLocalPath, p)
+}
+
+// joinLocal prefixes p with base, keeping p's trailing slash and avoiding a
+// doubled separator. base is empty only when a config omitted the directory.
+func joinLocal(base, p string) string {
+	if base == "" {
+		return p
+	}
+	return strings.TrimSuffix(base, "/") + "/" + p
+}
 
 func (ct *collTask) Execute(ctx context.Context) error {
 	ct.taskMgr.UpdateRestoreTask(ct.taskID, taskmgr.SetRestoreCollExecuting(ct.targetNS))
@@ -312,7 +371,7 @@ func (ct *collTask) cleanTempFiles(dir string) tearDownFn {
 		}
 
 		ct.logger.Info("delete temporary file", zap.String("dir", dir))
-		if err := storage.DeletePrefix(ctx, ct.milvusStorage, dir); err != nil {
+		if err := storage.DeletePrefix(ctx, ct.milvusStorage, ct.destKey(dir)); err != nil {
 			return fmt.Errorf("restore_collection: failed to delete temporary file: %w", err)
 		}
 
@@ -323,30 +382,31 @@ func (ct *collTask) cleanTempFiles(dir string) tearDownFn {
 func (ct *collTask) copyToMilvusBucket(ctx context.Context, tempDir, srcPrefix string) (string, error) {
 	ct.logger.Info("milvus and backup store in different bucket, copy the data first", zap.String("temp_dir", tempDir))
 	dest := path.Join(tempDir, strings.Replace(srcPrefix, ct.backupDir, "", 1)) + "/"
+	destKey := ct.destKey(dest)
 	opt := storage.CopyPrefixOpt{
 		Sem:        ct.copySem,
 		Src:        ct.backupStorage,
 		Dest:       ct.milvusStorage,
 		SrcPrefix:  srcPrefix,
-		DestPrefix: dest,
+		DestPrefix: destKey,
 		Streaming:  true,
 	}
 
-	ct.logger.Info("copy temporary restore file", zap.String("src", srcPrefix), zap.String("dest", dest))
+	ct.logger.Info("copy temporary restore file", zap.String("src", srcPrefix), zap.String("dest", destKey))
 	task := storage.NewCopyPrefixTask(opt)
 	if err := task.Execute(ctx); err != nil {
 		return "", fmt.Errorf("restore_collection: copy temporary restore file: %w", err)
 	}
 
-	expected, err := storage.ExpectedDestObjects(ctx, ct.backupStorage, srcPrefix, dest)
+	expected, err := storage.ExpectedDestObjects(ctx, ct.backupStorage, srcPrefix, destKey)
 	if err != nil {
 		return "", fmt.Errorf("restore_collection: build expected for copy verify: %w", err)
 	}
-	verifyTask := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{Cli: ct.milvusStorage, Prefix: dest, Expected: expected})
+	verifyTask := storage.NewVerifyPrefixTask(storage.VerifyPrefixOpt{Cli: ct.milvusStorage, Prefix: destKey, Expected: expected})
 	if err := verifyTask.Execute(ctx); err != nil {
 		return "", fmt.Errorf("restore_collection: verify temporary restore file: %w", err)
 	}
-	ct.logger.Info("copy temporary restore file success", zap.String("src", srcPrefix), zap.String("dest", dest))
+	ct.logger.Info("copy temporary restore file success", zap.String("src", srcPrefix), zap.String("dest", destKey))
 
 	return dest, nil
 }
@@ -408,22 +468,28 @@ func (ct *collTask) restoreNotL0SegV1(ctx context.Context, part *backuppb.Partit
 	return nil
 }
 
-func toPaths(dir partitionDir) []string {
+// toPaths builds the [insertLogDir, deltaLogDir] argument for the restful bulk
+// insert API, mapping each directory through the target storage's path
+// convention (absolute paths under localPath for a local target).
+func (ct *collTask) toPaths(dir partitionDir) []string {
 	paths := make([]string, 0, 2)
 	if dir.insertLogDir != "" {
-		paths = append(paths, dir.insertLogDir)
+		paths = append(paths, ct.importPath(dir.insertLogDir))
 	}
 	if dir.deltaLogDir != "" {
-		paths = append(paths, dir.deltaLogDir)
+		paths = append(paths, ct.importPath(dir.deltaLogDir))
 	}
 	return paths
 }
 
-func toGrpcPaths(dir partitionDir) []string {
+// toGrpcPaths builds the [insertLogDir, deltaLogDir] argument for the grpc bulk
+// insert API, mapping each directory through the target storage's path
+// convention (absolute paths under localPath for a local target).
+func (ct *collTask) toGrpcPaths(dir partitionDir) []string {
 	if len(dir.insertLogDir) == 0 {
-		return []string{dir.deltaLogDir}
+		return []string{ct.importPath(dir.deltaLogDir)}
 	}
-	return []string{dir.insertLogDir, dir.deltaLogDir}
+	return []string{ct.importPath(dir.insertLogDir), ct.importPath(dir.deltaLogDir)}
 }
 
 func (ct *collTask) restoreNotL0SegV2(ctx context.Context, part *backuppb.PartitionBackupInfo) error {
@@ -770,7 +836,7 @@ func (ct *collTask) bulkInsertViaGrpc(ctx context.Context, partitionName string,
 		g.Go(func() error {
 			defer ct.bulkInsertSem.Release(1)
 
-			paths := toGrpcPaths(dir)
+			paths := ct.toGrpcPaths(dir)
 			ct.logger.Info("start bulk insert via grpc", zap.Strings("paths", paths), zap.String("partition", partitionName))
 			in := milvus.GrpcBulkInsertInput{
 				DB:             ct.targetNS.DBName(),
@@ -842,7 +908,7 @@ func (ct *collTask) checkBulkInsertViaRestful(ctx context.Context, jobID string)
 
 func (ct *collTask) bulkInsertViaRestful(ctx context.Context, partition string, b batch) error {
 	ct.logger.Info("start bulk insert via restful", zap.Int("batch_num", len(b.partitionDirs)), zap.String("partition", partition))
-	paths := lo.Map(b.partitionDirs, func(dir partitionDir, _ int) []string { return toPaths(dir) })
+	paths := lo.Map(b.partitionDirs, func(dir partitionDir, _ int) []string { return ct.toPaths(dir) })
 	in := milvus.BulkInsertV2Input{
 		DB:             ct.targetNS.DBName(),
 		CollectionName: ct.targetNS.CollName(),

--- a/core/restore/coll_task_test.go
+++ b/core/restore/coll_task_test.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -10,11 +11,25 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+	"github.com/zilliztech/milvus-backup/internal/storage"
 )
 
 func newTestCollTask() *collTask {
 	return &collTask{logger: zap.NewNop(), option: &Option{}, maxSegsPerImportJob: 256}
+}
+
+// newTestStorageClient builds a storage client of the given provider without
+// touching any backend: constructing a client never connects.
+func newTestStorageClient(t *testing.T, provider string) storage.Client {
+	cli, err := storage.NewClient(context.Background(), storage.Config{
+		Provider:   provider,
+		Endpoint:   "localhost:9000",
+		Credential: storage.Credential{Type: storage.Static, AK: "a", SK: "b"},
+	})
+	require.NoError(t, err)
+	return cli
 }
 
 func TestGetFailedReason(t *testing.T) {
@@ -75,42 +90,73 @@ func TestCollTask_ezk(t *testing.T) {
 }
 
 func TestToPaths(t *testing.T) {
+	// a non-local target keeps the bucket-relative paths as-is
+	ct := &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderMinio)}
+
 	// normal
 	dir := partitionDir{insertLogDir: "insert", deltaLogDir: "delta"}
-	paths := toPaths(dir)
-	assert.Equal(t, []string{"insert", "delta"}, paths)
+	assert.Equal(t, []string{"insert", "delta"}, ct.toPaths(dir))
 
 	// without delta
 	dir = partitionDir{insertLogDir: "insert"}
-	paths = toPaths(dir)
-	assert.Equal(t, []string{"insert"}, paths)
+	assert.Equal(t, []string{"insert"}, ct.toPaths(dir))
 
 	// without insert
 	dir = partitionDir{deltaLogDir: "delta"}
-	paths = toPaths(dir)
-	assert.Equal(t, []string{"delta"}, paths)
+	assert.Equal(t, []string{"delta"}, ct.toPaths(dir))
 
 	// empty
 	dir = partitionDir{}
-	paths = toPaths(dir)
-	assert.Empty(t, paths)
+	assert.Empty(t, ct.toPaths(dir))
+
+	// a local target resolves import paths against the path Milvus sees
+	ct = &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderLocal), milvusLocalPath: "/var/lib/milvus/data"}
+	dir = partitionDir{insertLogDir: "insert", deltaLogDir: "delta"}
+	assert.Equal(t, []string{"/var/lib/milvus/data/insert", "/var/lib/milvus/data/delta"}, ct.toPaths(dir))
+
+	// paths already absolute are left alone (a same-directory local backup)
+	dir = partitionDir{insertLogDir: "/data/insert"}
+	assert.Equal(t, []string{"/data/insert"}, ct.toPaths(dir))
+
+	// a trailing slash is kept: the LocalChunkManager globs the prefix
+	dir = partitionDir{insertLogDir: "insert/"}
+	assert.Equal(t, []string{"/var/lib/milvus/data/insert/"}, ct.toPaths(dir))
 }
 
 func TestToGrpcPaths(t *testing.T) {
+	// a non-local target keeps the bucket-relative paths as-is
+	ct := &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderMinio)}
+
 	// normal
 	dir := partitionDir{insertLogDir: "insert", deltaLogDir: "delta"}
-	paths := toGrpcPaths(dir)
-	assert.Equal(t, []string{"insert", "delta"}, paths)
+	assert.Equal(t, []string{"insert", "delta"}, ct.toGrpcPaths(dir))
 
 	// without delta
 	dir = partitionDir{insertLogDir: "insert"}
-	paths = toGrpcPaths(dir)
-	assert.Equal(t, []string{"insert", ""}, paths)
+	assert.Equal(t, []string{"insert", ""}, ct.toGrpcPaths(dir))
 
 	// without insert
 	dir = partitionDir{deltaLogDir: "delta"}
-	paths = toGrpcPaths(dir)
-	assert.Equal(t, []string{"delta"}, paths)
+	assert.Equal(t, []string{"delta"}, ct.toGrpcPaths(dir))
+
+	// a local target resolves import paths against the path Milvus sees
+	ct = &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderLocal), milvusLocalPath: "/var/lib/milvus/data"}
+	dir = partitionDir{insertLogDir: "insert", deltaLogDir: "delta"}
+	assert.Equal(t, []string{"/var/lib/milvus/data/insert", "/var/lib/milvus/data/delta"}, ct.toGrpcPaths(dir))
+}
+
+func TestCollTask_destKey(t *testing.T) {
+	// a non-local target keeps the key as-is
+	ct := &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderMinio)}
+	assert.Equal(t, "restore-temp-1/", ct.destKey("restore-temp-1/"))
+
+	// a local target resolves against the directory milvus-backup writes to,
+	// keeping the key's trailing slash for the prefix replacement on copy
+	ct = &collTask{milvusStorage: newTestStorageClient(t, v2.ProviderLocal), milvusRootPath: "/data"}
+	assert.Equal(t, "/data/restore-temp-1/", ct.destKey("restore-temp-1/"))
+	assert.Equal(t, "/data/insert", ct.destKey("insert"))
+
+	assert.Equal(t, "", ct.destKey(""))
 }
 
 func TestL0SegmentBatches(t *testing.T) {

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -364,6 +364,14 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 	sourceNS := namespace.New(collBackup.GetDbName(), collBackup.GetCollectionName())
 	targetNSes := t.args.Plan.CollMapper.TagetNS(sourceNS)
 
+	// A local target resolves its storage directory two ways: the path
+	// milvus-backup reaches it at (rootPath) and the path the Milvus process
+	// itself resolves (localPath, falling back to rootPath).
+	milvusLocalPath := t.args.Params.Milvus.Storage.LocalPath.Val
+	if milvusLocalPath == "" {
+		milvusLocalPath = t.args.Params.Milvus.Storage.RootPath.Val
+	}
+
 	tasks := make([]collectionTask, 0, len(targetNSes))
 	for _, targetNS := range targetNSes {
 		t.logger.Debug("generate restore collection task", zap.String("source", sourceNS.String()), zap.String("target", targetNS.String()))
@@ -395,6 +403,10 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 			backupDir:     t.args.BackupDir,
 			backupStorage: t.args.BackupStorage,
 			milvusStorage: t.args.MilvusStorage,
+
+			milvusRootPath:  t.args.Params.Milvus.Storage.RootPath.Val,
+			milvusLocalPath: milvusLocalPath,
+
 			copySem:       t.copySem,
 			bulkInsertSem: t.bulkInsertSem,
 			grpcCli:       t.grpc,

--- a/internal/cfg/v2/render.go
+++ b/internal/cfg/v2/render.go
@@ -92,6 +92,10 @@ func (c *StorageConfig) inapplicableKeys() []string {
 	if c.Provider.Val != ProviderAzure {
 		skip = append(skip, c.AccountName.Keys...)
 	}
+	// localPath belongs to local storage and nothing else.
+	if c.Provider.Val != ProviderLocal {
+		skip = append(skip, c.LocalPath.Keys...)
+	}
 	for _, cred := range []*param.Value[string]{
 		&c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken,
 		&c.Auth.AccountKey, &c.Auth.CredentialsFile, &c.Auth.Endpoint,

--- a/internal/cfg/v2/storage.go
+++ b/internal/cfg/v2/storage.go
@@ -44,6 +44,13 @@ type StorageConfig struct {
 	BucketName param.Value[string]
 	RootPath   param.Value[string]
 
+	// LocalPath is the path the Milvus process itself sees as its
+	// localStorage.path, for the local provider. milvus-backup writes to
+	// rootPath (the host view of the same directory); when the two differ, such
+	// as a container bind-mount, the import paths handed to Milvus must use the
+	// path Milvus resolves. Empty means the same as rootPath.
+	LocalPath param.Value[string]
+
 	Auth StorageAuthConfig
 }
 
@@ -68,6 +75,7 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 
 		BucketName: param.Value[string]{Default: "a-bucket", Keys: key("bucketName")},
 		RootPath:   param.Value[string]{Default: "files", Keys: key("rootPath")},
+		LocalPath:  param.Value[string]{Default: "", Keys: key("localPath")},
 
 		Auth: StorageAuthConfig{
 			Type: param.Value[string]{Default: AuthStatic, Keys: key("auth.type")},
@@ -113,7 +121,7 @@ func (c *StorageConfig) Resolve(s *param.Source) error {
 	return param.Resolve(s,
 		&c.Provider,
 		&c.Address, &c.Port, &c.Region, &c.UseSSL,
-		&c.AccountName, &c.BucketName, &c.RootPath,
+		&c.AccountName, &c.BucketName, &c.RootPath, &c.LocalPath,
 		&c.Auth.Type,
 		&c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken,
 		&c.Auth.AccountKey,

--- a/internal/cfg/v2/validate.go
+++ b/internal/cfg/v2/validate.go
@@ -125,6 +125,13 @@ func (c *StorageConfig) validate() error {
 			keyOf(&c.AccountName), keyOf(&c.Provider), provider))
 	}
 
+	// localPath names the directory Milvus resolves against, which only exists
+	// for local storage; anywhere else it is a mistake, not a hint.
+	if !c.LocalPath.IsDefault() {
+		errs = append(errs, fmt.Errorf("cfg: %s only applies to the local provider, but %s is %q",
+			keyOf(&c.LocalPath), keyOf(&c.Provider), provider))
+	}
+
 	errs = append(errs, c.Auth.validate(provider))
 
 	return errors.Join(errs...)

--- a/internal/cfg/v2/validate_test.go
+++ b/internal/cfg/v2/validate_test.go
@@ -29,6 +29,11 @@ func TestValidate_Storage(t *testing.T) {
 			wantErr: "milvus.storage.accountName only applies to the azure provider",
 		},
 		{
+			name:    "LocalPathOnlyAppliesToLocal",
+			yaml:    "milvus:\n  storage:\n    provider: s3\n    localPath: /data\n",
+			wantErr: "milvus.storage.localPath only applies to the local provider",
+		},
+		{
 			name:    "AzureRejectsStaticAuth",
 			yaml:    "milvus:\n  storage:\n    provider: azure\n    accountName: account\n    auth:\n      type: static\n",
 			wantErr: `milvus.storage.auth.type: invalid value "static", want one of: sharedKey, default`,
@@ -86,6 +91,8 @@ func TestValidate_StorageAcceptsProviderShapes(t *testing.T) {
 		{name: "IAMWithEndpoint", yaml: "milvus:\n  storage:\n    provider: minio\n    auth:\n      type: iam\n      endpoint: http://iam:8080\n"},
 		// Local storage is a directory: no endpoint, no credentials.
 		{name: "Local", yaml: "backup:\n  storage:\n    provider: local\n    rootPath: /data/backup\n"},
+		// localPath is the optional Milvus-view of the same directory.
+		{name: "LocalWithLocalPath", yaml: "milvus:\n  storage:\n    provider: local\n    rootPath: /data\n    localPath: /var/lib/milvus/data\n"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Related to #964

Milvus standalone with `COMMON_STORAGETYPE=local` keeps its data on the local filesystem (`localStorage.path`). Backing one up and restoring into a remote-backed Milvus works (see #1138); restoring into a **local-storage target** did not: restore wrote its temp files under a bucket-relative key (the `LocalClient` treats keys as absolute paths, so they landed in the tool's working directory) and handed Milvus bucket-relative import paths that its `LocalChunkManager` cannot resolve (it globs the path directly and never prepends its own root).

This adds the optional `milvus.storage.localPath` config — the path the Milvus process resolves its `localStorage.path` at when it differs from `rootPath`, e.g. a container bind-mount — and makes restore local-aware: temp files are written under `rootPath`, and the import paths passed to Milvus are absolute under `localPath` (trailing slash kept, since the local chunk manager lists a prefix by globbing it).

## Changes
- cfg: add optional `milvus.storage.localPath`, rejected for non-local providers
- restore: detect a local target and resolve restore temp keys (`rootPath`) and bulk-insert paths (`localPath`) against the local directory
- CI: the local-storage job now restores into a second local-storage Milvus instead of a MinIO-backed one
- configs: document `localPath` in the local storage samples