### PR TITLE
storage: fix typos in error messages and comments

### DIFF
--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -145,7 +145,7 @@ type Client interface {
 	// ListPrefix list all objects with same prefix, and call WalkFunc for each object.
 	ListPrefix(ctx context.Context, prefix string, recursive bool) (ObjectIterator, error)
 
-	// BucketExist use a prefix to chack if bucket exist.
+	// BucketExist use a prefix to check if bucket exist.
 	// Using a prefix to confirm whether a bucket exists can avoid requesting the head Bucket permission.
 	BucketExist(ctx context.Context, prefix string) (bool, error)
 	// CreateBucket create a bucket.

--- a/internal/storage/hwc.go
+++ b/internal/storage/hwc.go
@@ -27,12 +27,12 @@ func (c *HwcCredentialProvider) RetrieveWithCredContext(_ *minioCred.CredContext
 func (c *HwcCredentialProvider) Retrieve() (minioCred.Value, error) {
 	cred, err := retrieveTempCredential(c.iamClient)
 	if err != nil {
-		return minioCred.Value{}, fmt.Errorf("storage: hwc retrieve tempporary credential %w", err)
+		return minioCred.Value{}, fmt.Errorf("storage: hwc retrieve temporary credential %w", err)
 	}
 
 	ti, err := time.Parse(time.RFC3339Nano, cred.ExpiresAt)
 	if err != nil {
-		return minioCred.Value{}, fmt.Errorf("storage: hwc retrieve tempporary credential parse expireTime time %w", err)
+		return minioCred.Value{}, fmt.Errorf("storage: hwc retrieve temporary credential parse expireTime time %w", err)
 	}
 
 	c.expireTime = ti
@@ -68,12 +68,12 @@ func newHwcCredProvider(cfg Config) (minioCred.Provider, error) {
 
 	cred, err := retrieveTempCredential(iamClient)
 	if err != nil {
-		return nil, fmt.Errorf("storage: hwc create tempporary credential %w", err)
+		return nil, fmt.Errorf("storage: hwc create temporary credential %w", err)
 	}
 
 	t, err := time.Parse(time.RFC3339Nano, cred.ExpiresAt)
 	if err != nil {
-		return nil, fmt.Errorf("storage: hwc create tempporary parse expireTime time %w", err)
+		return nil, fmt.Errorf("storage: hwc create temporary parse expireTime time %w", err)
 	}
 
 	return &HwcCredentialProvider{iamClient: iamClient, expireTime: t}, nil

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -197,7 +197,7 @@ func (l *LocalClient) listNonRecursive(prefix string) ([]ObjectAttr, error) {
 
 func (l *LocalClient) DeleteObject(_ context.Context, key string) error {
 	if err := os.Remove(key); err != nil {
-		return fmt.Errorf("storage: local delete prefix %w", err)
+		return fmt.Errorf("storage: local delete object %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
/kind improvement

## What this PR does

Fixes copy-paste and spelling mistakes in the storage package:

- `internal/storage/local.go`: `DeleteObject` error message said "delete prefix"; now "delete object"
- `internal/storage/client.go`: comment typo "chack" → "check"
- `internal/storage/hwc.go`: six occurrences of "tempporary" → "temporary"

Pure text changes, no behavior difference. Verified with `go build ./internal/storage/`.