### PR TITLE
storage: stop background listing goroutines on iterator close

### DIFF
--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -388,6 +388,10 @@ func (p *pageIterator[T]) Next(ctx context.Context) (ObjectAttr, bool, error) {
 	}
 }
 
+// Close is a no-op: the Azure pager fetches pages synchronously on Next and
+// keeps no background goroutine.
+func (p *pageIterator[T]) Close() error { return nil }
+
 type AzureObjectFlatIterator struct {
 	pageIterator[azblob.ListBlobsFlatResponse]
 }

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -115,7 +115,13 @@ func (c CredentialType) String() string {
 // ObjectIterator yields objects under a prefix. Each Next call returns the
 // next object, or ok=false once the listing is exhausted. err is non-nil only
 // on a real failure; exhaustion is not an error.
+//
+// The caller must Close the iterator when done, even after exhaustion or an
+// early return. Implementations may start a background listing goroutine that
+// Close is responsible for stopping; without it, a provider-backed iterator
+// can keep listing until its creation context is canceled.
 type ObjectIterator interface {
+	io.Closer
 	Next(ctx context.Context) (ObjectAttr, bool, error)
 }
 

--- a/internal/storage/copy_task.go
+++ b/internal/storage/copy_task.go
@@ -62,12 +62,22 @@ func (c *CopyPrefixTask) Execute(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("storage: copy prefix walk prefix %w", err)
 	}
+	defer iter.Close()
 
+	// Derive a cancellable context so in-flight copies can be stopped when the
+	// loop bails early, then join them through the single Wait below.
+	// defer cancel() satisfies vet's lostcancel check; it is a no-op on the
+	// happy path where Wait has already joined every copy.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	g, subCtx := errgroup.WithContext(ctx)
+
+	var loopErr error
 	for {
 		attr, ok, err := iter.Next(ctx)
 		if err != nil {
-			return fmt.Errorf("storage: copy prefix iter object %w", err)
+			loopErr = fmt.Errorf("storage: copy prefix iter object %w", err)
+			break
 		}
 		if !ok {
 			break
@@ -77,7 +87,8 @@ func (c *CopyPrefixTask) Execute(ctx context.Context) error {
 		}
 
 		if err := c.opt.Sem.Acquire(ctx, 1); err != nil {
-			return fmt.Errorf("storage: copy prefix acquire semaphore %w", err)
+			loopErr = fmt.Errorf("storage: copy prefix acquire semaphore %w", err)
+			break
 		}
 		g.Go(func() error {
 			defer c.opt.Sem.Release(1)
@@ -90,8 +101,18 @@ func (c *CopyPrefixTask) Execute(ctx context.Context) error {
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("storage: copy prefix %w", err)
+	// If the loop bailed early, stop the in-flight copies so Wait below
+	// returns promptly instead of running them to completion.
+	if loopErr != nil {
+		cancel()
+	}
+
+	waitErr := g.Wait()
+	if loopErr != nil {
+		return loopErr
+	}
+	if waitErr != nil {
+		return fmt.Errorf("storage: copy prefix %w", waitErr)
 	}
 
 	return nil
@@ -128,10 +149,19 @@ func (c *CopyObjectsTask) Execute(ctx context.Context) error {
 	// shuffle to avoid hot region
 	mutable.Shuffle(c.opt.Attrs)
 
+	// Derive a cancellable context so in-flight copies can be stopped when the
+	// loop bails early, then join them through the single Wait below.
+	// defer cancel() satisfies vet's lostcancel check; it is a no-op on the
+	// happy path where Wait has already joined every copy.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	g, subCtx := errgroup.WithContext(ctx)
+
+	var loopErr error
 	for _, attr := range c.opt.Attrs {
 		if err := c.opt.Sem.Acquire(ctx, 1); err != nil {
-			return fmt.Errorf("storage: copy objects acquire semaphore %w", err)
+			loopErr = fmt.Errorf("storage: copy objects acquire semaphore %w", err)
+			break
 		}
 		g.Go(func() error {
 			defer c.opt.Sem.Release(1)
@@ -144,8 +174,18 @@ func (c *CopyObjectsTask) Execute(ctx context.Context) error {
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("storage: copy objects %w", err)
+	// If the loop bailed early, stop the in-flight copies so Wait below
+	// returns promptly instead of running them to completion.
+	if loopErr != nil {
+		cancel()
+	}
+
+	waitErr := g.Wait()
+	if loopErr != nil {
+		return loopErr
+	}
+	if waitErr != nil {
+		return fmt.Errorf("storage: copy objects %w", waitErr)
 	}
 
 	return nil

--- a/internal/storage/copy_task_test.go
+++ b/internal/storage/copy_task_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,8 @@ func (errorIterator) Next(context.Context) (ObjectAttr, bool, error) {
 	return ObjectAttr{}, false, assert.AnError
 }
 
+func (errorIterator) Close() error { return nil }
+
 func TestCopyPrefixTask_Execute(t *testing.T) {
 	t.Run("CopiesAllAndRemapsKeys", func(t *testing.T) {
 		src := NewMockClient(t)
@@ -32,13 +35,15 @@ func TestCopyPrefixTask_Execute(t *testing.T) {
 			{Key: "src/b/c", Length: 2},
 			{Key: "src/dir/", Length: 0}, // directory marker, must be skipped
 		}
+		iter := &mockObjectIterator{objs: objs}
 		src.EXPECT().ListPrefix(mock.Anything, "src/", true).
-			Return(&mockObjectIterator{objs: objs}, nil).Once()
+			Return(iter, nil).Once()
 		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "src/a", Length: 1}, DestKey: "dest/a"}).Return(nil).Once()
 		dest.EXPECT().CopyObject(mock.Anything, CopyObjectInput{SrcCli: src, SrcAttr: ObjectAttr{Key: "src/b/c", Length: 2}, DestKey: "dest/b/c"}).Return(nil).Once()
 
 		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(2)})
 		assert.NoError(t, task.Execute(context.Background()))
+		assert.True(t, iter.closed, "CopyPrefixTask must close the iterator")
 	})
 
 	t.Run("ListError", func(t *testing.T) {
@@ -60,11 +65,51 @@ func TestCopyPrefixTask_Execute(t *testing.T) {
 		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
 		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
 		objs := []ObjectAttr{{Key: "src/a", Length: 1}}
-		src.EXPECT().ListPrefix(mock.Anything, "src/", true).Return(&mockObjectIterator{objs: objs}, nil).Once()
+		iter := &mockObjectIterator{objs: objs}
+		src.EXPECT().ListPrefix(mock.Anything, "src/", true).Return(iter, nil).Once()
 		dest.EXPECT().CopyObject(mock.Anything, mock.Anything).Return(retry.Unrecoverable(assert.AnError)).Once()
 
 		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(1)})
 		assert.Error(t, task.Execute(context.Background()))
+		assert.True(t, iter.closed, "CopyPrefixTask must close the iterator on error")
+	})
+
+	t.Run("StopsInflightCopiesOnIterError", func(t *testing.T) {
+		// Raw mocks, not NewMockClient, so a leaked goroutine holding a mock
+		// lock on a never-released copy cannot deadlock the test cleanup;
+		// without the errgroup fix the assertion below fails instead.
+		src := &MockClient{}
+		dest := &MockClient{}
+		src.EXPECT().Config().Return(Config{Bucket: "src"}).Maybe()
+		dest.EXPECT().Config().Return(Config{Bucket: "dest"}).Maybe()
+
+		released := make(chan struct{})
+		var once sync.Once
+		// A copy that blocks until its context is canceled. The release can
+		// only happen through Execute's own deferred cancel, so this test
+		// verifies in-flight copies are stopped on early return.
+		dest.EXPECT().CopyObject(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, _ CopyObjectInput) error {
+				<-ctx.Done()
+				once.Do(func() { close(released) })
+				return ctx.Err()
+			}).Once()
+
+		// The iterator yields one object, then errors so Execute returns
+		// before the listing is drained.
+		iter := &iterWithError{objs: []ObjectAttr{{Key: "src/a", Length: 1}}}
+		src.EXPECT().ListPrefix(mock.Anything, "src/", true).Return(iter, nil).Once()
+
+		task := NewCopyPrefixTask(CopyPrefixOpt{Src: src, Dest: dest, SrcPrefix: "src/", DestPrefix: "dest/", Sem: semaphore.NewWeighted(2)})
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.True(t, iter.closed, "CopyPrefixTask must close the iterator on early return")
+
+		select {
+		case <-released:
+		default:
+			assert.Fail(t, "CopyPrefixTask returned without stopping the in-flight copy")
+		}
 	})
 }
 

--- a/internal/storage/funcs.go
+++ b/internal/storage/funcs.go
@@ -30,6 +30,7 @@ func ListPrefixFlat(ctx context.Context, cli Client, prefix string, recursive bo
 	if err != nil {
 		return nil, nil, err
 	}
+	defer iter.Close()
 
 	var keys []string
 	var sizes []int64
@@ -80,19 +81,30 @@ func DeletePrefix(ctx context.Context, cli Client, prefix string) error {
 	if err != nil {
 		return fmt.Errorf("storage: delete prefix list prefix %w", err)
 	}
+	defer iter.Close()
 
+	// Derive a cancellable context so in-flight deletions can be stopped when
+	// the loop bails early, then join them through the single Wait below.
+	// defer cancel() satisfies vet's lostcancel check; it is a no-op on the
+	// happy path where Wait has already joined every deletion.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	g, subCtx := errgroup.WithContext(ctx)
 	g.SetLimit(_deleteConcurrent)
+
+	var loopErr error
 	for {
 		attr, ok, err := iter.Next(ctx)
 		if err != nil {
-			return fmt.Errorf("storage: delete prefix iter object %w", err)
+			loopErr = fmt.Errorf("storage: delete prefix iter object %w", err)
+			break
 		}
 		if !ok {
 			break
 		}
 		if !strings.HasPrefix(attr.Key, prefix) {
-			return fmt.Errorf("storage: delete prefix key %s not in prefix %s", attr.Key, prefix)
+			loopErr = fmt.Errorf("storage: delete prefix key %s not in prefix %s", attr.Key, prefix)
+			break
 		}
 
 		g.Go(func() error {
@@ -101,8 +113,18 @@ func DeletePrefix(ctx context.Context, cli Client, prefix string) error {
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("storage: delete prefix %w", err)
+	// If the loop bailed early, stop the in-flight deletions so Wait below
+	// returns promptly instead of running them to completion.
+	if loopErr != nil {
+		cancel()
+	}
+
+	waitErr := g.Wait()
+	if loopErr != nil {
+		return loopErr
+	}
+	if waitErr != nil {
+		return fmt.Errorf("storage: delete prefix %w", waitErr)
 	}
 
 	return nil
@@ -113,6 +135,7 @@ func Exist(ctx context.Context, cli Client, prefix string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("storage: exist list prefix %w", err)
 	}
+	defer iter.Close()
 
 	_, ok, err := iter.Next(ctx)
 	if err != nil {

--- a/internal/storage/funcs_test.go
+++ b/internal/storage/funcs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ import (
 type mockObjectIterator struct {
 	objs []ObjectAttr
 	idx  int
+
+	closed bool
 }
 
 func (m *mockObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
@@ -22,6 +25,33 @@ func (m *mockObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
 	obj := m.objs[m.idx]
 	m.idx++
 	return obj, true, nil
+}
+
+func (m *mockObjectIterator) Close() error {
+	m.closed = true
+	return nil
+}
+
+// iterWithError yields objs, then fails the next read so the consumer returns
+// before the listing is drained.
+type iterWithError struct {
+	objs   []ObjectAttr
+	idx    int
+	closed bool
+}
+
+func (m *iterWithError) Next(_ context.Context) (ObjectAttr, bool, error) {
+	if m.idx < len(m.objs) {
+		obj := m.objs[m.idx]
+		m.idx++
+		return obj, true, nil
+	}
+	return ObjectAttr{}, false, assert.AnError
+}
+
+func (m *iterWithError) Close() error {
+	m.closed = true
+	return nil
 }
 
 func TestSize(t *testing.T) {
@@ -34,13 +64,15 @@ func TestSize(t *testing.T) {
 		{Key: "a/b/f", Length: 4},
 	}
 
+	iter := &mockObjectIterator{objs: objs}
 	cli.EXPECT().
 		ListPrefix(context.Background(), "a/b/", true).
-		Return(&mockObjectIterator{objs: objs}, nil)
+		Return(iter, nil)
 
 	size, err := Size(context.Background(), cli, "a/b/")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), size)
+	assert.True(t, iter.closed, "Size must close the iterator")
 }
 
 func TestListPrefixFlat(t *testing.T) {
@@ -53,14 +85,16 @@ func TestListPrefixFlat(t *testing.T) {
 		{Key: "a/b/f", Length: 4},
 	}
 
+	iter := &mockObjectIterator{objs: objs}
 	cli.EXPECT().
 		ListPrefix(context.Background(), "a/b", true).
-		Return(&mockObjectIterator{objs: objs}, nil)
+		Return(iter, nil)
 
 	keys, sizes, err := ListPrefixFlat(context.Background(), cli, "a/b", true)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"a/b/c", "a/b/d", "a/b/e", "a/b/f"}, keys)
 	assert.Equal(t, []int64{1, 2, 3, 4}, sizes)
+	assert.True(t, iter.closed, "ListPrefixFlat must close the iterator")
 }
 
 func TestDeletePrefix(t *testing.T) {
@@ -74,9 +108,10 @@ func TestDeletePrefix(t *testing.T) {
 			{Key: "a/b/f", Length: 4},
 		}
 
+		iter := &mockObjectIterator{objs: objs}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "a/b", true).
-			Return(&mockObjectIterator{objs: objs}, nil)
+			Return(iter, nil)
 
 		for _, obj := range objs {
 			cli.EXPECT().
@@ -86,6 +121,45 @@ func TestDeletePrefix(t *testing.T) {
 
 		err := DeletePrefix(context.Background(), cli, "a/b")
 		assert.NoError(t, err)
+		assert.True(t, iter.closed, "DeletePrefix must close the iterator")
+	})
+
+	t.Run("StopsInflightDeletesOnIterError", func(t *testing.T) {
+		// A raw mock, not NewMockClient, so a leaked goroutine holding the mock
+		// lock on a never-released delete cannot deadlock the test cleanup;
+		// without the errgroup fix the assertion below fails instead.
+		cli := &MockClient{}
+
+		released := make(chan struct{})
+		var once sync.Once
+		// A delete that blocks until its context is canceled. If DeletePrefix
+		// fails to stop the errgroup on early return, the deferred Wait blocks
+		// forever and the test hangs.
+		cli.EXPECT().
+			DeleteObject(mock.MatchedBy(func(ctx context.Context) bool {
+				<-ctx.Done()
+				once.Do(func() { close(released) })
+				return true
+			}), "a/b/c").
+			Return(nil)
+
+		// The iterator yields one object, then errors so DeletePrefix returns
+		// before the listing is drained.
+		iter := &iterWithError{objs: []ObjectAttr{{Key: "a/b/c", Length: 1}}}
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "a/b", true).
+			Return(iter, nil)
+
+		err := DeletePrefix(context.Background(), cli, "a/b")
+		assert.Error(t, err)
+		assert.True(t, iter.closed, "DeletePrefix must close the iterator on early return")
+
+		// The in-flight delete was canceled and joined before returning.
+		select {
+		case <-released:
+		default:
+			assert.Fail(t, "DeletePrefix returned without stopping the in-flight delete")
+		}
 	})
 
 	t.Run("EmptyPrefix", func(t *testing.T) {
@@ -106,25 +180,29 @@ func TestExist(t *testing.T) {
 			{Key: "a/b/f", Length: 4},
 		}
 
+		iter := &mockObjectIterator{objs: objs}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "a/b", false).
-			Return(&mockObjectIterator{objs: objs}, nil)
+			Return(iter, nil)
 
 		exist, err := Exist(context.Background(), cli, "a/b")
 		assert.NoError(t, err)
 		assert.True(t, exist)
+		assert.True(t, iter.closed, "Exist must close the iterator even after a single read")
 	})
 
 	t.Run("NotExist", func(t *testing.T) {
 		cli := NewMockClient(t)
 
+		iter := &mockObjectIterator{}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "a/b", false).
-			Return(&mockObjectIterator{}, nil)
+			Return(iter, nil)
 
 		exist, err := Exist(context.Background(), cli, "a/b")
 		assert.NoError(t, err)
 		assert.False(t, exist)
+		assert.True(t, iter.closed, "Exist must close the iterator")
 	})
 }
 

--- a/internal/storage/gcp_native.go
+++ b/internal/storage/gcp_native.go
@@ -103,6 +103,10 @@ func (g *GcpNativeObjectIterator) Next(_ context.Context) (ObjectAttr, bool, err
 	return ObjectAttr{Key: next.Name, Length: next.Size}, true, nil
 }
 
+// Close is a no-op: the GCP iterator fetches pages synchronously on Next and
+// keeps no background goroutine.
+func (g *GcpNativeObjectIterator) Close() error { return nil }
+
 func (gcm *GCPNativeClient) ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error) {
 	delimiter := ""
 	if !recursive {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -122,6 +122,10 @@ func (l *localIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
 	return entry, true, nil
 }
 
+// Close is a no-op: the local iterator walks the filesystem synchronously in
+// ListPrefix and keeps no background goroutine.
+func (l *localIterator) Close() error { return nil }
+
 func (l *LocalClient) ListPrefix(_ context.Context, prefix string, recursive bool) (ObjectIterator, error) {
 	// check if prefix is a file
 	info, err := os.Stat(prefix)

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -311,7 +311,8 @@ func (m *MinioClient) DeleteObject(ctx context.Context, key string) error {
 type MinioObjectIterator struct {
 	cli *MinioClient
 
-	objCh <-chan minio.ObjectInfo
+	cancel context.CancelFunc
+	objCh  <-chan minio.ObjectInfo
 }
 
 func (m *MinioObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
@@ -326,10 +327,23 @@ func (m *MinioObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) 
 	return ObjectAttr{Key: item.Key, Length: item.Size}, true, nil
 }
 
+// Close stops the background listing goroutine feeding objCh. minio-go's
+// ListObjects only returns once its context is canceled and the channel is
+// drained, so Close both cancels and drains to guarantee the goroutine exits
+// even when the caller stops iterating early. A fully-exhausted iterator is
+// already closed, in which case the drain returns immediately.
+func (m *MinioObjectIterator) Close() error {
+	m.cancel()
+	for range m.objCh {
+	}
+	return nil
+}
+
 func (m *MinioClient) ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error) {
 	opt := minio.ListObjectsOptions{Prefix: prefix, Recursive: recursive}
-	objCh := m.cli.ListObjects(ctx, m.cfg.Bucket, opt)
-	return &MinioObjectIterator{cli: m, objCh: objCh}, nil
+	subCtx, cancel := context.WithCancel(ctx)
+	objCh := m.cli.ListObjects(subCtx, m.cfg.Bucket, opt)
+	return &MinioObjectIterator{cli: m, cancel: cancel, objCh: objCh}, nil
 }
 
 // BucketExist checks if the bucket exists by listing a single object.

--- a/internal/storage/minio_test.go
+++ b/internal/storage/minio_test.go
@@ -206,6 +206,85 @@ func TestBucketExistReturnsFalseForNoSuchBucket(t *testing.T) {
 	assert.False(t, exists)
 }
 
+// TestMinioObjectIteratorCloseStopsGoroutine verifies that closing an iterator
+// before the listing is exhausted actually stops minio-go's background listing
+// goroutine. The fake transport returns a truncated first page with a
+// continuation token, so the goroutine is still alive fetching the next page
+// when Close is called; Close must cancel it and drain until it exits.
+func TestMinioObjectIteratorCloseStopsGoroutine(t *testing.T) {
+	cli, err := newInternalMinio(Config{
+		Provider: "s3",
+		Endpoint: "example.com",
+		UseSSL:   true,
+		Bucket:   "test-bucket",
+		Credential: Credential{
+			Type: Static,
+			AK:   "ak",
+			SK:   "sk",
+		},
+	}, &minio.Options{
+		Secure: true,
+		Creds:  credentials.NewStaticV4("ak", "sk", ""),
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			if _, ok := r.URL.Query()["location"]; ok {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/xml"}},
+					Body:       io.NopCloser(strings.NewReader(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`)),
+					Request:    r,
+				}, nil
+			}
+
+			if r.URL.Query().Get("list-type") != "2" {
+				return nil, errors.New("unexpected request")
+			}
+
+			// A follow-up page blocks until its request context is canceled,
+			// so the test would hang if the goroutine is not stopped.
+			if token := r.URL.Query().Get("continuation-token"); token != "" {
+				<-r.Context().Done()
+				return nil, r.Context().Err()
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/xml"}},
+				Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Name>test-bucket</Name>
+  <Prefix></Prefix>
+  <IsTruncated>true</IsTruncated>
+  <Contents>
+    <Key>first-object</Key>
+    <Size>1</Size>
+  </Contents>
+  <NextContinuationToken>next-page</NextContinuationToken>
+</ListBucketResult>`)),
+				Request: r,
+			}, nil
+		}),
+	})
+	require.NoError(t, err)
+
+	iter, err := cli.ListPrefix(context.Background(), "prefix/", true)
+	require.NoError(t, err)
+
+	attr, ok, err := iter.Next(context.Background())
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "first-object", attr.Key)
+
+	// The listing is truncated, so the goroutine is alive fetching page two.
+	// Close must cancel it and drain the channel until it has exited.
+	require.NoError(t, iter.Close())
+
+	// After Close the channel is closed and drained: Next reports exhaustion
+	// rather than a cancellation error left in the channel.
+	_, ok, err = iter.Next(context.Background())
+	assert.False(t, ok)
+	assert.NoError(t, err)
+}
+
 func TestBucketExistPropagatesContextCancellation(t *testing.T) {
 	cli, err := newInternalMinio(Config{
 		Provider: "s3",

--- a/internal/storage/object_iterator_mock.go
+++ b/internal/storage/object_iterator_mock.go
@@ -18,6 +18,8 @@ func (m *MockObjectIterator) Next(_ context.Context) (ObjectAttr, bool, error) {
 	return obj, true, nil
 }
 
+func (m *MockObjectIterator) Close() error { return nil }
+
 func NewMockObjectIterator(objs []ObjectAttr) *MockObjectIterator {
 	return &MockObjectIterator{objs: objs}
 }

--- a/internal/storage/verify_task.go
+++ b/internal/storage/verify_task.go
@@ -51,6 +51,7 @@ func (t *VerifyPrefixTask) Execute(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("storage: verify prefix list prefix %w", err)
 	}
+	defer iter.Close()
 
 	// Track keys not yet seen in the listing; drop each as it is found.
 	missing := make(map[string]int64, len(t.opt.Expected))

--- a/internal/storage/verify_task_test.go
+++ b/internal/storage/verify_task_test.go
@@ -16,9 +16,10 @@ func TestVerifyPrefixTask_Execute(t *testing.T) {
 			{Key: "dest/a", Length: 1},
 			{Key: "dest/b", Length: 2},
 		}
+		iter := &mockObjectIterator{objs: objs}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "dest/", true).
-			Return(&mockObjectIterator{objs: objs}, nil).Once()
+			Return(iter, nil).Once()
 
 		task := NewVerifyPrefixTask(VerifyPrefixOpt{
 			Cli:      cli,
@@ -26,6 +27,7 @@ func TestVerifyPrefixTask_Execute(t *testing.T) {
 			Expected: map[string]int64{"dest/a": 1, "dest/b": 2},
 		})
 		assert.NoError(t, task.Execute(context.Background()))
+		assert.True(t, iter.closed, "VerifyPrefixTask must close the iterator")
 	})
 
 	t.Run("ExtraObjectsIgnored", func(t *testing.T) {
@@ -49,9 +51,10 @@ func TestVerifyPrefixTask_Execute(t *testing.T) {
 	t.Run("SizeMismatch", func(t *testing.T) {
 		cli := NewMockClient(t)
 		objs := []ObjectAttr{{Key: "dest/a", Length: 3}}
+		iter := &mockObjectIterator{objs: objs}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "dest/", true).
-			Return(&mockObjectIterator{objs: objs}, nil).Once()
+			Return(iter, nil).Once()
 
 		task := NewVerifyPrefixTask(VerifyPrefixOpt{
 			Cli:      cli,
@@ -61,6 +64,7 @@ func TestVerifyPrefixTask_Execute(t *testing.T) {
 		err := task.Execute(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size mismatch")
+		assert.True(t, iter.closed, "VerifyPrefixTask must close the iterator on error")
 	})
 
 	t.Run("Missing", func(t *testing.T) {
@@ -149,13 +153,15 @@ func TestExpectedDestObjects(t *testing.T) {
 			{Key: "src/sub/b", Length: 2},
 			{Key: "src/dir/", Length: 0}, // directory marker, must be skipped
 		}
+		iter := &mockObjectIterator{objs: objs}
 		cli.EXPECT().
 			ListPrefix(mock.Anything, "src/", true).
-			Return(&mockObjectIterator{objs: objs}, nil).Once()
+			Return(iter, nil).Once()
 
 		expected, err := ExpectedDestObjects(context.Background(), cli, "src/", "dest/")
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]int64{"dest/a": 1, "dest/sub/b": 2}, expected)
+		assert.True(t, iter.closed, "ExpectedDestObjects must close the iterator")
 	})
 
 	t.Run("ListError", func(t *testing.T) {


### PR DESCRIPTION
## Summary

minio-go's `ListObjects` spawns a background goroutine that feeds a channel and only returns once its context is cancelled and the channel is drained. The iterators returned by `ListPrefix` left that goroutine running when a consumer stopped early: `ListPrefixFlat`, `DeletePrefix` and `Exist` in `funcs.go` (and `CopyPrefixTask`/`VerifyPrefixTask`) returned on error or after a single read without stopping it, leaking a goroutine that keeps listing the whole prefix until the creation context is cancelled.

The same functions also abandoned errgroup workers on early return: `DeletePrefix`, `CopyPrefixTask.Execute` and `CopyObjectsTask.Execute` spawned delete/copy goroutines via `errgroup`, then returned before `g.Wait()` on an iterator or semaphore-acquire error, leaving the workers running with a context that never gets cancelled (errgroup only cancels its derived context when a worker errors or `Wait` returns).

The iterator now owns its lifecycle and errgroup workers are joined on every exit path. `ObjectIterator` embeds `io.Closer`, every consumer defers `iter.Close()`, and the minio iterator cancels its listing context and drains the channel so the goroutine deterministically exits. Azure, GCP and local iterators are pull-based, so their `Close` is a no-op. The errgroup consumers capture the loop error, break out, cancel the in-flight workers when bailing early, and join them through a single `g.Wait()`; a `defer cancel()` keeps `go vet`'s lostcancel check satisfied on the happy path.

## Changes

- add `Close` to `ObjectIterator` (`io.Closer`) with a documented caller contract
- minio: cancel the listing context and drain on `Close` so the goroutine exits even on early stop
- `defer iter.Close()` in `ListPrefixFlat`, `DeletePrefix`, `Exist`, `CopyPrefixTask` and `VerifyPrefixTask`
- `DeletePrefix`, `CopyPrefixTask.Execute` and `CopyObjectsTask.Execute`: single `g.Wait()` on every exit path, cancelling in-flight workers first when the loop bails early
- tests: assert each consumer closes the iterator; a transport-level test that `Close` stops a live truncated listing; regression tests that early-return paths cancel and join in-flight deletes/copies (verified to fail fast without the fixes)

/kind improvement
