### PR TITLE
restore: stop bulk insert polling on context cancellation

### DIFF
--- a/core/restore/coll_task.go
+++ b/core/restore/coll_task.go
@@ -793,7 +793,9 @@ func (ct *collTask) checkBulkInsertViaGrpc(ctx context.Context, jobID int64) err
 	// wait for bulk insert job done
 	var lastProgress int
 	lastUpdateTime := time.Now()
-	for range time.Tick(_bulkInsertCheckInterval) {
+	ticker := time.NewTicker(_bulkInsertCheckInterval)
+	defer ticker.Stop()
+	for {
 		state, err := ct.grpcCli.GetBulkInsertState(ctx, jobID)
 		if err != nil {
 			return fmt.Errorf("restore_collection: failed to get bulk insert state: %w", err)
@@ -819,11 +821,14 @@ func (ct *collTask) checkBulkInsertViaGrpc(ctx context.Context, jobID int64) err
 					zap.Duration("timeout", _bulkInsertTimeout))
 				lastUpdateTime = time.Now()
 			}
-			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("restore_collection: wait bulk insert state %w", ctx.Err())
+		case <-ticker.C:
 		}
 	}
-
-	return errors.New("restore_collection: walk into unreachable code")
 }
 
 func (ct *collTask) bulkInsertViaGrpc(ctx context.Context, partitionName string, b batch) error {
@@ -871,7 +876,9 @@ func (ct *collTask) checkBulkInsertViaRestful(ctx context.Context, jobID string)
 	// wait for bulk insert job done
 	var lastProgress int
 	lastUpdateTime := time.Now()
-	for range time.Tick(_bulkInsertCheckInterval) {
+	ticker := time.NewTicker(_bulkInsertCheckInterval)
+	defer ticker.Stop()
+	for {
 		resp, err := ct.restfulCli.GetBulkInsertState(ctx, ct.targetNS.DBName(), jobID)
 		if err != nil {
 			return fmt.Errorf("restore_collection: failed to get bulk insert state: %w", err)
@@ -899,11 +906,14 @@ func (ct *collTask) checkBulkInsertViaRestful(ctx context.Context, jobID string)
 					zap.Duration("timeout", _bulkInsertTimeout))
 				lastUpdateTime = time.Now()
 			}
-			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("restore_collection: wait bulk insert state %w", ctx.Err())
+		case <-ticker.C:
 		}
 	}
-
-	return errors.New("restore_collection: walk into unreachable code")
 }
 
 func (ct *collTask) bulkInsertViaRestful(ctx context.Context, partition string, b batch) error {


### PR DESCRIPTION
Fixes #1157

## Summary

The bulk insert state polling loops in `checkBulkInsertViaGrpc` and `checkBulkInsertViaRestful` (`core/restore/coll_task.go`) used `for range time.Tick(...)` and never checked `ctx.Done()` in the loop itself. Cancellation only surfaced indirectly, when the next `GetBulkInsertState` RPC failed with a context error, so a cancelled restore task kept polling for up to another poll interval (and, in a stale-success race at the moment of cancellation, longer). The loops also leaked their tickers.

## Changes

- Both loops now use `time.NewTicker` with `select { <-ctx.Done(); <-ticker.C }` between polls, mirroring the secondary restore implementation in `core/restore/secondary/coll_dml_task.go`
- Drop the trailing `return errors.New(...)` lines, which became unreachable (govet) once the loops were rewritten as unbounded `for {}`
- Polling cadence and no-progress watchdog behavior are unchanged

## Test plan

- `go test ./core/restore/` passes
- golangci-lint clean on the changed package
