### PR TITLE
test: backup index extra in secondary restore test

### DIFF
--- a/tests/testcases/test_restore_secondary.py
+++ b/tests/testcases/test_restore_secondary.py
@@ -37,6 +37,7 @@ class TestRestoreSecondary(TestcaseBase):
             "async": False,
             "backup_name": back_up_name,
             "collection_names": names_need_backup,
+            "with_index_extra": True,
         }
         res = self.client.create_backup(payload)
         log.info(f"create backup response: {res}")


### PR DESCRIPTION
## Summary

The secondary restore test was creating the backup without `with_index_extra`, but the backup used for a secondary restore needs the index extra info (the CI `test-backup-restore-secondary` job already passes `--backup_index_extra`). This aligns the API test with that behavior.

## Changes
- add `with_index_extra: True` to the create backup payload in `test_restore_secondary.py`

/kind improvement