### PR TITLE
ci: fix the py package collision in the api test job

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,6 +20,9 @@ ndg-httpsclient
 pyopenssl
 pyasn1
 pytest-html==4.2.0
+# pytest 9 ships a py.py module that shadows the py package, which pytest-xdist and
+# pytest-assume still import from (py.log, py.io). Pin py so the package wins.
+py==1.11.0
 delayed-assert==0.3.5
 kubernetes==24.2.0
 PyYAML==6.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -19,7 +19,7 @@ git+https://github.com/Projectplace/pytest-tags
 ndg-httpsclient
 pyopenssl
 pyasn1
-pytest-html==3.1.1
+pytest-html==4.2.0
 delayed-assert==0.3.5
 kubernetes==24.2.0
 PyYAML==6.0


### PR DESCRIPTION
## Summary
The api test job fails at pytest plugin load with `ModuleNotFoundError: No module named 'py.xml'` / `'py.log'` / `'py.io'`; `'py' is not a package`, red on main for every matrix variant.

**Root cause:** pytest 9 ships its own `py.py` module, which shadows the `py` package. The `py` package used to be installed as a transitive dependency of `pytest-forked` (pulled in by the pinned `pytest-xdist==2.5.0`), so `from py.log` / `py.xml` / `py.io` in pytest-xdist, pytest-html and pytest-assume resolved. pytest-forked **1.7.5 (released 2026-08-08) dropped the `py` dependency**, so `py` is no longer installed and `import py` falls back to pytest's `py.py` module, breaking all three plugins. Main went red from the 2026-08-09 daily run on.

**Fix:** pin `py==1.11.0` so the `py/` package wins over pytest's `py.py` again, and upgrade `pytest-html` to 4.2.0, which dropped the `py` dependency in 4.0 (pytest-dev/pytest-html#350) and renders reports with jinja2 instead.

Verified in a venv with pytest 9.0.3: with `py==1.11.0` installed, `import py` resolves to the package and `py.log`/`py.io`/`py.xml` all import cleanly; `pytest -n 2` runs with xdist 2.5.0 and the assume plugin loads without error. The full api matrix passes on this PR.

## Changes
- `tests/requirements.txt`: `pytest-html==3.1.1` → `pytest-html==4.2.0`
- `tests/requirements.txt`: pin `py==1.11.0` with a comment explaining the collision

/kind improvement
