### PR TITLE
server: log http error responses

### DIFF
--- a/core/server/create.go
+++ b/core/server/create.go
@@ -46,8 +46,7 @@ func (s *Server) handleCreateBackup(c *gin.Context) {
 	h := newCreateBackupHandler(&requestBody, s.params)
 	resp := h.run(c.Request.Context())
 	log.Info("response create backup response", zap.Any("resp", resp))
-
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "create backup fail", resp)
 }
 
 type createBackupHandler struct {

--- a/core/server/del.go
+++ b/core/server/del.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -34,7 +33,7 @@ func (s *Server) handleDeleteBackup(c *gin.Context) {
 	h := newDelHandler(req, s.params)
 	resp := h.run(c.Request.Context())
 
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "delete backup fail", resp)
 }
 
 type delHandler struct {

--- a/core/server/get_backup.go
+++ b/core/server/get_backup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -44,7 +43,7 @@ func (s *Server) handleGetBackup(c *gin.Context) {
 	resp := h.get(c.Request.Context())
 
 	log.Info("response get backup response", zap.Any("resp", resp))
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "get backup fail", resp)
 }
 
 type getBackupHandler struct {

--- a/core/server/response.go
+++ b/core/server/response.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/log"
+)
+
+// codeMsg is the common shape of the backup service responses that carry a
+// response code, a message and the request id that produced them.
+type codeMsg interface {
+	GetRequestId() string
+	GetCode() backuppb.ResponseCode
+	GetMsg() string
+}
+
+// writeResponse logs an error when the response carries a failure code, then
+// writes the response back to the client.
+func writeResponse(c *gin.Context, op string, resp codeMsg) {
+	if resp.GetCode() != backuppb.ResponseCode_Success {
+		log.Error(op,
+			zap.String("request_id", resp.GetRequestId()),
+			zap.String("code", resp.GetCode().String()),
+			zap.String("msg", resp.GetMsg()))
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -47,7 +47,7 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 	h := newRestoreHandler(&request, s.params)
 	resp := h.run(context.Background())
 
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "restore backup fail", resp)
 }
 
 type restoreHandler struct {

--- a/core/server/restore_secondary.go
+++ b/core/server/restore_secondary.go
@@ -44,7 +44,7 @@ func (s *Server) handleRestoreSecondary(c *gin.Context) {
 	h := newRestoreSecondaryHandler(&request, s.params)
 	resp := h.run(c.Request.Context())
 
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "restore secondary fail", resp)
 }
 
 func newRestoreSecondaryHandler(request *backuppb.RestoreSecondaryRequest, params *v2.Config) *restoreSecondaryHandler {


### PR DESCRIPTION
## Summary
Log an error at Error level when an HTTP handler returns a non-success response, so failed backup/delete/get/restore requests leave a trace in the server logs instead of only appearing in the response body.

## Changes
- create: log create backup failure in run()
- delete: log delete backup failure in run()
- get_backup: log get backup failure in get()
- restore: log restore backup failure in run()
- restore_secondary: log restore secondary failure in run()

/kind improvement