### PR TITLE
storage: unify object iterator into a single Next method

### DIFF
--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -347,127 +347,53 @@ func (a *AzureClient) UploadObject(ctx context.Context, i UploadObjectInput) err
 	return nil
 }
 
-type AzureObjectFlatIterator struct {
-	cli *AzureClient
-
-	pager *runtime.Pager[azblob.ListBlobsFlatResponse]
+// pageIterator is a pull-based iterator over the Azure pager API. It fetches
+// one page at a time, skips pages that yield no objects, and surfaces pager
+// errors through Next. Both flat (recursive) and hierarchy (delimiter) listings
+// share this logic, differing only in the pager type and how a page is
+// converted to ObjectAttr entries.
+type pageIterator[T any] struct {
+	pager *runtime.Pager[T]
 
 	currPage []ObjectAttr
 	nextIdx  int
 
-	err error
+	toAttrs func(T) []ObjectAttr
 }
 
-func (flatIter *AzureObjectFlatIterator) HasNext() bool {
-	// current page has more entries
-	if flatIter.nextIdx < len(flatIter.currPage) {
-		return true
-	}
+func (p *pageIterator[T]) Next(ctx context.Context) (ObjectAttr, bool, error) {
+	for {
+		if p.nextIdx < len(p.currPage) {
+			attr := p.currPage[p.nextIdx]
+			p.nextIdx++
+			return attr, true, nil
+		}
 
-	// Notice: the first call to `pager.More()` returns `true` even if the current prefix has no content.
-	if !flatIter.pager.More() {
-		return false
-	}
+		// Notice: the first call to `pager.More()` returns `true` even if the
+		// current prefix has no content.
+		if !p.pager.More() {
+			return ObjectAttr{}, false, nil
+		}
 
-	// try to get next page
-	page, err := flatIter.pager.NextPage(context.Background())
-	if err != nil {
-		flatIter.err = err
-		return false
-	}
-	flatIter.currPage = flatIter.currPage[:0]
-	flatIter.nextIdx = 0
-	for _, blob := range page.Segment.BlobItems {
-		attr := ObjectAttr{Key: *blob.Name, Length: *blob.Properties.ContentLength}
-		flatIter.currPage = append(flatIter.currPage, attr)
-	}
+		page, err := p.pager.NextPage(ctx)
+		if err != nil {
+			return ObjectAttr{}, false, fmt.Errorf("storage: azure list prefix %w", err)
+		}
+		p.currPage = p.currPage[:0]
+		p.nextIdx = 0
+		p.currPage = append(p.currPage, p.toAttrs(page)...)
 
-	// - In Azure's SDK, the first call to `pager.More()` returns `true` even if the current prefix has no content.
-	// - `ListBlobsHierarchy` can yield empty pages (no blobs and no prefixes).
-	// - To ensure the iterator reports `true` only when there is actual content, we keep fetching pages recursively
-	//   until either:
-	//   • `currPage` becomes non-empty, or
-	//   • `pager.More()` returns `false`.
-	if len(flatIter.currPage) == 0 {
-		return flatIter.HasNext()
+		// ListBlobs* can yield empty pages (no blobs and no prefixes). Loop
+		// until the page is non-empty or the pager is exhausted.
 	}
-
-	return true
 }
 
-func (flatIter *AzureObjectFlatIterator) Next() (ObjectAttr, error) {
-	if flatIter.err != nil {
-		return ObjectAttr{}, flatIter.err
-	}
-
-	attr := flatIter.currPage[flatIter.nextIdx]
-	flatIter.nextIdx++
-
-	return attr, nil
+type AzureObjectFlatIterator struct {
+	pageIterator[azblob.ListBlobsFlatResponse]
 }
 
 type AzureObjectHierarchyIterator struct {
-	cli *AzureClient
-
-	pager *runtime.Pager[container.ListBlobsHierarchyResponse]
-
-	currPage []ObjectAttr
-	nextIdx  int
-
-	err error
-}
-
-func (hierIter *AzureObjectHierarchyIterator) HasNext() bool {
-	// current page still has more entries
-	if hierIter.nextIdx < len(hierIter.currPage) {
-		return true
-	}
-
-	// Notice: the first call to `pager.More()` returns `true` even if the current prefix has no content.
-	if !hierIter.pager.More() {
-		return false
-	}
-
-	// try to get next page
-	page, err := hierIter.pager.NextPage(context.Background())
-	if err != nil {
-		// put error into err field, it will be returned in next call of Next()
-		// so we need to return true here, the caller will check err in Next()
-		hierIter.err = err
-		return true
-	}
-	hierIter.currPage = hierIter.currPage[:0]
-	hierIter.nextIdx = 0
-	for _, blob := range page.Segment.BlobItems {
-		attr := ObjectAttr{Key: *blob.Name, Length: *blob.Properties.ContentLength}
-		hierIter.currPage = append(hierIter.currPage, attr)
-	}
-	for _, prefix := range page.Segment.BlobPrefixes {
-		hierIter.currPage = append(hierIter.currPage, ObjectAttr{Key: *prefix.Name})
-	}
-
-	// - In Azure's SDK, the first call to `pager.More()` returns `true` even if the current prefix has no content.
-	// - `ListBlobsHierarchy` can yield empty pages (no blobs and no prefixes).
-	// - To ensure the iterator reports `true` only when there is actual content, we keep fetching pages recursively
-	//   until either:
-	//   • `currPage` becomes non-empty, or
-	//   • `pager.More()` returns `false`.
-	if len(hierIter.currPage) == 0 {
-		return hierIter.HasNext()
-	}
-
-	return true
-}
-
-func (hierIter *AzureObjectHierarchyIterator) Next() (ObjectAttr, error) {
-	if hierIter.err != nil {
-		return ObjectAttr{}, hierIter.err
-	}
-
-	attr := hierIter.currPage[hierIter.nextIdx]
-	hierIter.nextIdx++
-
-	return attr, nil
+	pageIterator[container.ListBlobsHierarchyResponse]
 }
 
 func (a *AzureClient) ListPrefix(_ context.Context, prefix string, recursive bool) (ObjectIterator, error) {
@@ -480,7 +406,16 @@ func (a *AzureClient) ListPrefix(_ context.Context, prefix string, recursive boo
 func (a *AzureClient) listPrefixRecursive(prefix string) (*AzureObjectFlatIterator, error) {
 	pager := a.cli.NewListBlobsFlatPager(a.cfg.Bucket, &azblob.ListBlobsFlatOptions{Prefix: to.Ptr(prefix)})
 
-	return &AzureObjectFlatIterator{cli: a, pager: pager}, nil
+	return &AzureObjectFlatIterator{pageIterator: pageIterator[azblob.ListBlobsFlatResponse]{
+		pager: pager,
+		toAttrs: func(page azblob.ListBlobsFlatResponse) []ObjectAttr {
+			attrs := make([]ObjectAttr, 0, len(page.Segment.BlobItems))
+			for _, blob := range page.Segment.BlobItems {
+				attrs = append(attrs, ObjectAttr{Key: *blob.Name, Length: *blob.Properties.ContentLength})
+			}
+			return attrs
+		},
+	}}, nil
 }
 
 func (a *AzureClient) listPrefixNonRecursive(prefix string) (*AzureObjectHierarchyIterator, error) {
@@ -488,7 +423,19 @@ func (a *AzureClient) listPrefixNonRecursive(prefix string) (*AzureObjectHierarc
 		NewContainerClient(a.cfg.Bucket).
 		NewListBlobsHierarchyPager("/", &container.ListBlobsHierarchyOptions{Prefix: to.Ptr(prefix)})
 
-	return &AzureObjectHierarchyIterator{cli: a, pager: pager}, nil
+	return &AzureObjectHierarchyIterator{pageIterator: pageIterator[container.ListBlobsHierarchyResponse]{
+		pager: pager,
+		toAttrs: func(page container.ListBlobsHierarchyResponse) []ObjectAttr {
+			attrs := make([]ObjectAttr, 0, len(page.Segment.BlobItems)+len(page.Segment.BlobPrefixes))
+			for _, blob := range page.Segment.BlobItems {
+				attrs = append(attrs, ObjectAttr{Key: *blob.Name, Length: *blob.Properties.ContentLength})
+			}
+			for _, prefix := range page.Segment.BlobPrefixes {
+				attrs = append(attrs, ObjectAttr{Key: *prefix.Name})
+			}
+			return attrs
+		},
+	}}, nil
 }
 
 func (a *AzureClient) DeleteObject(ctx context.Context, prefix string) error {

--- a/internal/storage/azure_test.go
+++ b/internal/storage/azure_test.go
@@ -1,9 +1,15 @@
 package storage
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAzureMultipartCopyThreshold(t *testing.T) {
@@ -26,4 +32,86 @@ func TestAzureMultipartCopyThreshold(t *testing.T) {
 		cli := &AzureClient{cfg: Config{MultipartCopyThresholdMiB: 500}}
 		assert.Equal(t, _azureMaxSyncCopySize, cli.multipartCopyThreshold())
 	})
+}
+
+// TestAzureObjectIteratorSurfacesPaginationError locks the iterator contract
+// that a pagination error must not be silently swallowed: Next returns
+// (zero, false, err) after a failed NextPage, so the caller loop propagates
+// the error instead of ending and reporting success (e.g. copy/delete/verify
+// tasks returning nil).
+func TestAzureObjectIteratorSurfacesPaginationError(t *testing.T) {
+	listErr := errors.New("azure list blobs failed")
+
+	flatPager := runtime.NewPager(runtime.PagingHandler[azblob.ListBlobsFlatResponse]{
+		More: func(azblob.ListBlobsFlatResponse) bool { return true },
+		Fetcher: func(context.Context, *azblob.ListBlobsFlatResponse) (azblob.ListBlobsFlatResponse, error) {
+			return azblob.ListBlobsFlatResponse{}, listErr
+		},
+	})
+	hierPager := runtime.NewPager(runtime.PagingHandler[container.ListBlobsHierarchyResponse]{
+		More: func(container.ListBlobsHierarchyResponse) bool { return true },
+		Fetcher: func(context.Context, *container.ListBlobsHierarchyResponse) (container.ListBlobsHierarchyResponse, error) {
+			return container.ListBlobsHierarchyResponse{}, listErr
+		},
+	})
+
+	tests := []struct {
+		name string
+		iter ObjectIterator
+	}{
+		{"Flat", &AzureObjectFlatIterator{pageIterator: pageIterator[azblob.ListBlobsFlatResponse]{pager: flatPager}}},
+		{"Hierarchy", &AzureObjectHierarchyIterator{pageIterator: pageIterator[container.ListBlobsHierarchyResponse]{pager: hierPager}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Next must surface the pagination error instead of ending the loop.
+			_, ok, err := tt.iter.Next(context.Background())
+			assert.False(t, ok)
+			require.Error(t, err) // err is dereferenced below
+			assert.Contains(t, err.Error(), "azure list blobs failed")
+
+			// The standard caller loop must propagate the error rather than
+			// complete silently with a nil return.
+			walkErr := func(iter ObjectIterator) error {
+				for {
+					_, ok, err := iter.Next(context.Background())
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil
+					}
+				}
+			}
+			assert.Error(t, walkErr(tt.iter))
+		})
+	}
+}
+
+// TestAzureObjectIteratorSkipsEmptyPage locks the empty-page handling: a pager
+// that yields a page with no objects before exhausting must terminate cleanly
+// with ok=false, not spin or error.
+func TestAzureObjectIteratorSkipsEmptyPage(t *testing.T) {
+	fetched := 0
+	pager := runtime.NewPager(runtime.PagingHandler[azblob.ListBlobsFlatResponse]{
+		More: func(azblob.ListBlobsFlatResponse) bool {
+			// only one page worth of content, then exhausted
+			return fetched == 0
+		},
+		Fetcher: func(context.Context, *azblob.ListBlobsFlatResponse) (azblob.ListBlobsFlatResponse, error) {
+			fetched++
+			return azblob.ListBlobsFlatResponse{}, nil
+		},
+	})
+	iter := &AzureObjectFlatIterator{pageIterator: pageIterator[azblob.ListBlobsFlatResponse]{
+		pager: pager,
+		toAttrs: func(page azblob.ListBlobsFlatResponse) []ObjectAttr {
+			return nil
+		},
+	}}
+
+	_, ok, err := iter.Next(context.Background())
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, 1, fetched)
 }

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -112,9 +112,11 @@ func (c CredentialType) String() string {
 	return "Can not find the credential type"
 }
 
+// ObjectIterator yields objects under a prefix. Each Next call returns the
+// next object, or ok=false once the listing is exhausted. err is non-nil only
+// on a real failure; exhaustion is not an error.
 type ObjectIterator interface {
-	HasNext() bool
-	Next() (ObjectAttr, error)
+	Next(ctx context.Context) (ObjectAttr, bool, error)
 }
 
 // Client is the interface for storage service.

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -64,10 +64,13 @@ func (c *CopyPrefixTask) Execute(ctx context.Context) error {
 	}
 
 	g, subCtx := errgroup.WithContext(ctx)
-	for iter.HasNext() {
-		attr, err := iter.Next()
+	for {
+		attr, ok, err := iter.Next(ctx)
 		if err != nil {
 			return fmt.Errorf("storage: copy prefix iter object %w", err)
+		}
+		if !ok {
+			break
 		}
 		if attr.IsEmpty() && strings.HasSuffix(attr.Key, "/") {
 			continue

--- a/internal/storage/copy_task_test.go
+++ b/internal/storage/copy_task_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/retry"
 )
 
-// errorIterator reports a next item but always fails when read.
+// errorIterator always fails the next read.
 type errorIterator struct{}
 
-func (errorIterator) HasNext() bool             { return true }
-func (errorIterator) Next() (ObjectAttr, error) { return ObjectAttr{}, assert.AnError }
+func (errorIterator) Next(context.Context) (ObjectAttr, bool, error) {
+	return ObjectAttr{}, false, assert.AnError
+}
 
 func TestCopyPrefixTask_Execute(t *testing.T) {
 	t.Run("CopiesAllAndRemapsKeys", func(t *testing.T) {

--- a/internal/storage/funcs.go
+++ b/internal/storage/funcs.go
@@ -33,10 +33,13 @@ func ListPrefixFlat(ctx context.Context, cli Client, prefix string, recursive bo
 
 	var keys []string
 	var sizes []int64
-	for iter.HasNext() {
-		attr, err := iter.Next()
+	for {
+		attr, ok, err := iter.Next(ctx)
 		if err != nil {
 			return nil, nil, fmt.Errorf("storage: list prefix flat %w", err)
+		}
+		if !ok {
+			break
 		}
 		keys = append(keys, attr.Key)
 		sizes = append(sizes, attr.Length)
@@ -80,10 +83,13 @@ func DeletePrefix(ctx context.Context, cli Client, prefix string) error {
 
 	g, subCtx := errgroup.WithContext(ctx)
 	g.SetLimit(_deleteConcurrent)
-	for iter.HasNext() {
-		attr, err := iter.Next()
+	for {
+		attr, ok, err := iter.Next(ctx)
 		if err != nil {
 			return fmt.Errorf("storage: delete prefix iter object %w", err)
+		}
+		if !ok {
+			break
 		}
 		if !strings.HasPrefix(attr.Key, prefix) {
 			return fmt.Errorf("storage: delete prefix key %s not in prefix %s", attr.Key, prefix)
@@ -108,11 +114,12 @@ func Exist(ctx context.Context, cli Client, prefix string) (bool, error) {
 		return false, fmt.Errorf("storage: exist list prefix %w", err)
 	}
 
-	if !iter.HasNext() {
-		return false, nil
+	_, ok, err := iter.Next(ctx)
+	if err != nil {
+		return false, fmt.Errorf("storage: exist list prefix %w", err)
 	}
 
-	return true, nil
+	return ok, nil
 }
 
 func CreateBucketIfNotExist(ctx context.Context, cli Client, prefix string) error {

--- a/internal/storage/funcs_test.go
+++ b/internal/storage/funcs_test.go
@@ -15,15 +15,13 @@ type mockObjectIterator struct {
 	idx  int
 }
 
-func (m *mockObjectIterator) HasNext() bool { return m.idx < len(m.objs) }
-
-func (m *mockObjectIterator) Next() (ObjectAttr, error) {
-	if !m.HasNext() {
-		return ObjectAttr{}, nil
+func (m *mockObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
+	if m.idx >= len(m.objs) {
+		return ObjectAttr{}, false, nil
 	}
 	obj := m.objs[m.idx]
 	m.idx++
-	return obj, nil
+	return obj, true, nil
 }
 
 func TestSize(t *testing.T) {

--- a/internal/storage/gcp_native.go
+++ b/internal/storage/gcp_native.go
@@ -88,31 +88,19 @@ func (gcm *GCPNativeClient) DeleteObject(ctx context.Context, key string) error 
 }
 
 type GcpNativeObjectIterator struct {
-	cli *GCPNativeClient
-
 	iter *storage.ObjectIterator
-
-	hasNext bool
-	nextObj *storage.ObjectAttrs
 }
 
-func (g *GcpNativeObjectIterator) HasNext() bool { return g.hasNext }
-
-func (g *GcpNativeObjectIterator) Next() (ObjectAttr, error) {
-	currObj := g.nextObj
+func (g *GcpNativeObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
 	next, err := g.iter.Next()
 	if err != nil {
 		if errors.Is(err, iterator.Done) {
-			g.hasNext = false
-			return ObjectAttr{Key: currObj.Name, Length: currObj.Size}, nil
+			return ObjectAttr{}, false, nil
 		}
-		return ObjectAttr{}, fmt.Errorf("storage: gcp native list prefix %w", err)
+		return ObjectAttr{}, false, fmt.Errorf("storage: gcp native list prefix %w", err)
 	}
 
-	g.nextObj = next
-	g.hasNext = true
-
-	return ObjectAttr{Key: currObj.Name, Length: currObj.Size}, nil
+	return ObjectAttr{Key: next.Name, Length: next.Size}, true, nil
 }
 
 func (gcm *GCPNativeClient) ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error) {
@@ -126,15 +114,7 @@ func (gcm *GCPNativeClient) ListPrefix(ctx context.Context, prefix string, recur
 		Delimiter: delimiter,
 	})
 
-	next, err := iter.Next()
-	if err != nil {
-		if errors.Is(err, iterator.Done) {
-			return &GcpNativeObjectIterator{cli: gcm, iter: iter, hasNext: false}, nil
-		}
-		return nil, fmt.Errorf("storage: gcp native list prefix %w", err)
-	}
-
-	return &GcpNativeObjectIterator{cli: gcm, iter: iter, nextObj: next, hasNext: true}, nil
+	return &GcpNativeObjectIterator{iter: iter}, nil
 }
 
 func (gcm *GCPNativeClient) BucketExist(ctx context.Context, _ string) (bool, error) {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -113,17 +113,13 @@ type localIterator struct {
 	index   int
 }
 
-func (l *localIterator) HasNext() bool {
-	return l.index < len(l.entries)
-}
-
-func (l *localIterator) Next() (ObjectAttr, error) {
-	if !l.HasNext() {
-		return ObjectAttr{}, fmt.Errorf("storage: local list prefix no more entries")
+func (l *localIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
+	if l.index >= len(l.entries) {
+		return ObjectAttr{}, false, nil
 	}
 	entry := l.entries[l.index]
 	l.index++
-	return entry, nil
+	return entry, true, nil
 }
 
 func (l *LocalClient) ListPrefix(_ context.Context, prefix string, recursive bool) (ObjectIterator, error) {

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -130,16 +130,16 @@ func TestLocalClient_ListPrefix(t *testing.T) {
 		iter, err := cli.ListPrefix(context.Background(), path.Join(dir, "backup", "meta", "test.txt"), false)
 		assert.NoError(t, err)
 
-		assert.True(t, iter.HasNext())
-		entry, err := iter.Next()
+		entry, ok, err := iter.Next(context.Background())
+		assert.True(t, ok)
 		assert.NoError(t, err)
 		assert.Equal(t, path.Join(dir, "backup", "meta", "test.txt"), entry.Key)
 		assert.Equal(t, int64(1), entry.Length)
 
 		iter, err = cli.ListPrefix(context.Background(), path.Join(dir, "backup", "meta", "test.txt"), true)
 		assert.NoError(t, err)
-		assert.True(t, iter.HasNext())
-		entry, err = iter.Next()
+		entry, ok, err = iter.Next(context.Background())
+		assert.True(t, ok)
 		assert.NoError(t, err)
 		assert.Equal(t, path.Join(dir, "backup", "meta", "test.txt"), entry.Key)
 		assert.Equal(t, int64(1), entry.Length)
@@ -149,11 +149,15 @@ func TestLocalClient_ListPrefix(t *testing.T) {
 		cli := &LocalClient{}
 		iter, err := cli.ListPrefix(context.Background(), path.Join(dir, "not_exist"), false)
 		assert.NoError(t, err)
-		assert.False(t, iter.HasNext())
+		_, ok, err := iter.Next(context.Background())
+		assert.NoError(t, err)
+		assert.False(t, ok)
 
 		iter, err = cli.ListPrefix(context.Background(), path.Join(dir, "not_exist"), true)
 		assert.NoError(t, err)
-		assert.False(t, iter.HasNext())
+		_, ok, err = iter.Next(context.Background())
+		assert.NoError(t, err)
+		assert.False(t, ok)
 	})
 
 	t.Run("Recursive", func(t *testing.T) {
@@ -162,9 +166,12 @@ func TestLocalClient_ListPrefix(t *testing.T) {
 		assert.NoError(t, err)
 
 		var entries []ObjectAttr
-		for iter.HasNext() {
-			entry, err := iter.Next()
+		for {
+			entry, ok, err := iter.Next(context.Background())
 			assert.NoError(t, err)
+			if !ok {
+				break
+			}
 			entries = append(entries, entry)
 		}
 
@@ -179,9 +186,12 @@ func TestLocalClient_ListPrefix(t *testing.T) {
 		assert.NoError(t, err)
 
 		var entries []ObjectAttr
-		for iter.HasNext() {
-			entry, err := iter.Next()
+		for {
+			entry, ok, err := iter.Next(context.Background())
 			assert.NoError(t, err)
+			if !ok {
+				break
+			}
 			entries = append(entries, entry)
 		}
 		assert.Len(t, entries, 2)

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -311,40 +311,25 @@ func (m *MinioClient) DeleteObject(ctx context.Context, key string) error {
 type MinioObjectIterator struct {
 	cli *MinioClient
 
-	objCh   <-chan minio.ObjectInfo
-	nextObj minio.ObjectInfo
-	hasNext bool
+	objCh <-chan minio.ObjectInfo
 }
 
-func newMinioObjectIterator(cli *MinioClient, objCh <-chan minio.ObjectInfo) (*MinioObjectIterator, error) {
-	nextObj, ok := <-objCh
+func (m *MinioObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
+	item, ok := <-m.objCh
 	if !ok {
-		return &MinioObjectIterator{cli: cli, objCh: objCh, hasNext: false}, nil
+		return ObjectAttr{}, false, nil
 	}
 
-	if nextObj.Err != nil {
-		return &MinioObjectIterator{cli: cli, objCh: objCh, hasNext: false}, fmt.Errorf("storage: %s list prefix %w", cli.cfg.Provider, nextObj.Err)
+	if item.Err != nil {
+		return ObjectAttr{}, false, fmt.Errorf("storage: %s list prefix %w", m.cli.cfg.Provider, item.Err)
 	}
-
-	return &MinioObjectIterator{cli: cli, objCh: objCh, nextObj: nextObj, hasNext: true}, nil
-}
-
-func (m *MinioObjectIterator) HasNext() bool { return m.hasNext }
-
-func (m *MinioObjectIterator) Next() (ObjectAttr, error) {
-	curr := m.nextObj
-	m.nextObj, m.hasNext = <-m.objCh
-
-	if curr.Err != nil {
-		return ObjectAttr{}, fmt.Errorf("storage: %s list prefix %w", m.cli.cfg.Provider, curr.Err)
-	}
-	return ObjectAttr{Key: curr.Key, Length: curr.Size}, nil
+	return ObjectAttr{Key: item.Key, Length: item.Size}, true, nil
 }
 
 func (m *MinioClient) ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error) {
 	opt := minio.ListObjectsOptions{Prefix: prefix, Recursive: recursive}
 	objCh := m.cli.ListObjects(ctx, m.cfg.Bucket, opt)
-	return newMinioObjectIterator(m, objCh)
+	return &MinioObjectIterator{cli: m, objCh: objCh}, nil
 }
 
 // BucketExist checks if the bucket exists by listing a single object.

--- a/internal/storage/object_iterator_mock.go
+++ b/internal/storage/object_iterator_mock.go
@@ -1,5 +1,7 @@
 package storage
 
+import "context"
+
 var _ ObjectIterator = (*MockObjectIterator)(nil)
 
 type MockObjectIterator struct {
@@ -7,17 +9,13 @@ type MockObjectIterator struct {
 	idx  int
 }
 
-func (m *MockObjectIterator) HasNext() bool {
-	return m.idx < len(m.objs)
-}
-
-func (m *MockObjectIterator) Next() (ObjectAttr, error) {
-	if !m.HasNext() {
-		return ObjectAttr{}, nil
+func (m *MockObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
+	if m.idx >= len(m.objs) {
+		return ObjectAttr{}, false, nil
 	}
 	obj := m.objs[m.idx]
 	m.idx++
-	return obj, nil
+	return obj, true, nil
 }
 
 func NewMockObjectIterator(objs []ObjectAttr) *MockObjectIterator {

--- a/internal/storage/verify_task.go
+++ b/internal/storage/verify_task.go
@@ -58,10 +58,13 @@ func (t *VerifyPrefixTask) Execute(ctx context.Context) error {
 		missing[key] = size
 	}
 
-	for iter.HasNext() {
-		attr, err := iter.Next()
+	for {
+		attr, ok, err := iter.Next(ctx)
 		if err != nil {
 			return fmt.Errorf("storage: verify prefix iter object %w", err)
+		}
+		if !ok {
+			break
 		}
 
 		want, ok := t.opt.Expected[attr.Key]


### PR DESCRIPTION
## Summary

Refactor the object-listing iterator in `internal/storage` from the two-phase `HasNext() bool` + `Next() (ObjectAttr, error)` contract to a single pull method `Next(ctx) (ObjectAttr, bool, error)`, following the `(*sql.Rows).Next()` idiom. `ok=true` means a real object was returned, `ok=false` means the listing is exhausted, and `err` is non-nil only on a real failure.

This removes the side-effecting `HasNext` (the Azure iterators fetched pages inside it), makes exhaustion vs failure unambiguous across providers, and threads the caller's `ctx` into Azure page fetches so iteration is cancellable. It also fixes a latent bug where the Azure flat iterator silently swallowed pagination errors, letting copy/delete/verify tasks report success on an incomplete listing.

## Changes

- `storage`: collapse `ObjectIterator` to `Next(ctx) (ObjectAttr, bool, error)`; drop the pre-read double-buffering in the minio and gcp-native iterators
- `storage`: unify the flat and hierarchy Azure iterators into a shared generic `pageIterator[T]`, using the caller context for page fetches
- `storage`: update the five call sites (`ListPrefixFlat`, `DeletePrefix`, `Exist`, `CopyPrefixTask`, `VerifyPrefixTask`) to the new loop idiom
- `test`: update the local and mock iterator tests; add Azure pagination-error and empty-page contract tests

/kind improvement
