### PR TITLE
ci: re-enable testing against milvus master images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -92,7 +92,7 @@ jobs:
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
         source_image_tag: [v2.2.16, v2.3.22, v2.4.23, v2.5.20, 2.6-latest]
-        target_image_tag: [2.6-latest]
+        target_image_tag: [master-latest, 2.6-latest]
         exclude:
           - source_image_tag: 2.6-latest
             target_image_tag: 2.6-latest
@@ -471,7 +471,7 @@ jobs:
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
         source_image_tag: [2.5-latest]
-        target_image_tag: [2.6-latest]
+        target_image_tag: [master-latest, 2.6-latest]
         exclude:
           - source_image_tag: 2.6-latest
             target_image_tag: 2.6-latest
@@ -616,7 +616,7 @@ jobs:
         deploy_tools: [docker-compose]
         milvus_mode: [standalone]
         another_milvus_mode: [standalone]
-        image_tag: [2.6-latest]
+        image_tag: [master-latest, 2.6-latest]
         # mq_type: [pulsar, kafka]  # TODO: add pulsar and kafka
 
     steps:
@@ -779,6 +779,94 @@ jobs:
         run: |
           ./milvus-backup restore -n my_backup -s _recover
       - name: Verify data from another Milvus
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          python example/verify_data.py
+
+  test-backup-restore-master-loonffi:
+    needs: unit-test-go
+    name: Backup and restore master (useLoonFFI=${{ matrix.use_loonffi }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        use_loonffi: [true, false]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - uses: actions/setup-go@v7
+        name: Set up Go ${{ env.go-version }}
+        with:
+          go-version: ${{ env.go-version }}
+          cache: true
+
+      - name: Build
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          go get
+          go build
+
+      - name: Install dependency
+        timeout-minutes: 5
+        working-directory: tests
+        shell: bash
+        run: |
+          pip install -r requirements.txt --trusted-host https://test.pypi.org
+
+      - name: Milvus deploy
+        timeout-minutes: 15
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag master-latest) && echo $tag
+          yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          yq -i '.common.storage.useLoonFFI = ${{ matrix.use_loonffi }}' custom_config.yaml
+          cat custom_config.yaml || true
+          mkdir -p volumes/etcd volumes/minio volumes/milvus
+          sudo chmod -R 777 volumes
+          sudo docker compose -f docker-compose.yml up -d --wait
+          sudo docker compose -f docker-compose.yml ps -a
+
+      - name: Export docker-compose status
+        if: ${{ always() }}
+        shell: bash
+        working-directory: deployment/standalone
+        run: |
+          echo "=== Docker Compose Status ==="
+          sudo docker compose -f docker-compose.yml ps -a || true
+          echo "=== Standalone Container Full Logs ==="
+          sudo docker compose -f docker-compose.yml logs standalone || true
+
+      - name: Prepare data
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          python example/prepare_data.py
+
+      - name: Backup
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          ./milvus-backup check
+          ./milvus-backup list
+          ./milvus-backup create -n my_backup
+          ./milvus-backup list
+
+      - name: Restore backup
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          ./milvus-backup restore -n my_backup -s _recover
+
+      - name: Verify data
         timeout-minutes: 5
         shell: bash
         run: |
@@ -1036,7 +1124,7 @@ jobs:
       matrix:
         deploy_tools: [helm]
         milvus_mode: [standalone]
-        image_tag: [2.6-latest]
+        image_tag: [master-latest, 2.6-latest]
 
     steps:
       - uses: actions/checkout@v7
@@ -1134,7 +1222,13 @@ jobs:
         run: |
           ./milvus-backup check
           ./milvus-backup list
-          ./milvus-backup create -n my_backup --rbac
+          # Pin binlog: this job writes the backup into the restore cluster's own
+          # MinIO (port 9010), a different storage server than the source Milvus.
+          # Snapshot export is a server-side copy within one storage service and
+          # cannot span two MinIO deployments; binlog streams through milvus-backup,
+          # which is also what the job's transfer.mode=streaming exercises. A no-op
+          # on 2.6, where auto resolves to binlog anyway.
+          ./milvus-backup create -n my_backup --rbac --format=binlog
           ./milvus-backup list
       - name: Modify Restore Config
         timeout-minutes: 5
@@ -1198,8 +1292,11 @@ jobs:
       matrix:
         deploy_tools: [docker-compose]
         milvus_mode: [standalone]
-        image_tag: [2.6-latest]
-        case_tag: [L0, L1, L2, RELEASE, RBAC]
+        image_tag: [master-latest, 2.6-latest]
+        case_tag: [L0, L1, L2, MASTER, RELEASE, RBAC]
+        exclude:
+          - image_tag: 2.6-latest
+            case_tag: MASTER
 
     steps:
       - uses: actions/checkout@v7
@@ -1239,7 +1336,7 @@ jobs:
         shell: bash
         working-directory: deployment/${{ matrix.milvus_mode }}
         run: |
-          if [ ${{ matrix.case_tag }} == "RELEASE" ]; then
+          if [ ${{ matrix.case_tag }} == "MASTER" ] || [ ${{ matrix.case_tag }} == "RELEASE" ]; then
             mv docker-compose-tei.yml docker-compose.yml
           fi
           if [ ${{ matrix.case_tag }} == "RBAC" ]; then
@@ -1247,6 +1344,16 @@ jobs:
           fi
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.image_tag }}) && echo $tag
           yq -i ".services.standalone.image=\"milvusdb/milvus:${tag}\"" docker-compose.yml
