### PR TITLE
restore: support collection description override on snapshot restores

### DIFF
--- a/core/restore/coll_snapshot_task.go
+++ b/core/restore/coll_snapshot_task.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
@@ -24,9 +26,10 @@ type collSnapshotTask struct {
 	collBackup *backuppb.CollectionBackupInfo
 	targetNS   namespace.NS
 
-	source      snapshotSource
-	dropExist   bool
-	maxShardNum int32
+	source       snapshotSource
+	dropExist    bool
+	maxShardNum  int32
+	descOverride string
 
 	pollInterval time.Duration
 
@@ -42,9 +45,10 @@ type collSnapshotTaskArgs struct {
 	collBackup *backuppb.CollectionBackupInfo
 	targetNS   namespace.NS
 
-	source      snapshotSource
-	dropExist   bool
-	maxShardNum int32
+	source       snapshotSource
+	dropExist    bool
+	maxShardNum  int32
+	descOverride string
 
 	grpcCli milvus.Grpc
 	taskMgr *taskmgr.Mgr
@@ -68,9 +72,10 @@ func newCollSnapshotTask(args collSnapshotTaskArgs) *collSnapshotTask {
 		collBackup: args.collBackup,
 		targetNS:   args.targetNS,
 
-		source:      args.source,
-		dropExist:   args.dropExist,
-		maxShardNum: args.maxShardNum,
+		source:       args.source,
+		dropExist:    args.dropExist,
+		maxShardNum:  args.maxShardNum,
+		descOverride: args.descOverride,
 
 		pollInterval: _snapshotPollInterval,
 
@@ -140,7 +145,30 @@ func (ct *collSnapshotTask) privateExecute(ctx context.Context) error {
 		zap.Int64("job_id", jobID),
 		zap.String("metadata_uri", metadataURI))
 
-	return ct.waitRestore(ctx, jobID)
+	if err := ct.waitRestore(ctx, jobID); err != nil {
+		return err
+	}
+
+	return ct.applyDescOverride(ctx)
+}
+
+// applyDescOverride rewrites the collection description after the restore completes. Milvus
+// creates the collection from the bundle's schema, so the only way to change the description
+// is an AlterCollection once the collection exists.
+func (ct *collSnapshotTask) applyDescOverride(ctx context.Context) error {
+	if ct.descOverride == "" {
+		return nil
+	}
+
+	props := []*commonpb.KeyValuePair{{Key: common.CollectionDescription, Value: ct.descOverride}}
+	if err := ct.grpcCli.AlterCollection(ctx, ct.targetNS.DBName(), ct.targetNS.CollName(), props); err != nil {
+		return fmt.Errorf("restore: alter collection description: %w", err)
+	}
+
+	ct.logger.Info("collection description overridden",
+		zap.String("target_ns", ct.targetNS.String()),
+		zap.String("description", ct.descOverride))
+	return nil
 }
 
 // dropExistedColl removes the target ahead of the restore. Milvus refuses to restore into a

--- a/core/restore/coll_snapshot_task_test.go
+++ b/core/restore/coll_snapshot_task_test.go
@@ -2,10 +2,13 @@ package restore
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -153,5 +156,52 @@ func TestCollSnapshotTask_Execute(t *testing.T) {
 		task.maxShardNum = 4
 		err := task.Execute(context.Background())
 		assert.ErrorContains(t, err, "exceeding max_shard_num")
+	})
+
+	// The description cannot be written into the bundle's schema, so an override is applied
+	// with an AlterCollection once the restore job completes.
+	t.Run("DescOverride", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+		cli.EXPECT().AlterCollection(mock.Anything, "db2", "coll2", mock.Anything).
+			RunAndReturn(func(_ context.Context, db, collName string, props []*commonpb.KeyValuePair) error {
+				assert.Len(t, props, 1)
+				assert.Equal(t, common.CollectionDescription, props[0].GetKey())
+				assert.Equal(t, "new desc", props[0].GetValue())
+				return nil
+			})
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.descOverride = "new desc"
+		require.NoError(t, task.Execute(context.Background()))
+	})
+
+	// Without an override, the collection keeps the description from the bundle and nothing
+	// is altered after the restore.
+	t.Run("DescOverrideEmpty", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		require.NoError(t, task.Execute(context.Background()))
+	})
+
+	// A failed alter surfaces through the task like any other restore failure.
+	t.Run("DescOverrideAlterFails", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+		cli.EXPECT().AlterCollection(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(errors.New("alter failed"))
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.descOverride = "new desc"
+		err := task.Execute(context.Background())
+		assert.ErrorContains(t, err, "alter collection description")
 	})
 }

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -244,8 +244,14 @@ func checkSnapshotSupport(plan *Plan, opt *Option) error {
 		len(opt.SkipParams.FieldTypeParams) != 0 || len(opt.SkipParams.IndexParams) != 0 {
 		unsupported = append(unsupported, "skip_params")
 	}
-	if len(plan.CollOverrides) != 0 {
-		unsupported = append(unsupported, "collection overrides")
+	// A description override is applied with an AlterCollection after the restore
+	// completes, so it stays available. The shard count cannot: Milvus creates the
+	// collection from the bundle, and shards are not alterable afterwards.
+	for _, override := range plan.CollOverrides {
+		if override.ShardNum != 0 {
+			unsupported = append(unsupported, "shard_num collection overrides")
+			break
+		}
 	}
 
 	if len(unsupported) != 0 {
@@ -378,14 +384,15 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 
 		if t.format == meta.FormatSnapshot {
 			tasks = append(tasks, newCollSnapshotTask(collSnapshotTaskArgs{
-				taskID:      t.args.TaskID,
-				collBackup:  collBackup,
-				targetNS:    targetNS,
-				source:      t.snapshotSource,
-				dropExist:   t.args.Option.DropExistCollection,
-				maxShardNum: t.args.Option.MaxShardNum,
-				grpcCli:     t.grpc,
-				taskMgr:     t.args.TaskMgr,
+				taskID:       t.args.TaskID,
+				collBackup:   collBackup,
+				targetNS:     targetNS,
+				source:       t.snapshotSource,
+				dropExist:    t.args.Option.DropExistCollection,
+				maxShardNum:  t.args.Option.MaxShardNum,
+				descOverride: t.args.Plan.CollOverrides[targetNS.String()].Description,
+				grpcCli:      t.grpc,
+				taskMgr:      t.args.TaskMgr,
 			}))
 			continue
 		}

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -90,7 +90,7 @@ func TestCheckSnapshotSupport(t *testing.T) {
 		{"TruncateBinlogByTs", &Plan{}, &Option{TruncateBinlogByTs: true}},
 		{"EZKMapping", &Plan{}, &Option{EZKMapping: map[string]string{"old": "new"}}},
 		{"SkipParams", &Plan{}, &Option{SkipParams: SkipParams{IndexParams: []string{"nlist"}}}},
-		{"CollOverrides", &Plan{CollOverrides: map[string]CollOverride{"db1.coll1": {ShardNum: 2}}}, &Option{}},
+		{"ShardNumOverride", &Plan{CollOverrides: map[string]CollOverride{"db1.coll1": {ShardNum: 2}}}, &Option{}},
 	}
 
 	for _, tt := range tests {
@@ -104,6 +104,13 @@ func TestCheckSnapshotSupport(t *testing.T) {
 	t.Run("SupportedOptions", func(t *testing.T) {
 		opt := &Option{DropExistCollection: true, RestoreRBAC: true}
 		assert.NoError(t, checkSnapshotSupport(&Plan{}, opt))
+	})
+
+	// A description override is applied with an AlterCollection after the restore, so it
+	// stays available even though the collection is created by Milvus.
+	t.Run("DescriptionOverride", func(t *testing.T) {
+		plan := &Plan{CollOverrides: map[string]CollOverride{"db1.coll1": {Description: "new desc"}}}
+		assert.NoError(t, checkSnapshotSupport(plan, &Option{}))
 	})
 }
 


### PR DESCRIPTION
## Summary
The snapshot restore path hands the whole restore to Milvus, which creates the collection from the bundle's schema, so the per-collection description override that the binlog path has honored since #982 was refused up front for snapshot backups. This PR applies it instead: once the restore job completes, the target collection's description is rewritten with an AlterCollection carrying the `collection.description` property.

## Changes
- `core/restore/task.go`: `checkSnapshotSupport` now only refuses `shardNum` overrides; a `description` override is threaded into the snapshot collection task
- `core/restore/coll_snapshot_task.go`: after the restore job completes, alter the collection with the `collection.description` property when an override is set
- tests: snapshot task override / empty / alter-failure cases, and the snapshot support check

Related to #1119
