### PR TITLE
backup: omit snapshot uri endpoint on the same backend as milvus

### DIFF
--- a/configs/backup.yaml
+++ b/configs/backup.yaml
@@ -118,6 +118,15 @@ backup:
     bucketName: "a-bucket"
     rootPath: "backup"
 
+    # The endpoint the Milvus server itself uses to reach this storage, when
+    # it differs from address/port above: a container port mapping, a private
+    # link, or an internal DNS name gives one store two endpoints. Snapshot
+    # URIs handed to Milvus must name the endpoint Milvus resolves. Left
+    # empty, a backup kept in the same backend as Milvus omits the endpoint
+    # from those URIs entirely and lets Milvus use its own storage config.
+    # milvusAddress: ""
+    # milvusPort: 0
+
     auth:
       type: static
       accessKeyID: minioadmin

--- a/core/backup/snapshot_target.go
+++ b/core/backup/snapshot_target.go
@@ -28,7 +28,7 @@ type snapshotTarget struct {
 }
 
 func newSnapshotTarget(milvusCfg, backupCfg storage.Config, backupDir string) (snapshotTarget, error) {
-	uri, err := storage.SnapshotURI(backupCfg, mpath.BackupBundleDir(backupDir))
+	uri, err := storage.SnapshotStoreURI(milvusCfg, backupCfg, mpath.BackupBundleDir(backupDir))
 	if err != nil {
 		return snapshotTarget{}, err
 	}
@@ -173,13 +173,31 @@ func snapshotEndpoint(u *url.URL, scheme string) (string, error) {
 }
 
 func (u snapshotURI) sameStorage(other snapshotURI) bool {
-	if u.endpointStyle != other.endpointStyle || u.bucket != other.bucket {
+	if u.bucket != other.bucket {
 		return false
 	}
-	if u.endpointStyle {
-		return u.endpoint == other.endpoint
+	if u.endpointStyle == other.endpointStyle {
+		if u.endpointStyle {
+			return u.endpoint == other.endpoint
+		}
+		return canonicalSnapshotScheme(u.scheme) == canonicalSnapshotScheme(other.scheme)
 	}
-	return canonicalSnapshotScheme(u.scheme) == canonicalSnapshotScheme(other.scheme)
+	// One side names only a bucket: the endpoint was deliberately omitted, and the
+	// server spelled the same bucket back with the endpoint it resolved from its own
+	// storage config. That endpoint is the server's to pick, so only the bucket
+	// (compared above) and the provider family can be matched.
+	provider, endpoint := u, other
+	if provider.endpointStyle {
+		provider, endpoint = other, u
+	}
+	switch provider.scheme {
+	case "s3":
+		return endpoint.scheme == "minio" || endpoint.scheme == "http" || endpoint.scheme == "https"
+	case "gs", "gcs":
+		return endpoint.scheme == "http" || endpoint.scheme == "https"
+	default:
+		return false
+	}
 }
 
 func canonicalSnapshotScheme(scheme string) string {

--- a/core/backup/snapshot_target_test.go
+++ b/core/backup/snapshot_target_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestNewSnapshotTarget(t *testing.T) {
 	// Milvus falls back to its own credential when no spec is given, which is what to
-	// rely on when both sides are the same backend — it keeps the key off the wire.
+	// rely on when both sides are the same backend — it keeps the key off the wire. The
+	// uri omits the endpoint for the same reason: it is Milvus's own store, which it
+	// resolves through its own storage config.
 	t.Run("SameBackendSendsNoSpec", func(t *testing.T) {
 		milvusCfg := storage.Config{
 			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
@@ -23,8 +25,24 @@ func TestNewSnapshotTarget(t *testing.T) {
 
 		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
 		require.NoError(t, err)
-		assert.Equal(t, "minio://minio:9000/backup-bucket/backup/mybackup/bundle", target.Path)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup/bundle", target.Path)
 		assert.Equal(t, "bundle", target.Dir)
+		assert.Empty(t, target.ExternalSpec)
+	})
+
+	// A pinned Milvus-view endpoint is written into the uri instead of being omitted.
+	t.Run("SameBackendWithMilvusEndpointPinsTheURI", func(t *testing.T) {
+		milvusCfg := storage.Config{
+			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+		backupCfg.MilvusEndpoint = "milvus-minio:9000"
+
+		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "minio://milvus-minio:9000/backup-bucket/backup/mybackup/bundle", target.Path)
 		assert.Empty(t, target.ExternalSpec)
 	})
 
@@ -64,6 +82,20 @@ func TestSnapshotTarget_MetadataPath(t *testing.T) {
 		got, err := target.metadataPath("https://s3.us-west-2.amazonaws.com/backup-bucket/instance-a/backup-a/bundle/exports/11111111-2222-3333-4444-555555555555/snapshots/1001/metadata/2002.json")
 		require.NoError(t, err)
 		assert.Equal(t, "bundle/exports/11111111-2222-3333-4444-555555555555/snapshots/1001/metadata/2002.json", got)
+	})
+
+	// The endpoint-less target names only a bucket; the export result spells the same
+	// bucket back with the endpoint the server resolved from its own storage config.
+	t.Run("EndpointlessTargetMatchesResolvedEndpoint", func(t *testing.T) {
+		got, err := target.metadataPath("minio://minio:9000/backup-bucket/backup/mybackup/bundle/snapshots/449577/metadata/449580.json")
+		require.NoError(t, err)
+		assert.Equal(t, "bundle/snapshots/449577/metadata/449580.json", got)
+	})
+
+	// A different bucket under the resolved endpoint is still not ours.
+	t.Run("EndpointlessTargetRejectsOtherBucket", func(t *testing.T) {
+		_, err := target.metadataPath("minio://minio:9000/other-bucket/backup/mybackup/bundle/snapshots/449577/metadata/449580.json")
+		assert.Error(t, err)
 	})
 
 	// Anything outside the target is not ours to record, and a path relative to the

--- a/core/restore/snapshot_source.go
+++ b/core/restore/snapshot_source.go
@@ -20,7 +20,7 @@ type snapshotSource struct {
 }
 
 func newSnapshotSource(milvusCfg, backupCfg storage.Config, backupDir string) (snapshotSource, error) {
-	uri, err := storage.SnapshotURI(backupCfg, backupDir)
+	uri, err := storage.SnapshotStoreURI(milvusCfg, backupCfg, backupDir)
 	if err != nil {
 		return snapshotSource{}, err
 	}

--- a/core/restore/snapshot_source_test.go
+++ b/core/restore/snapshot_source_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestNewSnapshotSource(t *testing.T) {
 	// Milvus falls back to its own credential when no spec is given, which is what to rely
-	// on when both sides are the same backend — it keeps the key off the wire.
+	// on when both sides are the same backend — it keeps the key off the wire. The uri
+	// omits the endpoint for the same reason: it is Milvus's own store, which it resolves
+	// through its own storage config.
 	t.Run("SameBackendSendsNoSpec", func(t *testing.T) {
 		milvusCfg := storage.Config{
 			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
@@ -23,7 +25,7 @@ func TestNewSnapshotSource(t *testing.T) {
 
 		source, err := newSnapshotSource(milvusCfg, backupCfg, "backup/mybackup/")
 		require.NoError(t, err)
-		assert.Equal(t, "minio://minio:9000/backup-bucket/backup/mybackup", source.dirURI)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup", source.dirURI)
 		assert.Empty(t, source.externalSpec)
 	})
 

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -72,7 +72,9 @@ func TestNewTask_SnapshotSource(t *testing.T) {
 	task, err := NewTask(args)
 	require.NoError(t, err)
 	assert.Equal(t, meta.FormatSnapshot, task.format)
-	assert.Equal(t, "minio://minio:9000/backup-bucket/backup/mybackup", task.snapshotSource.dirURI)
+	// Both sides are the same backend, so the uri names only the bucket and Milvus
+	// resolves it through its own storage config.
+	assert.Equal(t, "s3://backup-bucket/backup/mybackup", task.snapshotSource.dirURI)
 	// Both sides are the same backend, so Milvus reads with its own credential.
 	assert.Empty(t, task.snapshotSource.externalSpec)
 }

--- a/internal/cfg/v2/storage.go
+++ b/internal/cfg/v2/storage.go
@@ -51,6 +51,16 @@ type StorageConfig struct {
 	// path Milvus resolves. Empty means the same as rootPath.
 	LocalPath param.Value[string]
 
+	// MilvusAddress and MilvusPort name the endpoint the Milvus server itself
+	// uses to reach this storage, when it differs from the address and port
+	// milvus-backup connects to: a container port mapping, a private link, or
+	// an internal DNS name gives one store two endpoints. Snapshot URIs handed
+	// to Milvus must name the endpoint Milvus resolves, since Milvus connects
+	// to it. An empty milvusAddress means no override; a zero milvusPort means
+	// the same as port.
+	MilvusAddress param.Value[string]
+	MilvusPort    param.Value[int]
+
 	Auth StorageAuthConfig
 }
 
@@ -77,6 +87,9 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 		RootPath:   param.Value[string]{Default: "files", Keys: key("rootPath")},
 		LocalPath:  param.Value[string]{Default: "", Keys: key("localPath")},
 
+		MilvusAddress: param.Value[string]{Default: "", Keys: key("milvusAddress")},
+		MilvusPort:    param.Value[int]{Default: 0, Keys: key("milvusPort")},
+
 		Auth: StorageAuthConfig{
 			Type: param.Value[string]{Default: AuthStatic, Keys: key("auth.type")},
 
@@ -96,7 +109,8 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 // inherit makes the resolved values of other the defaults of c, so a config
 // that only names what differs still describes a complete backend. RootPath is
 // deliberately left alone: backup data does not belong under the Milvus root
-// path.
+// path. The Milvus-view endpoint override is left alone too: it describes how
+// one specific Milvus reaches the store, which says nothing about another.
 func (c *StorageConfig) inherit(other *StorageConfig) {
 	c.Provider.Default = other.Provider.Val
 
@@ -122,6 +136,7 @@ func (c *StorageConfig) Resolve(s *param.Source) error {
 		&c.Provider,
 		&c.Address, &c.Port, &c.Region, &c.UseSSL,
 		&c.AccountName, &c.BucketName, &c.RootPath, &c.LocalPath,
+		&c.MilvusAddress, &c.MilvusPort,
 		&c.Auth.Type,
 		&c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken,
 		&c.Auth.AccountKey,

--- a/internal/cfg/v2/validate.go
+++ b/internal/cfg/v2/validate.go
@@ -111,11 +111,29 @@ func (c *StorageConfig) validate() error {
 
 	provider := c.Provider.Val
 	if provider == ProviderLocal {
-		// Local storage is a directory: it has no endpoint and no credentials.
+		// Local storage is a directory: it has no endpoint and no credentials,
+		// so there is no Milvus-view endpoint to override either.
+		if c.MilvusAddress.Val != "" {
+			return fmt.Errorf("cfg: %s does not apply to the local provider", keyOf(&c.MilvusAddress))
+		}
 		return nil
 	}
 
 	errs := []error{validatePort(&c.Port)}
+
+	// The Milvus-view endpoint override is a bare host: the snapshot URI it is
+	// written into already carries the scheme.
+	if strings.Contains(c.MilvusAddress.Val, "://") {
+		errs = append(errs, fmt.Errorf("cfg: %s must be a host, not a URL: %q",
+			keyOf(&c.MilvusAddress), c.MilvusAddress.Val))
+	}
+	if c.MilvusPort.Val != 0 {
+		if c.MilvusAddress.Val == "" {
+			errs = append(errs, fmt.Errorf("cfg: %s requires %s to be set",
+				keyOf(&c.MilvusPort), keyOf(&c.MilvusAddress)))
+		}
+		errs = append(errs, validatePort(&c.MilvusPort))
+	}
 
 	switch {
 	case provider == ProviderAzure && c.AccountName.Val == "":

--- a/internal/cfg/v2/validate_test.go
+++ b/internal/cfg/v2/validate_test.go
@@ -64,6 +64,21 @@ func TestValidate_Storage(t *testing.T) {
 			wantErr: "milvus.storage.port: invalid port 70000",
 		},
 		{
+			name:    "MilvusAddressIsABareHost",
+			yaml:    "milvus:\n  storage:\n    milvusAddress: http://minio:9000\n",
+			wantErr: "milvus.storage.milvusAddress must be a host, not a URL",
+		},
+		{
+			name:    "MilvusPortRequiresMilvusAddress",
+			yaml:    "milvus:\n  storage:\n    milvusPort: 9001\n",
+			wantErr: "milvus.storage.milvusPort requires milvus.storage.milvusAddress to be set",
+		},
+		{
+			name:    "MilvusAddressRejectedForLocal",
+			yaml:    "milvus:\n  storage:\n    provider: local\n    milvusAddress: minio\n",
+			wantErr: "milvus.storage.milvusAddress does not apply to the local provider",
+		},
+		{
 			name:    "BackupStorageIsValidatedToo",
 			yaml:    "backup:\n  storage:\n    provider: ceph\n",
 			wantErr: `backup.storage.provider: invalid value "ceph"`,

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -44,6 +44,13 @@ type Config struct {
 	UseSSL   bool
 	Region   string
 
+	// MilvusEndpoint is the endpoint the Milvus server itself uses to reach
+	// this storage, when it differs from Endpoint: a container port mapping, a
+	// private link, or an internal DNS name gives one store two endpoints.
+	// Snapshot URIs handed to Milvus name it, since Milvus connects to it.
+	// Empty means Endpoint serves both.
+	MilvusEndpoint string
+
 	Credential Credential
 
 	Bucket string

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -60,10 +60,24 @@ func storageConfig(s *v2.StorageConfig, multipartCopyThresholdMiB int64) Config 
 		Endpoint:                  net.JoinHostPort(s.Address.Val, strconv.Itoa(s.Port.Val)),
 		UseSSL:                    s.UseSSL.Val,
 		Region:                    s.Region.Val,
+		MilvusEndpoint:            milvusEndpoint(s),
 		Credential:                newCredential(s),
 		Bucket:                    s.BucketName.Val,
 		MultipartCopyThresholdMiB: multipartCopyThresholdMiB,
 	}
+}
+
+// milvusEndpoint renders the optional Milvus-view endpoint override. The port
+// falls back to the section's own port, so a host-only override stays short.
+func milvusEndpoint(s *v2.StorageConfig) string {
+	if s.MilvusAddress.Val == "" {
+		return ""
+	}
+	port := s.MilvusPort.Val
+	if port == 0 {
+		port = s.Port.Val
+	}
+	return net.JoinHostPort(s.MilvusAddress.Val, strconv.Itoa(port))
 }
 
 // MilvusStorageConfig describes the backend the Milvus deployment keeps its

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -9,6 +9,30 @@ import (
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 )
 
+func TestMilvusEndpoint(t *testing.T) {
+	t.Run("Unset", func(t *testing.T) {
+		s := &v2.StorageConfig{}
+		assert.Empty(t, milvusEndpoint(s))
+	})
+
+	t.Run("PortFallsBackToTheSectionPort", func(t *testing.T) {
+		s := &v2.StorageConfig{
+			Port:          param.Value[int]{Val: 9000},
+			MilvusAddress: param.Value[string]{Val: "milvus-minio"},
+		}
+		assert.Equal(t, "milvus-minio:9000", milvusEndpoint(s))
+	})
+
+	t.Run("ExplicitPort", func(t *testing.T) {
+		s := &v2.StorageConfig{
+			Port:          param.Value[int]{Val: 9000},
+			MilvusAddress: param.Value[string]{Val: "milvus-minio"},
+			MilvusPort:    param.Value[int]{Val: 9001},
+		}
+		assert.Equal(t, "milvus-minio:9001", milvusEndpoint(s))
+	})
+}
+
 func TestNewCredential(t *testing.T) {
 	t.Run("Static", func(t *testing.T) {
 		cred := newCredential(&v2.StorageConfig{Auth: v2.StorageAuthConfig{

--- a/internal/storage/snapshot.go
+++ b/internal/storage/snapshot.go
@@ -19,9 +19,10 @@ import (
 // Milvus to derive it from cloud_provider and region, and gcs://<bucket>/<key> names a native
 // GCS store, whose provider the scheme alone decides.
 //
-// The configured endpoint wins whenever there is one, because derivation only ever produces
-// the canonical public endpoint — wrong for a deployment reached over an internal or
-// private-link address, and wrong as a copy failure rather than a configuration error.
+// The endpoint written into the URI is the one Milvus connects to, so the Milvus-view
+// override wins when there is one, then the configured endpoint: derivation only ever
+// produces the canonical public endpoint — wrong for a deployment reached over an internal
+// or private-link address, and wrong as a copy failure rather than a configuration error.
 func SnapshotURI(cfg Config, key string) (string, error) {
 	key = strings.Trim(key, "/")
 	if key == "" {
@@ -35,6 +36,9 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 	// extfs access_key_id, so the host is the blob. service endpoint, not the account one.
 	if cfg.Provider == v2.ProviderAzure {
 		host := endpointHost(cfg.Endpoint)
+		if cfg.MilvusEndpoint != "" {
+			host = endpointHost(cfg.MilvusEndpoint)
+		}
 		if host == "" {
 			return "", fmt.Errorf("storage: snapshot uri for azure needs an endpoint")
 		}
@@ -47,7 +51,11 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 		return fmt.Sprintf("gcs://%s/%s", cfg.Bucket, key), nil
 	}
 
-	if host := endpointHost(cfg.Endpoint); host != "" {
+	endpoint := cfg.Endpoint
+	if cfg.MilvusEndpoint != "" {
+		endpoint = cfg.MilvusEndpoint
+	}
+	if host := endpointHost(endpoint); host != "" {
 		return fmt.Sprintf("minio://%s/%s/%s", host, cfg.Bucket, key), nil
 	}
 
@@ -55,6 +63,46 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 	// needs the region to do it.
 	if cfg.Region == "" {
 		return "", fmt.Errorf("storage: snapshot uri for %s needs an endpoint or a region", cfg.Provider)
+	}
+
+	return fmt.Sprintf("s3://%s/%s", cfg.Bucket, key), nil
+}
+
+// SnapshotStoreURI names key in the backup bucket, in the form Milvus should resolve it
+// in. A snapshot export or restore is executed by Milvus, so the endpoint in the URI must
+// be one Milvus can reach — not the one milvus-backup reaches. When both configs describe
+// the same backend and no Milvus-view endpoint is pinned, the endpoint is omitted
+// entirely and Milvus resolves the bucket through its own storage config: the endpoint
+// milvus-backup would name is only its own view of that backend, and may be an alias — a
+// container port mapping, a private link — that Milvus cannot connect to, or rejects as a
+// foreign cross-bucket target.
+func SnapshotStoreURI(milvusCfg, backupCfg Config, key string) (string, error) {
+	// Azure has no endpoint-less URI form: its service endpoint is part of every URI.
+	if backupCfg.Provider != v2.ProviderAzure && backupCfg.MilvusEndpoint == "" &&
+		SameBackend(milvusCfg, backupCfg) {
+		return snapshotURIOnInstance(backupCfg, key)
+	}
+	return SnapshotURI(backupCfg, key)
+}
+
+// snapshotURIOnInstance builds the endpoint-less form of a snapshot URI: bucket and key
+// only, leaving the endpoint for Milvus to fill in from its own storage config. Only the
+// S3 family has such a form: Azure names its service endpoint in every URI, and native
+// GCS never carries one.
+func snapshotURIOnInstance(cfg Config, key string) (string, error) {
+	key = strings.Trim(key, "/")
+	if key == "" {
+		return "", fmt.Errorf("storage: snapshot uri needs a key")
+	}
+	if _, err := snapshotCloudProvider(cfg.Provider); err != nil {
+		return "", err
+	}
+
+	if cfg.Provider == v2.ProviderAzure {
+		return "", fmt.Errorf("storage: snapshot uri for azure cannot omit the endpoint")
+	}
+	if cfg.Provider == v2.ProviderGCPNative {
+		return fmt.Sprintf("gcs://%s/%s", cfg.Bucket, key), nil
 	}
 
 	return fmt.Sprintf("s3://%s/%s", cfg.Bucket, key), nil

--- a/internal/storage/snapshot_test.go
+++ b/internal/storage/snapshot_test.go
@@ -90,10 +90,90 @@ func TestSnapshotURI(t *testing.T) {
 		assert.ErrorContains(t, err, "endpoint")
 	})
 
+	// The Milvus-view endpoint override is what the URI names, since Milvus connects to it.
+	t.Run("MilvusEndpointOverridesTheEndpoint", func(t *testing.T) {
+		cfg := Config{
+			Provider: v2.ProviderMinio, Bucket: "backup-bucket",
+			Endpoint: "localhost:9000", MilvusEndpoint: "minio:9000",
+		}
+		got, err := SnapshotURI(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "minio://minio:9000/backup-bucket/backup/mybackup", got)
+	})
+
 	t.Run("UnsupportedProvider", func(t *testing.T) {
 		cfg := Config{Provider: "madeup", Bucket: "backup-bucket", Endpoint: "acct.blob.core.windows.net"}
 		_, err := SnapshotURI(cfg, "backup/mybackup")
 		assert.ErrorContains(t, err, "madeup")
+	})
+}
+
+func TestSnapshotStoreURI(t *testing.T) {
+	minioCfg := func() Config {
+		return Config{
+			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
+			Credential: Credential{Type: Static, AK: "ak", SK: "sk"},
+		}
+	}
+
+	// Same backend: the endpoint milvus-backup would write is only its own view of the
+	// store, which may be an alias Milvus cannot resolve — so the URI carries bucket and
+	// key only, and Milvus resolves them through its own storage config.
+	t.Run("SameBackendOmitsTheEndpoint", func(t *testing.T) {
+		milvusCfg := minioCfg()
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+
+		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "s3://backup-bucket/backup/mybackup", got)
+	})
+
+	// A pinned Milvus-view endpoint wins over omission: the deployment said explicitly
+	// how Milvus reaches the store.
+	t.Run("MilvusEndpointWinsOverOmission", func(t *testing.T) {
+		milvusCfg := minioCfg()
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+		backupCfg.MilvusEndpoint = "milvus-minio:9000"
+
+		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "minio://milvus-minio:9000/backup-bucket/backup/mybackup", got)
+	})
+
+	// A different backend has no instance config to inherit, so the URI names the
+	// backup storage's own endpoint as before.
+	t.Run("OtherBackendKeepsTheEndpoint", func(t *testing.T) {
+		milvusCfg := minioCfg()
+		backupCfg := Config{Provider: v2.ProviderMinio, Endpoint: "other:9000", Bucket: "backup-bucket"}
+
+		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "minio://other:9000/backup-bucket/backup/mybackup", got)
+	})
+
+	// Azure has no endpoint-less form, so the URI keeps the service endpoint even on
+	// the same backend.
+	t.Run("AzureKeepsTheEndpoint", func(t *testing.T) {
+		milvusCfg := Config{Provider: v2.ProviderAzure, Endpoint: "core.windows.net", Bucket: "milvus-bucket"}
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+
+		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "azure://blob.core.windows.net/backup-bucket/backup/mybackup", got)
+	})
+
+	// Native GCS never carries an endpoint, so same-backend changes nothing.
+	t.Run("GCPNativeUnchanged", func(t *testing.T) {
+		milvusCfg := Config{Provider: v2.ProviderGCPNative, Bucket: "milvus-bucket"}
+		backupCfg := milvusCfg
+		backupCfg.Bucket = "backup-bucket"
+
+		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "gcs://backup-bucket/backup/mybackup", got)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes #1163

Snapshot-format backup on Milvus master fails whenever milvus-backup and the Milvus server reach the same storage through different endpoint names (e.g. `localhost:9000` from the host vs `minio:9000` inside a container network): milvus-backup wrote its own view of the endpoint into the ExportSnapshot target URI, and Milvus rejects the string mismatch as a foreign cross-bucket target.

A snapshot export/restore is executed by Milvus, so the URI endpoint must be one Milvus can reach. When the backup storage is the same backend as Milvus, that endpoint is redundant at best and an unresolvable alias at worst — so it is now omitted from the URI (`s3://<bucket>/<key>`), and Milvus resolves the bucket through its own storage config. No endpoint comparison happens on that path at all.

## Changes

- `storage.SnapshotStoreURI`: omit the endpoint for same-backend S3-family storage; fall back to the previous behavior otherwise (Azure has no endpoint-less form, native GCS never carries one)
- new `backup.storage.milvusAddress`/`milvusPort` config to pin the Milvus-view endpoint explicitly, following the `localPath` precedent; wins over omission when set
- `snapshotTarget.sameStorage`: accept the endpoint-style metadata URI Milvus rebuilds from its resolved storage config when the target named only a bucket, as long as bucket and provider family match
- config validation, sample config docs, and tests for the above