### PR TITLE
restore: apply skip_params on snapshot restores via delete_keys

### DIFF
--- a/core/restore/coll_snapshot_task.go
+++ b/core/restore/coll_snapshot_task.go
@@ -3,12 +3,14 @@ package restore
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
@@ -30,6 +32,7 @@ type collSnapshotTask struct {
 	dropExist    bool
 	maxShardNum  int32
 	descOverride string
+	skipParams   SkipParams
 
 	pollInterval time.Duration
 
@@ -49,6 +52,7 @@ type collSnapshotTaskArgs struct {
 	dropExist    bool
 	maxShardNum  int32
 	descOverride string
+	skipParams   SkipParams
 
 	grpcCli milvus.Grpc
 	taskMgr *taskmgr.Mgr
@@ -76,6 +80,7 @@ func newCollSnapshotTask(args collSnapshotTaskArgs) *collSnapshotTask {
 		dropExist:    args.dropExist,
 		maxShardNum:  args.maxShardNum,
 		descOverride: args.descOverride,
+		skipParams:   args.skipParams,
 
 		pollInterval: _snapshotPollInterval,
 
@@ -149,7 +154,73 @@ func (ct *collSnapshotTask) privateExecute(ctx context.Context) error {
 		return err
 	}
 
+	if err := ct.applySkipParams(ctx); err != nil {
+		return err
+	}
+
 	return ct.applyDescOverride(ctx)
+}
+
+// applySkipParams drops the params the caller asked to skip from the restored collection.
+// Milvus creates the collection from the bundle's schema, so the source cluster's overrides
+// (mmap.enabled, for example) come along with it; the binlog path would simply not write
+// them. Here they are removed after the restore with delete_keys, which drops the override
+// and lets each key fall back to the target cluster's own default.
+//
+// What gets deleted is filtered against the schema saved in the backup meta: a key the
+// backed-up object did not carry is not sent to the server at all. That also makes a skip
+// list naming absent keys — the common case — a quiet no-op rather than an error.
+func (ct *collSnapshotTask) applySkipParams(ctx context.Context) error {
+	props := append(ct.collBackup.GetSchema().GetProperties(), ct.collBackup.GetProperties()...)
+	if present := presentKeys(props, ct.skipParams.CollectionProperties); len(present) != 0 {
+		if err := ct.grpcCli.DropCollectionProperties(ctx, ct.targetNS.DBName(), ct.targetNS.CollName(), present); err != nil {
+			return fmt.Errorf("restore: drop skipped collection properties: %w", err)
+		}
+		ct.logger.Info("skipped collection properties dropped", zap.Strings("keys", present))
+	}
+
+	for _, field := range ct.collBackup.GetSchema().GetFields() {
+		present := presentKeys(field.GetTypeParams(), ct.skipParams.FieldTypeParams)
+		if len(present) == 0 {
+			continue
+		}
+		if err := ct.grpcCli.DropCollectionFieldProperties(ctx, ct.targetNS.DBName(), ct.targetNS.CollName(), field.GetName(), present); err != nil {
+			return fmt.Errorf("restore: drop skipped type params of field %s: %w", field.GetName(), err)
+		}
+		ct.logger.Info("skipped field type params dropped",
+			zap.String("field", field.GetName()), zap.Strings("keys", present))
+	}
+
+	// A param the caller wants off an index can be recorded either as an index param or as
+	// a field index param; both live on the index once Milvus restores the bundle, so the
+	// two skip lists are dropped together.
+	indexKeys := lo.Union(ct.skipParams.IndexParams, ct.skipParams.FieldIndexParams)
+	for _, index := range ct.collBackup.GetIndexInfos() {
+		present := lo.Intersect(indexKeys, lo.Keys(index.GetParams()))
+		if len(present) == 0 {
+			continue
+		}
+		sort.Strings(present)
+		if err := ct.grpcCli.DropIndexProperties(ctx, ct.targetNS.DBName(), ct.targetNS.CollName(), index.GetIndexName(), present); err != nil {
+			return fmt.Errorf("restore: drop skipped params of index %s: %w", index.GetIndexName(), err)
+		}
+		ct.logger.Info("skipped index params dropped",
+			zap.String("index", index.GetIndexName()), zap.Strings("keys", present))
+	}
+
+	return nil
+}
+
+// presentKeys returns the subset of keys that actually appear in kvs, so a delete_keys call
+// only names overrides the restored object really carries.
+func presentKeys[K interface{ GetKey() string }](kvs []K, keys []string) []string {
+	present := make([]string, 0, len(keys))
+	for _, kv := range kvs {
+		if lo.Contains(keys, kv.GetKey()) {
+			present = append(present, kv.GetKey())
+		}
+	}
+	return present
 }
 
 // applyDescOverride rewrites the collection description after the restore completes. Milvus

--- a/core/restore/coll_snapshot_task_test.go
+++ b/core/restore/coll_snapshot_task_test.go
@@ -204,4 +204,79 @@ func TestCollSnapshotTask_Execute(t *testing.T) {
 		err := task.Execute(context.Background())
 		assert.ErrorContains(t, err, "alter collection description")
 	})
+
+	// Skipped params ride along in the bundle's schema, so they are dropped with
+	// delete_keys after the job completes, only from the objects the meta says carry them.
+	t.Run("SkipParams", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+		cli.EXPECT().DropCollectionProperties(mock.Anything, "db2", "coll2", []string{"mmap.enabled"}).
+			Return(nil).Once()
+		// Only the vector field carries the skipped key, so only it is altered.
+		cli.EXPECT().DropCollectionFieldProperties(mock.Anything, "db2", "coll2", "vec", []string{"mmap.enabled"}).
+			Return(nil).Once()
+		cli.EXPECT().DropIndexProperties(mock.Anything, "db2", "coll2", "idx_vec", []string{"mmap.enabled"}).
+			Return(nil).Once()
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.collBackup.Schema = &backuppb.CollectionSchema{
+			Properties: []*backuppb.KeyValuePair{{Key: "mmap.enabled", Value: "true"}},
+			Fields: []*backuppb.FieldSchema{
+				{Name: "pk", TypeParams: []*backuppb.KeyValuePair{{Key: "max_length", Value: "64"}}},
+				{Name: "vec", TypeParams: []*backuppb.KeyValuePair{{Key: "mmap.enabled", Value: "true"}}},
+			},
+		}
+		task.collBackup.IndexInfos = []*backuppb.IndexInfo{
+			{IndexName: "idx_vec", Params: map[string]string{"mmap.enabled": "true"}},
+			{IndexName: "idx_other", Params: map[string]string{"nlist": "128"}},
+		}
+		task.skipParams = SkipParams{
+			CollectionProperties: []string{"mmap.enabled"},
+			FieldTypeParams:      []string{"mmap.enabled"},
+			FieldIndexParams:     []string{"mmap.enabled"},
+		}
+		require.NoError(t, task.Execute(context.Background()))
+	})
+
+	// A key the backup never recorded is not deleted: dropping an absent override would be
+	// a no-op on the server, so no call is made at all.
+	t.Run("SkipParamsAbsentFromMeta", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.collBackup.Schema = &backuppb.CollectionSchema{
+			Fields: []*backuppb.FieldSchema{
+				{Name: "vec", TypeParams: []*backuppb.KeyValuePair{{Key: "dim", Value: "128"}}},
+			},
+		}
+		task.skipParams = SkipParams{
+			CollectionProperties: []string{"mmap.enabled"},
+			FieldTypeParams:      []string{"mmap.enabled"},
+			IndexParams:          []string{"mmap.enabled"},
+		}
+		require.NoError(t, task.Execute(context.Background()))
+	})
+
+	// A failed drop surfaces through the task like any other restore failure.
+	t.Run("SkipParamsDropFails", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(9001, nil)
+		cli.EXPECT().GetRestoreSnapshotState(mock.Anything, int64(9001)).
+			Return(&milvuspb.RestoreSnapshotInfo{State: milvuspb.RestoreSnapshotState_RestoreSnapshotCompleted}, nil)
+		cli.EXPECT().DropCollectionProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(errors.New("drop failed"))
+
+		task := newTestCollSnapshotTask(t, cli, false)
+		task.collBackup.Schema = &backuppb.CollectionSchema{
+			Properties: []*backuppb.KeyValuePair{{Key: "mmap.enabled", Value: "true"}},
+		}
+		task.skipParams = SkipParams{CollectionProperties: []string{"mmap.enabled"}}
+		err := task.Execute(context.Background())
+		assert.ErrorContains(t, err, "drop skipped collection properties")
+	})
 }

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -226,6 +226,9 @@ func NewTask(args TaskArgs) (*Task, error) {
 // The snapshot path hands the whole restore to Milvus: it creates the collection from the
 // schema in the bundle, restores its indexes and partitions, and copies the data in. Options
 // that ask for something else would silently hand back a collection nobody asked for.
+// skip_params is not one of them: the skipped keys are dropped from the restored collection
+// with delete_keys once the job completes, which is what skipping them at creation time
+// achieves on the binlog path.
 func checkSnapshotSupport(plan *Plan, opt *Option) error {
 	var unsupported []string
 	if opt.SkipCreateCollection {
@@ -239,10 +242,6 @@ func checkSnapshotSupport(plan *Plan, opt *Option) error {
 	}
 	if len(opt.EZKMapping) != 0 {
 		unsupported = append(unsupported, "ezk_mapping")
-	}
-	if len(opt.SkipParams.CollectionProperties) != 0 || len(opt.SkipParams.FieldIndexParams) != 0 ||
-		len(opt.SkipParams.FieldTypeParams) != 0 || len(opt.SkipParams.IndexParams) != 0 {
-		unsupported = append(unsupported, "skip_params")
 	}
 	// A description override is applied with an AlterCollection after the restore
 	// completes, so it stays available. The shard count cannot: Milvus creates the
@@ -391,6 +390,7 @@ func (t *Task) newCollTask(dbBackup *backuppb.DatabaseBackupInfo, collBackup *ba
 				dropExist:    t.args.Option.DropExistCollection,
 				maxShardNum:  t.args.Option.MaxShardNum,
 				descOverride: t.args.Plan.CollOverrides[targetNS.String()].Description,
+				skipParams:   t.args.Option.SkipParams,
 				grpcCli:      t.grpc,
 				taskMgr:      t.args.TaskMgr,
 			}))

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -91,7 +91,6 @@ func TestCheckSnapshotSupport(t *testing.T) {
 		{"MetaOnly", &Plan{}, &Option{MetaOnly: true}},
 		{"TruncateBinlogByTs", &Plan{}, &Option{TruncateBinlogByTs: true}},
 		{"EZKMapping", &Plan{}, &Option{EZKMapping: map[string]string{"old": "new"}}},
-		{"SkipParams", &Plan{}, &Option{SkipParams: SkipParams{IndexParams: []string{"nlist"}}}},
 		{"ShardNumOverride", &Plan{CollOverrides: map[string]CollOverride{"db1.coll1": {ShardNum: 2}}}, &Option{}},
 	}
 
@@ -105,6 +104,17 @@ func TestCheckSnapshotSupport(t *testing.T) {
 	// restore, so they stay available.
 	t.Run("SupportedOptions", func(t *testing.T) {
 		opt := &Option{DropExistCollection: true, RestoreRBAC: true}
+		assert.NoError(t, checkSnapshotSupport(&Plan{}, opt))
+	})
+
+	// Skipped params are dropped from the restored collection with delete_keys once the
+	// job completes, so they stay available even though Milvus creates the collection.
+	t.Run("SkipParams", func(t *testing.T) {
+		opt := &Option{SkipParams: SkipParams{
+			CollectionProperties: []string{"mmap.enabled"},
+			FieldTypeParams:      []string{"mmap.enabled"},
+			IndexParams:          []string{"mmap.enabled"},
+		}}
 		assert.NoError(t, checkSnapshotSupport(&Plan{}, opt))
 	})
 

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -145,11 +145,14 @@ type Grpc interface {
 	GetBulkInsertState(ctx context.Context, taskID int64) (*milvuspb.GetImportStateResponse, error)
 	CreateCollection(ctx context.Context, input CreateCollectionInput) error
 	AlterCollection(ctx context.Context, db, collName string, properties []*commonpb.KeyValuePair) error
+	DropCollectionProperties(ctx context.Context, db, collName string, keys []string) error
+	DropCollectionFieldProperties(ctx context.Context, db, collName, fieldName string, keys []string) error
 	CreatePartition(ctx context.Context, db, collName, partitionName string) error
 	HasPartition(ctx context.Context, db, collName, partitionName string) (bool, error)
 	AddField(ctx context.Context, db, collName string, field *schemapb.FieldSchema) error
 	CreateIndex(ctx context.Context, input CreateIndexInput) error
 	DropIndex(ctx context.Context, db, collName, indexName string) error
+	DropIndexProperties(ctx context.Context, db, collName, indexName string, keys []string) error
 	BackupRBAC(ctx context.Context) (*milvuspb.BackupRBACMetaResponse, error)
 	RestoreRBAC(ctx context.Context, rbacMeta *milvuspb.RBACMeta) error
 	ReplicateMessage(ctx context.Context, channelName string) (string, error)
@@ -975,6 +978,32 @@ func (g *GrpcClient) AlterCollection(ctx context.Context, db, collName string, p
 	return nil
 }
 
+// DropCollectionProperties removes collection-level property overrides, letting each key
+// fall back to the target cluster's own default.
+func (g *GrpcClient) DropCollectionProperties(ctx context.Context, db, collName string, keys []string) error {
+	ctx = g.newCtxWithDB(ctx, db)
+	in := &milvuspb.AlterCollectionRequest{CollectionName: collName, DeleteKeys: keys}
+	resp, err := g.srv.AlterCollection(ctx, in)
+	if err := checkResponse(resp, err); err != nil {
+		return fmt.Errorf("client: drop collection properties failed: %w", err)
+	}
+
+	return nil
+}
+
+// DropCollectionFieldProperties removes field-level property overrides, letting each key
+// fall back to the target cluster's own default.
+func (g *GrpcClient) DropCollectionFieldProperties(ctx context.Context, db, collName, fieldName string, keys []string) error {
+	ctx = g.newCtxWithDB(ctx, db)
+	in := &milvuspb.AlterCollectionFieldRequest{CollectionName: collName, FieldName: fieldName, DeleteKeys: keys}
+	resp, err := g.srv.AlterCollectionField(ctx, in)
+	if err := checkResponse(resp, err); err != nil {
+		return fmt.Errorf("client: drop collection field properties failed: %w", err)
+	}
+
+	return nil
+}
+
 func (g *GrpcClient) DropCollection(ctx context.Context, db, collectionName string) error {
 	ctx = g.newCtxWithDB(ctx, db)
 	resp, err := g.srv.DropCollection(ctx, &milvuspb.DropCollectionRequest{CollectionName: collectionName})
@@ -1087,6 +1116,18 @@ func (g *GrpcClient) DropIndex(ctx context.Context, db, collName, indexName stri
 	resp, err := g.srv.DropIndex(ctx, in)
 	if err := checkResponse(resp, err); err != nil {
 		return fmt.Errorf("client: drop index failed: %w", err)
+	}
+	return nil
+}
+
+// DropIndexProperties removes index-level param overrides, letting each key fall back to
+// the target cluster's own default.
+func (g *GrpcClient) DropIndexProperties(ctx context.Context, db, collName, indexName string, keys []string) error {
+	ctx = g.newCtxWithDB(ctx, db)
+	in := &milvuspb.AlterIndexRequest{CollectionName: collName, IndexName: indexName, DeleteKeys: keys}
+	resp, err := g.srv.AlterIndex(ctx, in)
+	if err := checkResponse(resp, err); err != nil {
+		return fmt.Errorf("client: drop index properties failed: %w", err)
 	}
 	return nil
 }

--- a/internal/client/milvus/grpc_mock.go
+++ b/internal/client/milvus/grpc_mock.go
@@ -1019,6 +1019,150 @@ func (_c *MockGrpc_DropCollection_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
+// DropCollectionFieldProperties provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) DropCollectionFieldProperties(ctx context.Context, db string, collName string, fieldName string, keys []string) error {
+	ret := _mock.Called(ctx, db, collName, fieldName, keys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropCollectionFieldProperties")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, []string) error); ok {
+		r0 = returnFunc(ctx, db, collName, fieldName, keys)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockGrpc_DropCollectionFieldProperties_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropCollectionFieldProperties'
+type MockGrpc_DropCollectionFieldProperties_Call struct {
+	*mock.Call
+}
+
+// DropCollectionFieldProperties is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db string
+//   - collName string
+//   - fieldName string
+//   - keys []string
+func (_e *MockGrpc_Expecter) DropCollectionFieldProperties(ctx any, db any, collName any, fieldName any, keys any) *MockGrpc_DropCollectionFieldProperties_Call {
+	return &MockGrpc_DropCollectionFieldProperties_Call{Call: _e.mock.On("DropCollectionFieldProperties", ctx, db, collName, fieldName, keys)}
+}
+
+func (_c *MockGrpc_DropCollectionFieldProperties_Call) Run(run func(ctx context.Context, db string, collName string, fieldName string, keys []string)) *MockGrpc_DropCollectionFieldProperties_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 []string
+		if args[4] != nil {
+			arg4 = args[4].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_DropCollectionFieldProperties_Call) Return(err error) *MockGrpc_DropCollectionFieldProperties_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockGrpc_DropCollectionFieldProperties_Call) RunAndReturn(run func(ctx context.Context, db string, collName string, fieldName string, keys []string) error) *MockGrpc_DropCollectionFieldProperties_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DropCollectionProperties provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) DropCollectionProperties(ctx context.Context, db string, collName string, keys []string) error {
+	ret := _mock.Called(ctx, db, collName, keys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropCollectionProperties")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, []string) error); ok {
+		r0 = returnFunc(ctx, db, collName, keys)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockGrpc_DropCollectionProperties_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropCollectionProperties'
+type MockGrpc_DropCollectionProperties_Call struct {
+	*mock.Call
+}
+
+// DropCollectionProperties is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db string
+//   - collName string
+//   - keys []string
+func (_e *MockGrpc_Expecter) DropCollectionProperties(ctx any, db any, collName any, keys any) *MockGrpc_DropCollectionProperties_Call {
+	return &MockGrpc_DropCollectionProperties_Call{Call: _e.mock.On("DropCollectionProperties", ctx, db, collName, keys)}
+}
+
+func (_c *MockGrpc_DropCollectionProperties_Call) Run(run func(ctx context.Context, db string, collName string, keys []string)) *MockGrpc_DropCollectionProperties_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []string
+		if args[3] != nil {
+			arg3 = args[3].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_DropCollectionProperties_Call) Return(err error) *MockGrpc_DropCollectionProperties_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockGrpc_DropCollectionProperties_Call) RunAndReturn(run func(ctx context.Context, db string, collName string, keys []string) error) *MockGrpc_DropCollectionProperties_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DropIndex provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) DropIndex(ctx context.Context, db string, collName string, indexName string) error {
 	ret := _mock.Called(ctx, db, collName, indexName)
@@ -1084,6 +1228,81 @@ func (_c *MockGrpc_DropIndex_Call) Return(err error) *MockGrpc_DropIndex_Call {
 }
 
 func (_c *MockGrpc_DropIndex_Call) RunAndReturn(run func(ctx context.Context, db string, collName string, indexName string) error) *MockGrpc_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DropIndexProperties provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) DropIndexProperties(ctx context.Context, db string, collName string, indexName string, keys []string) error {
+	ret := _mock.Called(ctx, db, collName, indexName, keys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndexProperties")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, []string) error); ok {
+		r0 = returnFunc(ctx, db, collName, indexName, keys)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockGrpc_DropIndexProperties_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndexProperties'
+type MockGrpc_DropIndexProperties_Call struct {
+	*mock.Call
+}
+
+// DropIndexProperties is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db string
+//   - collName string
+//   - indexName string
+//   - keys []string
+func (_e *MockGrpc_Expecter) DropIndexProperties(ctx any, db any, collName any, indexName any, keys any) *MockGrpc_DropIndexProperties_Call {
+	return &MockGrpc_DropIndexProperties_Call{Call: _e.mock.On("DropIndexProperties", ctx, db, collName, indexName, keys)}
+}
+
+func (_c *MockGrpc_DropIndexProperties_Call) Run(run func(ctx context.Context, db string, collName string, indexName string, keys []string)) *MockGrpc_DropIndexProperties_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 []string
+		if args[4] != nil {
+			arg4 = args[4].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_DropIndexProperties_Call) Return(err error) *MockGrpc_DropIndexProperties_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockGrpc_DropIndexProperties_Call) RunAndReturn(run func(ctx context.Context, db string, collName string, indexName string, keys []string) error) *MockGrpc_DropIndexProperties_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
close #1174

## Problem

The snapshot restore path refuses any non-empty `skip_params`:

```
restore: skip_params cannot be used with a snapshot format backup
```

Cross-type restores (e.g. serverless to dedicated) rely on `skip_params` to drop source-cluster overrides like `mmap.enabled`, so they cannot restore snapshot-format backups at all. Since the backup side auto-selects the snapshot format on Milvus 3.0+, every cross-type restore of a 3.0 backup hits this. It fires even when the skipped keys are absent from the backup entirely, which is the common case.

## Change

Instead of refusing, apply `skip_params` after the snapshot restore job completes, using the `delete_keys` field of the Alter RPCs:

- collection properties -> `AlterCollection`
- field type params -> `AlterCollectionField` (only fields carrying the keys)
- index params + field index params -> `AlterIndex` (only indexes carrying the keys)

Deleting an override makes each key fall back to the target cluster's own default, which is exactly the semantics "don't write it at creation time" has on the binlog path — and it never needs to know what that default is.

What gets deleted is filtered against the schema saved in the backup meta (`schema.properties`, `fields[].type_params`, `index_infos[].params`), so a skip list naming params the collection never set is a quiet no-op rather than an error.

## Notes

- `delete_keys` on these Alter requests exists since Milvus 2.5, and the snapshot format already requires 3.0+ on both backup and restore sides, so no version gating is needed.
- grpc client: added `DropCollectionProperties` / `DropCollectionFieldProperties` / `DropIndexProperties`; mocks regenerated with mockery.
- Tests: flipped the `checkSnapshotSupport` case for skip_params from refused to accepted, and added snapshot-task tests covering selective drop, absent keys, and drop failure propagation.
