### PR TITLE
ci: pin golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
 
   unit-test-go:
     name: Unit test go


### PR DESCRIPTION
## Problem

Lint is red on every PR right now, independent of its content.

The job runs `golangci/golangci-lint-action@v9` with `version: latest`. Since golangci-lint **v2.13.0** (2026-08-19), that resolves to a build carrying `honnef.co/go/tools v0.8.0-rc.1`, whose `nilness` analyzer panics under Go 1.26 while analyzing a dependency package:

```
level=error msg="[linters_context/goanalysis] nilness: panic during analysis:
  internal error: unhandled builtin recover ...
  honnef.co/go/tools@v0.8.0-rc.1/analysis/facts/nilness/nilness.go:361"
level=error msg="[runner] Panic: nilness: package \"sentry\" ... unhandled builtin recover"
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
Ran golangci-lint in 951948ms
##[error]golangci-lint exit with code 4        # 4 = timeout
```

| PR | golangci-lint | Lint |
|---|---|---|
| #1165 (08-18 10:09 UTC) | v2.12.2 | pass, 1m37s |
| #1158 (08-17) | v2.12.2 | pass, 1m30s |
| #1168 (08-20 00:26 UTC) | v2.13.0 | fail, 16m17s |

Reproduced locally: v2.13.0 does not finish in 10 minutes on this repo; v2.12.2 reports `0 issues` in ~1.5 minutes on the same tree.

## Change

Pin the action to `v2.12.2` — the version the last green runs used. Bumping it becomes a deliberate change rather than something an upstream release can do to the whole PR queue.