+          # On master, keep auto compaction on even though the l0compact suite
+          # wants it off: master enables sort compaction, whose event-driven
+          # trigger ignores enableAutoCompaction while the periodic retry
+          # honors it. With it off, a sort compaction rejected by a snapshot
+          # export pin is never retried, the segment stays unsorted and is
+          # never indexed, and any create_index on the collection hangs
+          # forever. The l0compact cases only pass on 2.6 anyway.
+          if [ ${{ matrix.image_tag }} == "master-latest" ]; then
+            yq -i '.dataCoord.compaction.enableAutoCompaction = true' custom_config.yaml
+          fi
           cat custom_config.yaml || true
           mkdir -p volumes/etcd volumes/minio volumes/milvus
           sudo chmod -R 777 volumes
@@ -1315,6 +1422,7 @@ jobs:
       - test-backup-restore-cross-version
       - test-backup-restore-after-upgrade
       - test-backup-restore-cli
+      - test-backup-restore-master-loonffi
       - test-backup-restore-secondary
       - test-backup-restore-with-rbac-config
       - test-backup-restore-api

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,9 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        milvus_version: ["2.6", "2.5"]
-        case_tag: [L0, L1, L2, RELEASE, RBAC]
+        milvus_version: ["master", "2.6", "2.5"]
+        case_tag: [L0, L1, L2, MASTER, RELEASE, RBAC]
         exclude:
+          - milvus_version: 2.5
+            case_tag: MASTER
+          - milvus_version: 2.6
+            case_tag: MASTER
           - milvus_version: 2.5
             case_tag: RELEASE
 
@@ -59,7 +63,7 @@ jobs:
         run: |
           if [ ${{ matrix.case_tag }} == "RBAC" ]; then
             mv docker-compose-rbac.yml docker-compose.yml
-          elif [ ${{ matrix.case_tag }} == "RELEASE" ]; then
+          elif [ ${{ matrix.case_tag }} == "MASTER" ] || [ ${{ matrix.case_tag }} == "RELEASE" ] || [ ${{ matrix.milvus_version }} == "master" ]; then
             mv docker-compose-tei.yml docker-compose.yml
           fi
           tag=$(python ../../scripts/get_image_tag_by_short_name.py --tag ${{ matrix.milvus_version }}-latest) && echo $tag
@@ -83,7 +87,7 @@ jobs:
         run: |
           if [ ${{ matrix.case_tag }} == "RBAC" ]; then
             pytest -s -v --tags ${{ matrix.case_tag }}
-          elif [ ${{ matrix.case_tag }} == "RELEASE" ]; then
+          elif [ ${{ matrix.case_tag }} == "MASTER" ] || [ ${{ matrix.case_tag }} == "RELEASE" ] || [ ${{ matrix.milvus_version }} == "master" ]; then
             pytest -s -v --tags ${{ matrix.case_tag }} -n 4 --tei_endpoint http://text-embeddings:80
           else
             pytest -s -v --tags ${{ matrix.case_tag }} -n 4

--- a/tests/testcases/test_l0compact.py
+++ b/tests/testcases/test_l0compact.py
@@ -133,6 +133,12 @@ class TestL0Compact(TestcaseBase):
             {"async": False, "backup_name": bk, "collection_names": [name]}
         )
         log.info(f"create_backup {bk}: {res}")
+        # L0 segments are a binlog-format concept: a snapshot backup does not
+        # record them and the l0compact CLI only operates on binlog backups,
+        # so the whole suite only applies to binlog-format backups.
+        backup = self.client.get_backup(bk)
+        if backup["data"].get("format") == "snapshot":
+            pytest.skip("l0compact operates on binlog-format backups only")
         return bk
 
     def _restore(self, backup_name, src_name, suffix):

--- a/tests/testcases/test_restore_backup.py
+++ b/tests/testcases/test_restore_backup.py
@@ -2281,7 +2281,19 @@ class TestRestoreBackup(TestcaseBase):
         collection_w = self.init_collection_wrap(
             name=name_origin, schema=default_schema, active_trace=True
         )
