### PR TITLE
cfg: keep azure iam auth when migrating v1 config to v2

### DIFF
--- a/internal/cfg/migrate/migrate.go
+++ b/internal/cfg/migrate/migrate.go
@@ -221,10 +221,18 @@ func migrateStorageSide(out *v2.StorageConfig, in storageV1, side string, r *Rep
 	case provider == v2.ProviderLocal:
 		// Local storage is a directory: no endpoint, no credentials.
 	case provider == v2.ProviderAzure:
-		// v1 overloaded the access key ID as the Azure account name.
+		// v1 overloaded the access key ID as the Azure account name. The name is
+		// needed whichever way the account authenticates, so it is always carried
+		// over; only the credential differs.
 		out.AccountName.Val = in.accessKeyID
-		out.Auth.Type.Val = v2.AuthSharedKey
-		mapSecret(&out.Auth.AccountKey, in.secretAccessKey, storageEnv(side, "AUTH_ACCOUNT_KEY"), r)
+		if in.useIAM {
+			// v1's useIAM for Azure meant DefaultAzureCredential (managed
+			// identity / workload identity): no account key is required.
+			out.Auth.Type.Val = v2.AuthDefault
+		} else {
+			out.Auth.Type.Val = v2.AuthSharedKey
+			mapSecret(&out.Auth.AccountKey, in.secretAccessKey, storageEnv(side, "AUTH_ACCOUNT_KEY"), r)
+		}
 	case provider == v2.ProviderGCPNative:
 		out.Auth.Type.Val = v2.AuthServiceAccount
 		mapSecret(&out.Auth.CredentialsFile, in.gcpCredentialJSON, storageEnv(side, "AUTH_CREDENTIALS_FILE"), r)

--- a/internal/cfg/migrate/migrate_test.go
+++ b/internal/cfg/migrate/migrate_test.go
@@ -157,6 +157,24 @@ minio:
 		assert.Equal(t, "mykey", s.Auth.AccountKey.Val)
 	})
 
+	// v1's useIAM for Azure meant DefaultAzureCredential (managed identity /
+	// workload identity): the account name is still carried to build the blob
+	// URL, but no account key exists to migrate.
+	t.Run("AzureUseIAM", func(t *testing.T) {
+		out, _ := Migrate(loadV1(t, `
+minio:
+  storageType: azure
+  useIAM: true
+  accessKeyID: myaccount
+  bucketName: mycontainer
+`))
+		s := out.Milvus.Storage
+		assert.Equal(t, v2.ProviderAzure, s.Provider.Val)
+		assert.Equal(t, "myaccount", s.AccountName.Val)
+		assert.Equal(t, v2.AuthDefault, s.Auth.Type.Val)
+		assert.Equal(t, "", s.Auth.AccountKey.Val)
+	})
+
 	t.Run("GCPNative", func(t *testing.T) {
 		out, _ := Migrate(loadV1(t, `
 minio:

--- a/internal/cfg/migrate/translate_test.go
+++ b/internal/cfg/migrate/translate_test.go
@@ -96,6 +96,29 @@ func TestTranslate_CrossStorageStreams(t *testing.T) {
 	assert.Equal(t, v2.TransferStreaming, out.Transfer.Mode.Val)
 }
 
+// The loader path is what a v1 file hits at startup. Azure with useIAM used to
+// be forced to auth.type=sharedKey, and the empty account key then tripped the
+// v2 validator ("milvus.storage.auth.accountKey is required"), panicking the
+// process. It must translate to auth.type=default instead.
+func TestTranslate_AzureUseIAM(t *testing.T) {
+	out, err := Translate(loadV1(t, `
+minio:
+  storageType: azure
+  useIAM: true
+  accessKeyID: myaccount
+  backupAccessKeyID: backupaccount
+  backupBucketName: backups
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, v2.AuthDefault, out.Milvus.Storage.Auth.Type.Val)
+	assert.Equal(t, "myaccount", out.Milvus.Storage.AccountName.Val)
+	// The backup side inherits useIAM from the primary in v1, so it must land
+	// on default too rather than demand an account key.
+	assert.Equal(t, v2.AuthDefault, out.Backup.Storage.Auth.Type.Val)
+	assert.Equal(t, "backupaccount", out.Backup.Storage.AccountName.Val)
+}
+
 // v1 never validated the provider name and only failed when it came time to
 // build a client. Translating runs the v2 validator, so the mistake surfaces
 // while the config is being loaded.


### PR DESCRIPTION
## Summary
Fixes #1153
A v1 config that points storage at Azure Blob with `useIAM: true` (managed identity) panics at startup, because the v1→v2 translation forces `auth.type=sharedKey` and demands an account key that an IAM setup does not have. The Azure branch of the translation now honors `useIAM` and maps it to `auth.type=default` (DefaultAzureCredential), which is what v1 did.

## Changes
- internal/cfg/migrate: translate azure + useIAM to `auth.type=default` instead of `sharedKey`, so no account key is required
- add migrate and translate tests covering the azure useIAM path on both the milvus and backup storage sides
