### PR TITLE
ci: add api secondary restore test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1027,6 +1027,126 @@ jobs:
             /tmp/schema_verify_*.json
             ./server.log
 
+  test-backup-restore-secondary-api:
+    needs: unit-test-go
+    name: Backup and restore secondary api
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - uses: actions/setup-go@v7
+        name: Set up Go ${{ env.go-version }}
+        with:
+          go-version: ${{ env.go-version }}
+          cache: true
+
+      - name: Build
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          go get
+          go build
+          go build -o inittarget ./cmd/inittarget
+
+      - name: Install dependency
+        timeout-minutes: 5
+        working-directory: tests
+        shell: bash
+        run: |
+          pip install -r requirements.txt --trusted-host https://test.pypi.org
+
+      - name: Deploy dual Milvus
+        timeout-minutes: 15
+        shell: bash
+        working-directory: deployment/secondary
+        run: |
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag 2.6-latest) && echo $tag
+          yq -i ".services.upstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          yq -i ".services.downstream-standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          mkdir -p volumes/etcd volumes/minio volumes/upstream volumes/downstream volumes/upstream-runtime volumes/downstream-runtime
+          sudo chmod -R 777 volumes
+          sudo docker compose -f docker-compose.yml up -d --wait
+          sudo docker compose -f docker-compose.yml ps -a
+
+      - name: Configure backup configs for upstream and downstream
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          # create (upstream) and restore secondary (downstream) reach different
+          # Milvus instances, so each gets its own backup server and config.
+          cp configs/backup.yaml configs/backup-secondary-upstream.yaml
+          cp configs/backup.yaml configs/backup-secondary-downstream.yaml
+          # upstream server config: reach the upstream Milvus and its etcd rootPath
+          yq -i '.milvus.grpc.port = 19530' configs/backup-secondary-upstream.yaml
+          yq -i '.milvus.storage.bucketName = "milvus-backup-test"' configs/backup-secondary-upstream.yaml
+          yq -i '.milvus.storage.rootPath = "backup-test-upstream"' configs/backup-secondary-upstream.yaml
+          yq -i '.backup.storage.bucketName = "milvus-backup-test"' configs/backup-secondary-upstream.yaml
+          yq -i '.milvus.replicate.rpcChannelName = "backup-test-upstream-replicate-msg"' configs/backup-secondary-upstream.yaml
+          yq -i '.milvus.etcd.rootPath = "backup-test-upstream"' configs/backup-secondary-upstream.yaml
+          # downstream server config: reach the downstream Milvus and share the
+          # same backup storage so it reads the backup the upstream server wrote
+          yq -i '.milvus.grpc.port = 19500' configs/backup-secondary-downstream.yaml
+          yq -i '.backup.storage.bucketName = "milvus-backup-test"' configs/backup-secondary-downstream.yaml
+          cat configs/backup-secondary-upstream.yaml
+
+      - name: Init downstream replicate configuration
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          ./inittarget --target downstream \
+            --upstream-uri upstream-standalone:19530 \
+            --downstream-uri downstream-standalone:19530
+
+      - name: Run secondary restore api test
+        timeout-minutes: 20
+        shell: bash
+        run: |
+          set -e
+          # start both backup servers in the same step so they outlive the shell
+          nohup ./milvus-backup server --config configs/backup-secondary-upstream.yaml --port 8081 > /tmp/backup_server_upstream.log 2>&1 &
+          nohup ./milvus-backup server --config configs/backup-secondary-downstream.yaml --port 8082 > /tmp/backup_server_downstream.log 2>&1 &
+          trap 'kill $(jobs -p) || true' EXIT
+          sleep 5
+          curl -f http://localhost:8081/api/v1/hello
+          curl -f http://localhost:8082/api/v1/hello
+          cd tests
+          pytest -s -v --tags SECONDARY \
+            --backup_uri http://localhost:8081 \
+            --backup_uri_secondary http://localhost:8082 \
+            --secondary_milvus_uri http://localhost:19500
+
+      - name: Export backup server logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/ci_logs
+          cat /tmp/backup_server_upstream.log > /tmp/ci_logs/backup_server_upstream.log || true
+          cat /tmp/backup_server_downstream.log > /tmp/ci_logs/backup_server_downstream.log || true
+
+      - name: Export Milvus logs
+        if: ${{ always() }}
+        shell: bash
+        working-directory: deployment/secondary
+        run: |
+          sudo docker compose -f docker-compose.yml logs upstream-standalone > /tmp/ci_logs/upstream.log 2>&1 || true
+          sudo docker compose -f docker-compose.yml logs downstream-standalone > /tmp/ci_logs/downstream.log 2>&1 || true
+          sudo docker compose -f docker-compose.yml logs etcd > /tmp/ci_logs/etcd.log 2>&1 || true
+          sudo docker compose -f docker-compose.yml logs minio > /tmp/ci_logs/minio.log 2>&1 || true
+
+      - name: Upload logs
+        if: ${{ ! success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: secondary-restore-api-logs
+          path: |
+            /tmp/ci_logs
+
   test-backup-restore-with-rbac-config:
     needs: unit-test-go
     name: Backup and restore with rbac config
@@ -1316,6 +1436,7 @@ jobs:
       - test-backup-restore-after-upgrade
       - test-backup-restore-cli
       - test-backup-restore-secondary
+      - test-backup-restore-secondary-api
       - test-backup-restore-with-rbac-config
       - test-backup-restore-api
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,18 @@ def pytest_addoption(parser):
         default="http://localhost:8080",
         help="backup server uri",
     )
+    parser.addoption(
+        "--backup_uri_secondary",
+        action="store",
+        default="http://localhost:8080",
+        help="secondary backup server uri (restore secondary targets the downstream)",
+    )
+    parser.addoption(
+        "--secondary_milvus_uri",
+        action="store",
+        default="http://localhost:19500",
+        help="downstream milvus uri (used to verify secondary restore result)",
+    )
     parser.addoption("--host", action="store", default="localhost", help="service's ip")
     parser.addoption("--service", action="store", default="", help="service address")
     parser.addoption("--port", action="store", default=19530, help="service's port")
@@ -126,6 +138,16 @@ def pytest_addoption(parser):
 @pytest.fixture
 def backup_uri(request):
     return request.config.getoption("--backup_uri")
+
+
+@pytest.fixture
+def backup_uri_secondary(request):
+    return request.config.getoption("--backup_uri_secondary")
+
+
+@pytest.fixture
+def secondary_milvus_uri(request):
+    return request.config.getoption("--secondary_milvus_uri")
 
 
 @pytest.fixture

--- a/tests/testcases/test_restore_secondary.py
+++ b/tests/testcases/test_restore_secondary.py
@@ -1,4 +1,5 @@
 import pytest
+from pymilvus import MilvusClient
 from base.client_base import TestcaseBase
 from common import common_func as cf
 from common import common_type as ct
@@ -16,8 +17,11 @@ class TestRestoreSecondary(TestcaseBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("is_async", [False])
     @pytest.mark.tags(CaseLabel.SECONDARY)
-    def test_secondary_restore_basic(self, is_async, nb):
-        # prepare data
+    def test_secondary_restore_basic(
+        self, is_async, nb, backup_uri_secondary, secondary_milvus_uri
+    ):
+        # prepare data with index and load so the backup captures index extra
+        # and the restore replicates the load state to the downstream
         self._connect()
         names_origin = []
         back_up_name = cf.gen_unique_str(backup_prefix)
@@ -28,38 +32,62 @@ class TestRestoreSecondary(TestcaseBase):
                 nb=nb,
                 is_binary=is_binary,
                 auto_id=False,
-                check_function=False,
+                check_function=True,
             )
 
-        # create backup
-        names_need_backup = names_origin
+        # create backup on the upstream via the upstream backup server
         payload = {
             "async": False,
             "backup_name": back_up_name,
-            "collection_names": names_need_backup,
+            "collection_names": names_origin,
             "with_index_extra": True,
+            "format": "binlog",
         }
         res = self.client.create_backup(payload)
         log.info(f"create backup response: {res}")
-        assert res["code"] == 200
+        assert res.get("code", 0) == 0
 
-        # restore secondary
+        # the backup must carry the etcd index extra attributes; without them
+        # the secondary restore rebuilds the index with field_id=0 and empty
+        # user_index_params, breaking the downstream index state
+        backup = self.client.get_backup(back_up_name)
+        for coll in backup["data"]["collection_backups"]:
+            assert len(coll["index_infos"]) > 0, (
+                f"collection {coll['collection_name']} has no index info"
+            )
+            for index in coll["index_infos"]:
+                assert index["field_id"] != 0
+                assert len(index["user_index_params"]) > 0
+
+        # restore secondary into the downstream via the downstream backup server
+        downstream = MilvusBackupClient(f"{backup_uri_secondary}/api/v1")
         payload = {
             "async": is_async,
             "backup_name": back_up_name,
-            "source_cluster_id": "backup-test-upstream",
-            "target_cluster_id": "backup-test-downstream",
+            "sourceClusterID": "backup-test-upstream",
+            "targetClusterID": "backup-test-downstream",
         }
-        res = self.client.restore_secondary(payload)
+        res = downstream.restore_secondary(payload)
         log.info(f"restore secondary response: {res}")
-        assert res["code"] == 200
+        assert res.get("code", 0) == 0
 
         if is_async:
             restore_id = res["data"]["id"]
-            success = self.client.wait_restore_complete(restore_id)
+            success = downstream.wait_restore_complete(restore_id)
             assert success
 
-        # verify collections exist on upstream (same instance in API test)
+        # verify collections still exist on upstream
         res, _ = self.utility_wrap.list_collections()
         for name in names_origin:
             assert name in res
+
+        # verify the collections and data were actually restored on downstream
+        down_client = MilvusClient(uri=secondary_milvus_uri, token="root:Milvus")
+        down_collections = down_client.list_collections()
+        for name in names_origin:
+            assert name in down_collections
+        for name in names_origin:
+            count = down_client.query(
+                collection_name=name, output_fields=["count(*)"], limit=1
+            )
+            assert count[0]["count(*)"] > 0


### PR DESCRIPTION
## Summary

Wire the SECONDARY-tagged pytest `test_restore_secondary.py` into CI so the HTTP-API
secondary-restore flow is actually exercised. The test had never run: the api-test matrix
only passes `--tags {L0,L1,L2,RELEASE,RBAC}` and `pytest-tags` deselects SECONDARY tests.
It was also broken in several ways that a real run exposes:

- `res["code"] == 200` raised `KeyError` on success (success `code=0` is omitted by omitempty)
- `source_cluster_id`/`target_cluster_id` never bound to `sourceClusterID`/`targetClusterID`
- data was not indexed/loaded, so `with_index_extra` had nothing to capture and the load
  state was not replicated downstream

## Changes

- `tests/testcases/test_restore_secondary.py`: fix the success assertion and the
  restore_secondary field names; add `with_index_extra` + `format: binlog` to the create
  payload; prepare indexed/loaded data; assert the backup carries the index extra
  attributes (`field_id`/`user_index_params`); verify the restored collections and data
  on the downstream (19500) in addition to the upstream.
- `tests/conftest.py`: add `--backup_uri_secondary` and `--secondary_milvus_uri` options
  so the test can reach a downstream-pointed backup server and the downstream Milvus.
- `.github/workflows/main.yaml`: new `test-backup-restore-secondary-api` job that deploys
  the existing dual-cluster `deployment/secondary` environment, runs `inittarget` to
  register the downstream, starts two backup servers (upstream :8081 for create,
  downstream :8082 for restore secondary), and runs `pytest --tags SECONDARY`.

/kind improvement