### PR TITLE
restore: refuse a secondary restore whose backup has no index extra info

### DIFF
--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -109,8 +109,9 @@ func newSecondaryCmd(opt *root.Options) *cobra.Command {
 		Long: "Restore a backup to a secondary cluster.\n\n" +
 			"Create the backup with --backup_index_extra to restore its indexes too: secondary\n" +
 			"restore replays the source cluster DDL verbatim and needs the index attributes that\n" +
-			"only that flag reads from etcd. A backup created without it restores the collections\n" +
-			"and the data, but without their indexes.",
+			"only that flag reads from etcd. A backup created without it is refused: a collection\n" +
+			"without its indexes cannot be loaded, so restoring one would produce a secondary\n" +
+			"that can never serve after a failover.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()
 

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -106,6 +106,11 @@ func newSecondaryCmd(opt *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secondary",
 		Short: "restore a backup to a secondary cluster",
+		Long: "Restore a backup to a secondary cluster.\n\n" +
+			"Create the backup with --backup_index_extra to restore its indexes too: secondary\n" +
+			"restore replays the source cluster DDL verbatim and needs the index attributes that\n" +
+			"only that flag reads from etcd. A backup created without it restores the collections\n" +
+			"and the data, but without their indexes.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params := opt.InitGlobalVars()
 

--- a/core/restore/secondary/coll_ddl_task.go
+++ b/core/restore/secondary/coll_ddl_task.go
@@ -27,8 +27,6 @@ type collDDLTask struct {
 	dbBackup   *backuppb.DatabaseBackupInfo
 	collBackup *backuppb.CollectionBackupInfo
 
-	replayIndex bool
-
 	streamCli milvus.Stream
 	logger    *zap.Logger
 }
@@ -37,10 +35,6 @@ type ddlTaskArgs struct {
 	TaskID string
 
 	BackupInfo *backuppb.BackupInfo
-
-	// ReplayIndex reports whether the backup carries the index attributes that
-	// a verbatim create index replay needs. See replayIndex.
-	ReplayIndex bool
 
 	StreamCli milvus.Stream
 }
@@ -54,8 +48,6 @@ func newCollDDLTask(args ddlTaskArgs, dbBackup *backuppb.DatabaseBackupInfo, col
 		backupInfo: args.BackupInfo,
 		dbBackup:   dbBackup,
 		collBackup: collBackup,
-
-		replayIndex: args.ReplayIndex,
 
 		streamCli: args.StreamCli,
 		logger:    log.With(zap.String("task_id", args.TaskID), zap.String("ns", ns.String())),
@@ -75,12 +67,6 @@ func (ddlt *collDDLTask) Execute(ctx context.Context) error {
 }
 
 func (ddlt *collDDLTask) createIndexes(ctx context.Context) error {
-	// The backup carries no index attributes to replay; Task.Execute has already
-	// reported which indexes are left out.
-	if !ddlt.replayIndex {
-		return nil
-	}
-
 	for _, index := range ddlt.collBackup.GetIndexInfos() {
 		if err := ddlt.createIndex(ctx, index); err != nil {
 			return fmt.Errorf("collection: create index: %w", err)

--- a/core/restore/secondary/coll_ddl_task.go
+++ b/core/restore/secondary/coll_ddl_task.go
@@ -27,6 +27,8 @@ type collDDLTask struct {
 	dbBackup   *backuppb.DatabaseBackupInfo
 	collBackup *backuppb.CollectionBackupInfo
 
+	replayIndex bool
+
 	streamCli milvus.Stream
 	logger    *zap.Logger
 }
@@ -35,6 +37,10 @@ type ddlTaskArgs struct {
 	TaskID string
 
 	BackupInfo *backuppb.BackupInfo
+
+	// ReplayIndex reports whether the backup carries the index attributes that
+	// a verbatim create index replay needs. See replayIndex.
+	ReplayIndex bool
 
 	StreamCli milvus.Stream
 }
@@ -48,6 +54,8 @@ func newCollDDLTask(args ddlTaskArgs, dbBackup *backuppb.DatabaseBackupInfo, col
 		backupInfo: args.BackupInfo,
 		dbBackup:   dbBackup,
 		collBackup: collBackup,
+
+		replayIndex: args.ReplayIndex,
 
 		streamCli: args.StreamCli,
 		logger:    log.With(zap.String("task_id", args.TaskID), zap.String("ns", ns.String())),
@@ -67,6 +75,12 @@ func (ddlt *collDDLTask) Execute(ctx context.Context) error {
 }
 
 func (ddlt *collDDLTask) createIndexes(ctx context.Context) error {
+	// The backup carries no index attributes to replay; Task.Execute has already
+	// reported which indexes are left out.
+	if !ddlt.replayIndex {
+		return nil
+	}
+
 	for _, index := range ddlt.collBackup.GetIndexInfos() {
 		if err := ddlt.createIndex(ctx, index); err != nil {
 			return fmt.Errorf("collection: create index: %w", err)

--- a/core/restore/secondary/funcs.go
+++ b/core/restore/secondary/funcs.go
@@ -54,37 +54,46 @@ func hasIndexExtra(index *backuppb.IndexInfo) bool {
 	return index.GetFieldId() != 0 && len(index.GetIndexParams()) != 0
 }
 
-// replayIndex decides whether the create index DDL of a backup can be replayed
-// on the secondary cluster, and is the only place that decision is made.
+// checkIndexExtra fails the restore if any index in the backup is missing the
+// attributes only --backup_index_extra collects. A secondary restore replays
+// the source cluster DDL verbatim, and those attributes are what makes the
+// replay match the source, so a backup without them cannot produce a secondary
+// that matches -- the same shape as checkDynamicField, and handled the same way.
 //
-// The backup answers it as a whole, because the extra attributes are collected
-// for every index at once or for none: a backup created with
-// --backup_index_extra carries the indexes to replay, one created without it
-// carries no index information that a verbatim DDL replay can use, and its
-// collections are restored without indexes.
+// Restoring without the indexes is not an alternative. A collection with no
+// index cannot be loaded: loadCollectionTask.PreExecute fails with
+// ErrIndexNotFound when DescribeIndex returns nothing, so a loaded source --
+// the ordinary DR case -- fails later at the load broadcast with a less
+// obvious error, and an unloaded one yields a secondary that can never be
+// loaded and cannot serve after a failover. Reporting success on a silently
+// diverged secondary is worse than failing: the failure is visible, the
+// divergence is not.
 //
-// The missing attributes cannot be reconstructed on the client side - they are
-// what makes the replay match the source cluster - so a partially populated
-// backup is a contradiction rather than a case to work around, and is
-// reported. The alternative, broadcasting create index with FieldID 0, leaves
-// the target with an index on a field that cannot be indexed: the import job
-// sits in IndexBuilding forever and DescribeIndex fails with "failed to get
-// collection field: 0". See zilliztech/milvus-backup#1167.
-func replayIndex(backup *backuppb.BackupInfo) (bool, error) {
-	with := indexNames(backup, hasIndexExtra)
+// Broadcasting the create index anyway is worse still. With no field id the
+// index lands on FieldID 0, which is RowIDField and cannot be indexed: the
+// import job sits in IndexBuilding forever and DescribeIndex then fails with
+// "failed to get collection field: 0". See zilliztech/milvus-backup#1167.
+func checkIndexExtra(backup *backuppb.BackupInfo) error {
 	without := indexNames(backup, func(index *backuppb.IndexInfo) bool { return !hasIndexExtra(index) })
-
-	switch {
-	case len(with) != 0 && len(without) != 0:
-		return false, fmt.Errorf("secondary: backup %q carries the index extra info of %s but not of %s, "+
-			"the index extra info is collected for every index or for none, so the backup meta is "+
-			"inconsistent; re-create the backup with --backup_index_extra",
-			backup.GetName(), strings.Join(with, ", "), strings.Join(without, ", "))
-	case len(without) != 0:
-		return false, nil
-	default:
-		return true, nil
+	if len(without) == 0 {
+		return nil
 	}
+
+	with := indexNames(backup, hasIndexExtra)
+	if len(with) == 0 {
+		return fmt.Errorf("secondary: backup %q carries no index extra info, so %s cannot be "+
+			"recreated to match the source; take the backup again with --backup_index_extra "+
+			"(with_index_extra in the REST create request)",
+			backup.GetName(), strings.Join(without, ", "))
+	}
+
+	// The etcd attributes are collected for every index at once or for none, so
+	// a backup holding some but not others is inconsistent rather than merely
+	// incomplete, and is reported as such.
+	return fmt.Errorf("secondary: backup %q carries the index extra info of %s but not of %s, "+
+		"the index extra info is collected for every index or for none, so the backup meta is "+
+		"inconsistent; take the backup again with --backup_index_extra",
+		backup.GetName(), strings.Join(with, ", "), strings.Join(without, ", "))
 }
 
 func appendSysFields(schema *schemapb.CollectionSchema) {

--- a/core/restore/secondary/funcs.go
+++ b/core/restore/secondary/funcs.go
@@ -2,9 +2,12 @@ package secondary
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 )
 
 // checkDynamicField fails the restore if the source collection had dynamic
@@ -20,6 +23,68 @@ func checkDynamicField(schema *schemapb.CollectionSchema) error {
 		}
 	}
 	return fmt.Errorf("secondary: %q missing dynamic field in backup", schema.GetName())
+}
+
+// indexNames formats the indexes as "<db>.<coll>/<index>" for error and log
+// messages.
+func indexNames(backup *backuppb.BackupInfo, has func(*backuppb.IndexInfo) bool) []string {
+	var names []string
+	for _, coll := range backup.GetCollectionBackups() {
+		for _, index := range coll.GetIndexInfos() {
+			if !has(index) {
+				continue
+			}
+			names = append(names, fmt.Sprintf("%s.%s/%s",
+				coll.GetDbName(), coll.GetCollectionName(), index.GetIndexName()))
+		}
+	}
+	return names
+}
+
+// hasIndexExtra reports whether an index info carries the attributes that only
+// the index-extra task collects. field_id, type_params, index_params,
+// create_time, is_auto_index and min/max_index_version are read from etcd when
+// the backup is created with --backup_index_extra; without it the index info
+// holds only what DescribeIndex returns (field_name, index_name, index_type,
+// params, index_id).
+//
+// FieldID 0 is RowIDField, and user fields start at 100, so a zero field id
+// means the etcd attributes were never merged in.
+func hasIndexExtra(index *backuppb.IndexInfo) bool {
+	return index.GetFieldId() != 0 && len(index.GetIndexParams()) != 0
+}
+
+// replayIndex decides whether the create index DDL of a backup can be replayed
+// on the secondary cluster, and is the only place that decision is made.
+//
+// The backup answers it as a whole, because the extra attributes are collected
+// for every index at once or for none: a backup created with
+// --backup_index_extra carries the indexes to replay, one created without it
+// carries no index information that a verbatim DDL replay can use, and its
+// collections are restored without indexes.
+//
+// The missing attributes cannot be reconstructed on the client side - they are
+// what makes the replay match the source cluster - so a partially populated
+// backup is a contradiction rather than a case to work around, and is
+// reported. The alternative, broadcasting create index with FieldID 0, leaves
+// the target with an index on a field that cannot be indexed: the import job
+// sits in IndexBuilding forever and DescribeIndex fails with "failed to get
+// collection field: 0". See zilliztech/milvus-backup#1167.
+func replayIndex(backup *backuppb.BackupInfo) (bool, error) {
+	with := indexNames(backup, hasIndexExtra)
+	without := indexNames(backup, func(index *backuppb.IndexInfo) bool { return !hasIndexExtra(index) })
+
+	switch {
+	case len(with) != 0 && len(without) != 0:
+		return false, fmt.Errorf("secondary: backup %q carries the index extra info of %s but not of %s, "+
+			"the index extra info is collected for every index or for none, so the backup meta is "+
+			"inconsistent; re-create the backup with --backup_index_extra",
+			backup.GetName(), strings.Join(with, ", "), strings.Join(without, ", "))
+	case len(without) != 0:
+		return false, nil
+	default:
+		return true, nil
+	}
 }
 
 func appendSysFields(schema *schemapb.CollectionSchema) {

--- a/core/restore/secondary/funcs_test.go
+++ b/core/restore/secondary/funcs_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 )
 
 func TestCheckDynamicField(t *testing.T) {
@@ -43,4 +45,91 @@ func TestCheckDynamicField(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), `"coll"`)
 	})
+}
+
+func TestReplayIndex(t *testing.T) {
+	withExtra := func(name string) *backuppb.IndexInfo {
+		return &backuppb.IndexInfo{
+			FieldName:   "vec",
+			IndexName:   name,
+			FieldId:     101,
+			IndexParams: []*backuppb.KeyValuePair{{Key: "index_type", Value: "IVF_FLAT"}},
+		}
+	}
+	withoutExtra := func(name string) *backuppb.IndexInfo {
+		return &backuppb.IndexInfo{FieldName: "vec", IndexName: name}
+	}
+	newBackup := func(indexes ...*backuppb.IndexInfo) *backuppb.BackupInfo {
+		return &backuppb.BackupInfo{
+			Name: "bak1",
+			CollectionBackups: []*backuppb.CollectionBackupInfo{
+				{DbName: "default", CollectionName: "coll1", IndexInfos: indexes},
+			},
+		}
+	}
+
+	t.Run("EveryIndexHasExtra", func(t *testing.T) {
+		replay, err := replayIndex(newBackup(withExtra("idx1"), withExtra("idx2")))
+		assert.NoError(t, err)
+		assert.True(t, replay)
+	})
+
+	t.Run("NoIndexHasExtra", func(t *testing.T) {
+		replay, err := replayIndex(newBackup(withoutExtra("idx1"), withoutExtra("idx2")))
+		assert.NoError(t, err)
+		assert.False(t, replay)
+	})
+
+	t.Run("IndexParamsMissingCountsAsNoExtra", func(t *testing.T) {
+		index := withExtra("idx1")
+		index.IndexParams = nil
+		replay, err := replayIndex(newBackup(index))
+		assert.NoError(t, err)
+		assert.False(t, replay)
+	})
+
+	t.Run("NoIndexAtAll", func(t *testing.T) {
+		replay, err := replayIndex(newBackup())
+		assert.NoError(t, err)
+		assert.True(t, replay)
+	})
+
+	t.Run("NoCollection", func(t *testing.T) {
+		replay, err := replayIndex(&backuppb.BackupInfo{Name: "bak1"})
+		assert.NoError(t, err)
+		assert.True(t, replay)
+	})
+
+	t.Run("PartiallyPopulatedIsAnError", func(t *testing.T) {
+		backup := &backuppb.BackupInfo{
+			Name: "bak1",
+			CollectionBackups: []*backuppb.CollectionBackupInfo{
+				{DbName: "default", CollectionName: "coll1", IndexInfos: []*backuppb.IndexInfo{withExtra("good_idx")}},
+				{DbName: "db2", CollectionName: "coll2", IndexInfos: []*backuppb.IndexInfo{withoutExtra("bad_idx")}},
+			},
+		}
+		replay, err := replayIndex(backup)
+		assert.Error(t, err)
+		assert.False(t, replay)
+		assert.Contains(t, err.Error(), `"bak1"`)
+		assert.Contains(t, err.Error(), "default.coll1/good_idx")
+		assert.Contains(t, err.Error(), "db2.coll2/bad_idx")
+		assert.Contains(t, err.Error(), "--backup_index_extra")
+	})
+}
+
+func TestIndexNames(t *testing.T) {
+	backup := &backuppb.BackupInfo{
+		CollectionBackups: []*backuppb.CollectionBackupInfo{
+			{DbName: "default", CollectionName: "coll1", IndexInfos: []*backuppb.IndexInfo{
+				{IndexName: "idx1", FieldId: 101, IndexParams: []*backuppb.KeyValuePair{{Key: "index_type", Value: "IVF_FLAT"}}},
+				{IndexName: "idx2"},
+			}},
+		},
+	}
+
+	all := indexNames(backup, func(*backuppb.IndexInfo) bool { return true })
+	assert.Equal(t, []string{"default.coll1/idx1", "default.coll1/idx2"}, all)
+
+	assert.Equal(t, []string{"default.coll1/idx1"}, indexNames(backup, hasIndexExtra))
 }

--- a/core/restore/secondary/funcs_test.go
+++ b/core/restore/secondary/funcs_test.go
@@ -47,7 +47,7 @@ func TestCheckDynamicField(t *testing.T) {
 	})
 }
 
-func TestReplayIndex(t *testing.T) {
+func TestCheckIndexExtra(t *testing.T) {
 	withExtra := func(name string) *backuppb.IndexInfo {
 		return &backuppb.IndexInfo{
 			FieldName:   "vec",
@@ -69,38 +69,35 @@ func TestReplayIndex(t *testing.T) {
 	}
 
 	t.Run("EveryIndexHasExtra", func(t *testing.T) {
-		replay, err := replayIndex(newBackup(withExtra("idx1"), withExtra("idx2")))
-		assert.NoError(t, err)
-		assert.True(t, replay)
+		assert.NoError(t, checkIndexExtra(newBackup(withExtra("idx1"), withExtra("idx2"))))
 	})
 
 	t.Run("NoIndexHasExtra", func(t *testing.T) {
-		replay, err := replayIndex(newBackup(withoutExtra("idx1"), withoutExtra("idx2")))
-		assert.NoError(t, err)
-		assert.False(t, replay)
+		err := checkIndexExtra(newBackup(withoutExtra("idx1"), withoutExtra("idx2")))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"bak1"`)
+		assert.Contains(t, err.Error(), "default.coll1/idx1")
+		assert.Contains(t, err.Error(), "default.coll1/idx2")
+		assert.Contains(t, err.Error(), "--backup_index_extra")
 	})
 
 	t.Run("IndexParamsMissingCountsAsNoExtra", func(t *testing.T) {
 		index := withExtra("idx1")
 		index.IndexParams = nil
-		replay, err := replayIndex(newBackup(index))
-		assert.NoError(t, err)
-		assert.False(t, replay)
+		err := checkIndexExtra(newBackup(index))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "default.coll1/idx1")
 	})
 
 	t.Run("NoIndexAtAll", func(t *testing.T) {
-		replay, err := replayIndex(newBackup())
-		assert.NoError(t, err)
-		assert.True(t, replay)
+		assert.NoError(t, checkIndexExtra(newBackup()))
 	})
 
 	t.Run("NoCollection", func(t *testing.T) {
-		replay, err := replayIndex(&backuppb.BackupInfo{Name: "bak1"})
-		assert.NoError(t, err)
-		assert.True(t, replay)
+		assert.NoError(t, checkIndexExtra(&backuppb.BackupInfo{Name: "bak1"}))
 	})
 
-	t.Run("PartiallyPopulatedIsAnError", func(t *testing.T) {
+	t.Run("PartiallyPopulatedNamesBothSides", func(t *testing.T) {
 		backup := &backuppb.BackupInfo{
 			Name: "bak1",
 			CollectionBackups: []*backuppb.CollectionBackupInfo{
@@ -108,12 +105,12 @@ func TestReplayIndex(t *testing.T) {
 				{DbName: "db2", CollectionName: "coll2", IndexInfos: []*backuppb.IndexInfo{withoutExtra("bad_idx")}},
 			},
 		}
-		replay, err := replayIndex(backup)
+		err := checkIndexExtra(backup)
 		assert.Error(t, err)
-		assert.False(t, replay)
 		assert.Contains(t, err.Error(), `"bak1"`)
 		assert.Contains(t, err.Error(), "default.coll1/good_idx")
 		assert.Contains(t, err.Error(), "db2.coll2/bad_idx")
+		assert.Contains(t, err.Error(), "inconsistent")
 		assert.Contains(t, err.Error(), "--backup_index_extra")
 	})
 }

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -50,10 +50,6 @@ type TaskArgs struct {
 type Task struct {
 	args TaskArgs
 
-	// replayIndex reports whether the backup carries the index attributes that
-	// a verbatim create index replay needs. See replayIndex.
-	replayIndex bool
-
 	grpc    milvus.Grpc
 	restful milvus.Restful
 
@@ -107,22 +103,12 @@ func (t *Task) closeClients() {
 }
 
 func (t *Task) Execute(ctx context.Context) error {
-	// Decide before any client is created or any DDL is broadcast, so an
-	// inconsistent backup cannot leave a half-created collection behind and the
-	// user learns that indexes are not part of this restore before it starts.
-	replay, err := replayIndex(t.args.Backup)
-	if err != nil {
+	// Check before any client is created or any DDL is broadcast, so a backup
+	// that cannot produce a matching secondary is rejected before it leaves a
+	// half-created collection behind.
+	if err := checkIndexExtra(t.args.Backup); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
 		return err
-	}
-	t.replayIndex = replay
-	if !replay {
-		skipped := indexNames(t.args.Backup, func(*backuppb.IndexInfo) bool { return true })
-		if len(skipped) != 0 {
-			t.logger.Warn("backup was taken without --backup_index_extra, "+
-				"restoring the collections without their indexes",
-				zap.Strings("indexes", skipped))
-		}
 	}
 
 	defer t.closeClients()
@@ -228,10 +214,9 @@ func (t *Task) dmlTaskArgs() (dmlTaskArgs, error) {
 
 func (t *Task) ddlTaskArgs() ddlTaskArgs {
 	return ddlTaskArgs{
-		TaskID:      t.args.TaskID,
-		BackupInfo:  t.args.Backup,
-		ReplayIndex: t.replayIndex,
-		StreamCli:   t.streamCli,
+		TaskID:     t.args.TaskID,
+		BackupInfo: t.args.Backup,
+		StreamCli:  t.streamCli,
 	}
 }
 

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -50,6 +50,10 @@ type TaskArgs struct {
 type Task struct {
 	args TaskArgs
 
+	// replayIndex reports whether the backup carries the index attributes that
+	// a verbatim create index replay needs. See replayIndex.
+	replayIndex bool
+
 	grpc    milvus.Grpc
 	restful milvus.Restful
 
@@ -103,6 +107,24 @@ func (t *Task) closeClients() {
 }
 
 func (t *Task) Execute(ctx context.Context) error {
+	// Decide before any client is created or any DDL is broadcast, so an
+	// inconsistent backup cannot leave a half-created collection behind and the
+	// user learns that indexes are not part of this restore before it starts.
+	replay, err := replayIndex(t.args.Backup)
+	if err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return err
+	}
+	t.replayIndex = replay
+	if !replay {
+		skipped := indexNames(t.args.Backup, func(*backuppb.IndexInfo) bool { return true })
+		if len(skipped) != 0 {
+			t.logger.Warn("backup was taken without --backup_index_extra, "+
+				"restoring the collections without their indexes",
+				zap.Strings("indexes", skipped))
+		}
+	}
+
 	defer t.closeClients()
 	if err := t.initClients(); err != nil {
 		return err
@@ -206,9 +228,10 @@ func (t *Task) dmlTaskArgs() (dmlTaskArgs, error) {
 
 func (t *Task) ddlTaskArgs() ddlTaskArgs {
 	return ddlTaskArgs{
-		TaskID:     t.args.TaskID,
-		BackupInfo: t.args.Backup,
-		StreamCli:  t.streamCli,
+		TaskID:      t.args.TaskID,
+		BackupInfo:  t.args.Backup,
+		ReplayIndex: t.replayIndex,
+		StreamCli:   t.streamCli,
 	}
 }
 


### PR DESCRIPTION
issue: #1167

Follow-up to #1168.

## Problem

`IndexInfo` splits into two groups by source:

| source | fields |
|---|---|
| DescribeIndex (always present) | `field_name` `index_name` `index_type` `params` `index_id` |
| etcd, only with `--backup_index_extra` | `field_id` `create_time` `type_params` `index_params` `user_index_params` `is_auto_index` `min_index_version` `max_index_version` |

`createIndexes` looped over the index infos and broadcast each one unconditionally — written assuming the etcd half is always there, with no check. So a backup taken without the flag broadcasts an index on **FieldID 0** (`RowIDField`, which is never indexed), and the target ends up with an index entry that gates every future import of that collection:

- the import job finishes importing and then stays in `IndexBuilding`; the client polls `[state=Importing] [progress=80]` and never stops, because `waitBulkInsertState` only returns on `Completed` or `Failed`;
- DataCoord index tasks fail with `parse magic number failed, expected: 16775868, actual: 827474256` — `PAR1`, the index node reading the storage-v2 packed column file of field 0 as a v1 binlog;
- `DescribeIndex` on the restored collection fails with `failed to get collection field: 0`, so the bogus entry is hard to even inspect.

## Change

Whether a backup can serve a secondary restore at all is settled when the backup is created, not at restore time. So check it once, in `Task.Execute`, before any client is created or any DDL is broadcast:

| backup | behaviour |
|---|---|
| every index carries the extra attributes | replay create index as before — unchanged |
| any index does not | fail before anything is restored, naming the indexes and the option to re-create the backup with |

`replayIndex` becomes `checkIndexExtra` and returns only an error. The bool it used to thread through `Task` and `collDDLTask` is gone with it, and so is the warn that announced which indexes were being left out — there is nothing to leave out any more. Net −22 lines.

## Why not restore without the indexes

The first revision degraded instead: no extra attributes meant restoring the collections and their data with no indexes, saying so up front. @huanghaoyuanhhy's review is right that this does not work, and the reasons are now in the doc string:

**A collection with no index cannot be loaded.** `loadCollectionTask.PreExecute` fails with `ErrIndexNotFound` when `DescribeIndex` returns nothing. A loaded source is the ordinary DR case, so the degrade path just moves the failure to the `AlterLoadConfig` broadcast, with a less obvious error. For an unloaded source it yields a secondary that can never be loaded and cannot serve after a failover. Reporting success on a silently diverged secondary is worse than failing — the failure is visible, the divergence is not. This also answers the open question the first revision left: it does not load.

**The backups the degrade path was for barely exist.** Building a secondary needs the backup taken around a flush all, with CDC reading the WAL from its checkpoint; once the primary's WAL is GC'd past that point no secondary can be built from it, indexes or not. The workflow is always made-to-order, so failing on the missing option catches the misconfiguration while it can still be fixed.

**There is precedent in this package.** `checkDynamicField` already fails the restore for the dynamic-field gap behind the same option. This is the same shape and is now handled the same way.

Nothing is reconstructed on the client side. The missing attributes are what makes the DDL replay match the source cluster, and `create_time` in particular does not exist anywhere in a default backup; guessing them would silently put an index with different parameters on the replica.

## Seen in production

A default REST create (`{"async": true, "backup_name": "..."}`, no `with_index_extra`) against a 66-collection cluster this week. `restore secondary` walked past sixty of them before failing on `"test_storage" missing dynamic field in backup` — the dynamic-field check catching it first, behind the same option. Had that check not been there, this path would have been next, and it would have failed later and less clearly.

## Tests

`TestCheckIndexExtra` covers both outcomes plus the partially-populated case, empty index list, empty collection list, and `index_params` missing on its own; `TestIndexNames` covers the message formatting.

`restore secondary --help` now says a backup without the flag is refused, rather than restored without indexes.

## Not in scope

- **Recovering an existing backup.** The attributes can still be read from the source cluster's etcd, so a command that backfills them into an already-taken backup would make those backups restorable. Restore-time is too late for it: `restore secondary` is configured against the target, and `--source_cluster_id` is an identifier, not a connection — this belongs on the source side, as its own command.
- **Making the backup side say so.** `--backup_index_extra` defaults to false, and it also gates the dynamic-field backup through the etcd client created only for it. #1190 covers the visibility half; the contract half — refusing at create time once the user has declared secondary intent — is #1170.