-        create_index_for_vector_fields(collection_w)
+        # The shared create_index_for_vector_fields helper builds binary
+        # fields with BIN_IVF_FLAT/JACCARD, which cannot serve the mandatory
+        # MHJACCARD search on a MinHash function output field. Build the
+        # indexes explicitly so the backup — and any snapshot-restored copy
+        # of it — carries a searchable index.
+        collection_w.create_index(
+            "float_vector",
+            {"index_type": "HNSW", "metric_type": "L2", "params": {"M": 48, "efConstruction": 500}},
+        )
+        collection_w.create_index(
+            "minhash_signature",
+            {"index_type": "MINHASH_LSH", "metric_type": "MHJACCARD", "params": {}},
+        )
         nb = 3000
         data = [
             {
@@ -2330,13 +2342,19 @@ class TestRestoreBackup(TestcaseBase):
         )
         # Verify MinHash search works on restored collection
         c = Collection(name=name_origin + suffix)
-        # Create float_vector index
-        c.create_index("float_vector", {"index_type": "FLAT", "metric_type": "L2", "params": {}})
-        # Create minhash_signature index with MHJACCARD metric
-        c.create_index(
-            "minhash_signature",
-            {"index_type": "BIN_FLAT", "metric_type": "MHJACCARD", "params": {}},
-        )
+        if backup["data"].get("format") == "snapshot":
+            # Snapshot restore brings the source's own indexes back, which
+            # are already MHJACCARD here and searchable directly. Master
+            # allows at most one distinct index per field, so recreating
+            # them would be rejected.
+            pass
+        else:
+            # Binlog restore carries no indexes, recreate them as on 2.6.
+            c.create_index("float_vector", {"index_type": "FLAT", "metric_type": "L2", "params": {}})
+            c.create_index(
+                "minhash_signature",
+                {"index_type": "MINHASH_LSH", "metric_type": "MHJACCARD", "params": {}},
+            )
         c.load()
         res = c.search(
             data=[data[0]["text"]],
@@ -2545,6 +2563,12 @@ class TestRestoreBackup(TestcaseBase):
             {"async": False, "backup_name": back_up_name, "collection_names": [name_origin]}
         )
         log.info(f"create backup response: {res}")
+        # shard_num override is rejected for snapshot format backups (the
+        # collection is restored by Milvus from the snapshot bundle, so its
+        # shard layout cannot change). Run this case on binlog backups only.
+        backup = self.client.get_backup(back_up_name)
+        if backup["data"].get("format") == "snapshot":
+            pytest.skip("shard_num override is not supported with snapshot format backups")
 
         # restore with restorePlan containing override
         target_shard_num = 1

--- a/tests/testcases/test_restore_backup_with_rbac.py
+++ b/tests/testcases/test_restore_backup_with_rbac.py
@@ -58,20 +58,38 @@ class TestRestoreBackupWithRbac(TestcaseBase):
         for role in client.list_roles():
             if role in build_in_role:
                 continue
-            privileges = client.describe_role(role_name=role)["privileges"]
-            for privilege in privileges:
-                client.revoke_privilege_v2(
-                    **privilege,
-                    collection_name='*',
-                )
-            client.drop_role(role)
+            try:
+                privileges = client.describe_role(role_name=role)["privileges"]
+                for privilege in privileges:
+                    client.revoke_privilege_v2(
+                        **privilege,
+                        collection_name='*',
+                    )
+                client.drop_role(role)
+            except MilvusException as e:
+                # A parallel xdist worker running another rbac test may drop
+                # the role between our list_roles and here; cleanup of an
+                # already-gone role is success, not failure.
+                if "not found" not in str(e):
+                    raise
+                log.info(f"role {role} already dropped by a parallel test")
 
         for pg in client.list_privilege_groups():
-            client.drop_privilege_group(group_name=pg["privilege_group"])
+            try:
+                client.drop_privilege_group(group_name=pg["privilege_group"])
+            except MilvusException as e:
+                if "not found" not in str(e):
+                    raise
+                log.info(f"privilege group {pg['privilege_group']} already dropped by a parallel test")
         for user in client.list_users():
             if user in build_in_user:
                 continue
-            client.drop_user(user_name=user)
+            try:
+                client.drop_user(user_name=user)
+            except MilvusException as e:
+                if "not found" not in str(e):
+                    raise
+                log.info(f"user {user} already dropped by a parallel test")
 
     @staticmethod
     def list_rbac(client: MilvusClient):


### PR DESCRIPTION
## Summary

Milvus master has caught up with the released line: ExportSnapshot now implements the snapshot export RPC, and the L0 import path is fail-closed. The secondary same-version-master job has been green since #1077, so drop the #1080 exclusion and put master-latest back in the matrices.

## Changes

- main.yaml: re-add master-latest as a cross-version / after-upgrade restore target
- main.yaml: cli and rbac-config run master-latest next to 2.6-latest
- main.yaml: api re-adds master-latest and the MASTER case tag (the three MinHash cases), which only runs on master via the matrix exclude
- main.yaml: add test-backup-restore-master-loonffi, a dedicated matrix that runs a master backup/restore with common.storage.useLoonFFI both true and false, covering the config choice on the 3.0 line explicitly
- nightly.yaml: re-add master to milvus_version and the MASTER case tag

Master jobs may be red initially: the delete-restore tests exercise the L0 import path that master disables until l0_delta_paths is wired, and the api suite runs the snapshot export path end-to-end for the first time.

/kind improvement