### PR TITLE
restore: stop waiting for an import job the target does not have

### DIFF
--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -49,6 +49,10 @@ var (
 	// target only knows the job once that message has been applied; the window
 	// covers the message still being in flight.
 	_bulkInsertUnknownJobTimeout = 1 * time.Minute
+	// How long to let the target apply the DDL before concluding that a
+	// collection the restore created is not there.
+	_restoreVerifyTimeout  = 30 * time.Second
+	_restoreVerifyInterval = 3 * time.Second
 )
 
 type partitionDir struct {
@@ -380,15 +384,16 @@ func (dmlt *collDMLTask) waitBulkInsertState(
 				unknownSince = time.Now()
 			} else if time.Since(unknownSince) >= _bulkInsertUnknownJobTimeout {
 				return "", fmt.Errorf("secondary: the target does not know import job %d after %s, "+
-					"so the import message this restore sent was never applied. The usual reason is "+
-					"that the target is not a freshly configured secondary: a secondary only moves "+
-					"its replicate checkpoint forward, and the messages a restore injects are "+
-					"time-ticked from 1, so everything this restore sends is discarded as too old "+
-					"once an earlier restore has advanced that checkpoint. Reset the target before "+
-					"restoring again: force-promote it to a standalone primary, which is the only "+
-					"transition that drops the checkpoint (re-applying the same replicate "+
-					"configuration does not, and neither does restarting it), drop whatever an "+
-					"earlier restore left behind, then configure it as a secondary again",
+					"so the import message this restore sent was never applied. A secondary restore "+
+					"targets a newly deployed secondary and runs once: the messages it injects are "+
+					"time-ticked from 1, while a secondary only ever moves its replicate checkpoint "+
+					"forward, so a target that has already been restored discards everything a "+
+					"second restore sends. There is no way to return a used target to that state -- "+
+					"re-applying the same replicate configuration does not clear the checkpoint, "+
+					"restarting the target does not, and dropping its collections makes matters "+
+					"worse, because their ids stay reserved while the collections are being "+
+					"reclaimed and a later restore of the same ids is then discarded without an "+
+					"error. To bootstrap again, deploy a new secondary and restore into that",
 					jobID, _bulkInsertUnknownJobTimeout)
 			}
 		} else {

--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -36,9 +36,19 @@ import (
 const (
 	_bulkInsertTimeout             = 60 * time.Minute
 	_bulkInsertRestfulAPIChunkSize = 256
-	_bulkInsertCheckInterval       = 3 * time.Second
 	_commitImportMessageType       = 45
 	_commitImportMessageVersion    = 2
+)
+
+// Overridden in tests so the unknown-job path does not take a minute to
+// exercise.
+var (
+	_bulkInsertCheckInterval = 3 * time.Second
+	// How long an import job may stay unknown to the target before the restore
+	// gives up on it. The job id travels inside the import message, so the
+	// target only knows the job once that message has been applied; the window
+	// covers the message still being in flight.
+	_bulkInsertUnknownJobTimeout = 1 * time.Minute
 )
 
 type partitionDir struct {
@@ -342,6 +352,9 @@ func (dmlt *collDMLTask) waitBulkInsertState(
 	jobIDStr := strconv.FormatInt(jobID, 10)
 
 	var lastProgress int
+	// Stays zero until the target reports an empty state, so the window only
+	// starts once there is something to wait out.
+	var unknownSince time.Time
 	lastUpdateTime := time.Now()
 	ticker := time.NewTicker(_bulkInsertCheckInterval)
 	defer ticker.Stop()
@@ -358,6 +371,28 @@ func (dmlt *collDMLTask) waitBulkInsertState(
 			zap.Int("progress", resp.Data.Progress))
 		if state == milvus.ImportStateFailed {
 			return "", fmt.Errorf("secondary: bulk insert failed: %s", resp.Data.Reason)
+		}
+		// An empty state is not a state the job can be in: the target does not
+		// have this job at all. That never turns into anything else, so waiting
+		// for it is waiting forever.
+		if state == "" {
+			if unknownSince.IsZero() {
+				unknownSince = time.Now()
+			} else if time.Since(unknownSince) >= _bulkInsertUnknownJobTimeout {
+				return "", fmt.Errorf("secondary: the target does not know import job %d after %s, "+
+					"so the import message this restore sent was never applied. The usual reason is "+
+					"that the target is not a freshly configured secondary: a secondary only moves "+
+					"its replicate checkpoint forward, and the messages a restore injects are "+
+					"time-ticked from 1, so everything this restore sends is discarded as too old "+
+					"once an earlier restore has advanced that checkpoint. Reset the target before "+
+					"restoring again: force-promote it to a standalone primary, which is the only "+
+					"transition that drops the checkpoint (re-applying the same replicate "+
+					"configuration does not, and neither does restarting it), drop whatever an "+
+					"earlier restore left behind, then configure it as a secondary again",
+					jobID, _bulkInsertUnknownJobTimeout)
+			}
+		} else {
+			unknownSince = time.Time{}
 		}
 		if done(state) {
 			if state == milvus.ImportStateCompleted {

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -676,7 +676,7 @@ func TestWaitBulkInsertStateUnknownJob(t *testing.T) {
 		_, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 4242)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not know import job 4242")
-		assert.Contains(t, err.Error(), "force-promote")
+		assert.Contains(t, err.Error(), "deploy a new secondary")
 	})
 
 	t.Run("a job that is merely slow to appear is waited for", func(t *testing.T) {

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
@@ -620,4 +621,88 @@ func TestExecute_Import2PCPreservesPhaseAndTimestampOrdering(t *testing.T) {
 				"timestamps on pch %s should be strictly increasing, got %v", pch, timestamps)
 		}
 	}
+}
+
+// stateSequenceRestful answers GetBulkInsertState from a fixed sequence,
+// repeating the last entry once the sequence is exhausted. Only that one method
+// is used by the wait loop, so the rest of the interface is left embedded.
+type stateSequenceRestful struct {
+	milvus.Restful
+
+	mu     sync.Mutex
+	states []string
+	calls  int
+}
+
+func (r *stateSequenceRestful) GetBulkInsertState(_ context.Context, _, _ string) (*milvus.GetProcessResp, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	i := r.calls
+	if i >= len(r.states) {
+		i = len(r.states) - 1
+	}
+	r.calls++
+	resp := &milvus.GetProcessResp{}
+	resp.Data.State = r.states[i]
+	return resp, nil
+}
+
+func (r *stateSequenceRestful) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func newWaitTask(cli milvus.Restful) *collDMLTask {
+	return &collDMLTask{
+		collBackup: &backuppb.CollectionBackupInfo{DbName: "default"},
+		restfulCli: cli,
+		logger:     zap.NewNop(),
+	}
+}
+
+// A job the target does not have reports an empty state, which is not a state
+// the job can be in and never becomes one. The wait must end rather than poll
+// for it forever.
+func TestWaitBulkInsertStateUnknownJob(t *testing.T) {
+	prevInterval, prevTimeout := _bulkInsertCheckInterval, _bulkInsertUnknownJobTimeout
+	_bulkInsertCheckInterval, _bulkInsertUnknownJobTimeout = time.Millisecond, 20*time.Millisecond
+	defer func() {
+		_bulkInsertCheckInterval, _bulkInsertUnknownJobTimeout = prevInterval, prevTimeout
+	}()
+
+	t.Run("an always unknown job gives up and says how to recover", func(t *testing.T) {
+		cli := &stateSequenceRestful{states: []string{""}}
+		_, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 4242)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not know import job 4242")
+		assert.Contains(t, err.Error(), "force-promote")
+	})
+
+	t.Run("a job that is merely slow to appear is waited for", func(t *testing.T) {
+		// Empty for a few polls, well inside the window, then a real state.
+		cli := &stateSequenceRestful{states: []string{"", "", "", string(milvus.ImportStateCompleted)}}
+		state, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 7)
+		assert.NoError(t, err)
+		assert.Equal(t, milvus.ImportStateCompleted, state)
+		assert.Equal(t, 4, cli.callCount())
+	})
+
+	t.Run("the window restarts once the job becomes known again", func(t *testing.T) {
+		// Empty, then known, then empty again: the second empty run is shorter
+		// than the window, so it must not trip the give-up path.
+		cli := &stateSequenceRestful{states: []string{
+			"", string(milvus.ImportStatePending), "", string(milvus.ImportStateCompleted),
+		}}
+		state, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 9)
+		assert.NoError(t, err)
+		assert.Equal(t, milvus.ImportStateCompleted, state)
+	})
+
+	t.Run("a failed job still reports its own reason", func(t *testing.T) {
+		cli := &stateSequenceRestful{states: []string{string(milvus.ImportStateFailed)}}
+		_, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 11)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bulk insert failed")
+	})
 }

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -111,6 +111,11 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreExecuting())
 
+	if err := t.checkTargetNotRestored(ctx); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return err
+	}
+
 	if err := t.checkTargetIsUnused(ctx); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
 		return err
@@ -146,6 +151,71 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreSuccess())
 	t.logger.Info("restore done")
+	return nil
+}
+
+// checkTargetNotRestored refuses to restore into a target that has already been
+// restored.
+//
+// The replicate checkpoint is what says so. A newly deployed secondary reports
+// zero on every pchannel; a restore ends by forwarding the backup's flush-all
+// messages, which carry the source's own time ticks and leave the checkpoint
+// there. Nothing an operator does brings it back to zero -- re-applying the
+// same replicate configuration does not, and neither does restarting the
+// target or dropping its collections.
+//
+// This matters most for the case that is otherwise invisible. Dropping the
+// target's collections hides them but keeps their ids reserved until the
+// collections are reclaimed, and a replayed create for a reserved id is
+// skipped without an error, so the restore would report success having created
+// nothing. That target still carries the checkpoint of the restore that put
+// the collections there, which is what this catches.
+func (t *Task) checkTargetNotRestored(ctx context.Context) error {
+	cfg, err := t.grpc.GetReplicateConfiguration(ctx)
+	if err != nil {
+		// A cluster with no replication cannot have been restored into as a
+		// secondary, and the restore fails on its own if it is not one.
+		t.logger.Info("cannot read the target's replicate configuration, skipping the check",
+			zap.Error(err))
+		return nil
+	}
+
+	var pchannels []string
+	for _, cluster := range cfg.GetClusters() {
+		if cluster.GetClusterId() == t.args.TargetClusterID {
+			pchannels = cluster.GetPchannels()
+			break
+		}
+	}
+	if len(pchannels) == 0 {
+		t.logger.Info("the target reports no pchannels of its own, skipping the check",
+			zap.String("targetClusterID", t.args.TargetClusterID))
+		return nil
+	}
+
+	for _, pchannel := range pchannels {
+		resp, err := t.grpc.GetReplicateInfo(ctx, t.args.SourceClusterID, pchannel)
+		if err != nil {
+			return fmt.Errorf("secondary: read the replicate checkpoint of %s: %w", pchannel, err)
+		}
+		tick := resp.GetCheckpoint().GetTimeTick()
+		if tick == 0 {
+			continue
+		}
+		return fmt.Errorf("secondary: %s already has a replicate checkpoint (%s is at time tick "+
+			"%d), so this target has been restored before. A secondary restore runs once, "+
+			"against a newly deployed secondary: the messages it injects are time-ticked from "+
+			"1, and a secondary only ever moves its checkpoint forward, so everything this "+
+			"restore sends would be discarded. Nothing returns a used target to that state -- "+
+			"re-applying the same replicate configuration does not clear the checkpoint, "+
+			"restarting the target does not, and dropping its collections only hides them "+
+			"while their ids stay reserved. To bootstrap again, deploy a new secondary and "+
+			"restore into that",
+			t.args.TargetClusterID, pchannel, tick)
+	}
+
+	t.logger.Info("the target has no replicate checkpoint, as a newly deployed secondary should",
+		zap.Int("pchannels", len(pchannels)))
 	return nil
 }
 

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand/v2"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -110,6 +111,11 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreExecuting())
 
+	if err := t.checkTargetIsUnused(ctx); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return err
+	}
+
 	if err := t.runDBTasks(ctx); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
 		return fmt.Errorf("secondary: run database tasks: %w", err)
@@ -133,9 +139,104 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.logger.Info("wait confirm")
 	t.streamCli.WaitConfirm()
 
+	if err := t.verifyRestored(ctx); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return err
+	}
+
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreSuccess())
 	t.logger.Info("restore done")
 	return nil
+}
+
+// checkTargetIsUnused refuses to restore into a target that already holds one
+// of the collections in the backup.
+//
+// A secondary restore replays the source's DDL verbatim, collection ids
+// included, and it is meant to run once against a newly deployed secondary.
+// Restoring on top of a collection that is already there does not replace it:
+// the create is skipped and the data is imported into the existing collection,
+// which silently doubles its rows.
+func (t *Task) checkTargetIsUnused(ctx context.Context) error {
+	var present []string
+	for _, coll := range t.args.Backup.GetCollectionBackups() {
+		ns := fmt.Sprintf("%s.%s", coll.GetDbName(), coll.GetCollectionName())
+		has, err := t.grpc.HasCollection(ctx, coll.GetDbName(), coll.GetCollectionName())
+		if err != nil {
+			// A database the backup will create does not exist yet, which is
+			// the expected state; anything else is reported when it is used.
+			t.logger.Info("cannot check whether the target already holds a collection, continuing",
+				zap.String("ns", ns), zap.Error(err))
+			continue
+		}
+		if has {
+			present = append(present, ns)
+		}
+	}
+	if len(present) == 0 {
+		return nil
+	}
+	return fmt.Errorf("secondary: the target already holds %v, so it is not a newly "+
+		"deployed secondary. A secondary restore replays the source's DDL with the "+
+		"source's collection ids and is meant to run once: restoring on top of an "+
+		"existing collection does not replace it, it imports into it and doubles its "+
+		"rows. Dropping those collections does not make the target usable either, "+
+		"because their ids stay reserved while they are reclaimed and a restore of the "+
+		"same ids is then discarded without an error. To bootstrap again, deploy a new "+
+		"secondary and restore into that", present)
+}
+
+// verifyRestored confirms the collections actually exist on the target.
+//
+// Every step of this restore reports on whether the messages it sent were
+// accepted, not on what the target did with them. The target can accept them
+// and still create nothing -- a collection id left reserved by an earlier,
+// reclaimed collection makes the replayed create a silent no-op -- so without
+// this check the restore reports success against an empty target.
+func (t *Task) verifyRestored(ctx context.Context) error {
+	deadline := time.Now().Add(_restoreVerifyTimeout)
+	var missing []string
+	for {
+		missing = missing[:0]
+		for _, coll := range t.args.Backup.GetCollectionBackups() {
+			has, err := t.grpc.HasCollection(ctx, coll.GetDbName(), coll.GetCollectionName())
+			if err != nil {
+				return fmt.Errorf("secondary: verify restored collection %s.%s: %w",
+					coll.GetDbName(), coll.GetCollectionName(), err)
+			}
+			if !has {
+				missing = append(missing, fmt.Sprintf("%s.%s",
+					coll.GetDbName(), coll.GetCollectionName()))
+			}
+		}
+		if len(missing) == 0 {
+			t.logger.Info("all restored collections are present on the target")
+			return nil
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		// The DDL is applied asynchronously on the target, so give it a moment
+		// before concluding that it never arrived.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(_restoreVerifyInterval):
+		}
+	}
+	return fmt.Errorf("secondary: the restore reported no errors, but %v %s not present on "+
+		"the target after %s. The messages were accepted and nothing was created, which "+
+		"happens when the target is not a newly deployed secondary: a collection id that "+
+		"an earlier collection still holds while it is being reclaimed makes the replayed "+
+		"create a silent no-op. Deploy a new secondary and restore into that",
+		missing, plural(len(missing)), _restoreVerifyTimeout)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "is"
+	}
+	return "are"
 }
 
 func (t *Task) runDBTasks(ctx context.Context) error {

--- a/core/restore/secondary/task_precondition_test.go
+++ b/core/restore/secondary/task_precondition_test.go
@@ -1,0 +1,113 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secondary
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+)
+
+func taskWithBackup(cli milvus.Grpc, colls ...*backuppb.CollectionBackupInfo) *Task {
+	return &Task{
+		args:   TaskArgs{Backup: &backuppb.BackupInfo{CollectionBackups: colls}},
+		grpc:   cli,
+		logger: zap.NewNop(),
+	}
+}
+
+func coll(db, name string) *backuppb.CollectionBackupInfo {
+	return &backuppb.CollectionBackupInfo{DbName: db, CollectionName: name}
+}
+
+func TestCheckTargetIsUnused(t *testing.T) {
+	orders, invoices := coll("default", "orders"), coll("default", "invoices")
+
+	t.Run("a target that holds none of them is accepted", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(false, nil)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "invoices").Return(false, nil)
+		assert.NoError(t, taskWithBackup(cli, orders, invoices).checkTargetIsUnused(context.Background()))
+	})
+
+	t.Run("a target that already holds one is refused, and it is named", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(true, nil)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "invoices").Return(false, nil)
+		err := taskWithBackup(cli, orders, invoices).checkTargetIsUnused(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "default.orders")
+		assert.NotContains(t, err.Error(), "default.invoices")
+		assert.Contains(t, err.Error(), "new secondary")
+	})
+
+	t.Run("a database that does not exist yet is not a reason to refuse", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "other", "orders").
+			Return(false, errors.New("database not found"))
+		assert.NoError(t, taskWithBackup(cli, coll("other", "orders")).checkTargetIsUnused(context.Background()))
+	})
+}
+
+func TestVerifyRestored(t *testing.T) {
+	prevTimeout, prevInterval := _restoreVerifyTimeout, _restoreVerifyInterval
+	_restoreVerifyTimeout, _restoreVerifyInterval = 30*time.Millisecond, time.Millisecond
+	defer func() {
+		_restoreVerifyTimeout, _restoreVerifyInterval = prevTimeout, prevInterval
+	}()
+
+	t.Run("collections that are present pass", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(true, nil)
+		assert.NoError(t, taskWithBackup(cli, coll("default", "orders")).verifyRestored(context.Background()))
+	})
+
+	// The whole point: every message was accepted and nothing was created.
+	t.Run("a collection that never appears fails the restore", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(false, nil)
+		err := taskWithBackup(cli, coll("default", "orders")).verifyRestored(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "default.orders")
+		assert.Contains(t, err.Error(), "reported no errors")
+		assert.Contains(t, err.Error(), "new secondary")
+	})
+
+	t.Run("a collection that appears a moment later still passes", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(false, nil).Once()
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").Return(true, nil)
+		assert.NoError(t, taskWithBackup(cli, coll("default", "orders")).verifyRestored(context.Background()))
+	})
+
+	t.Run("a failing lookup is reported rather than treated as missing", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").
+			Return(false, errors.New("connection refused"))
+		err := taskWithBackup(cli, coll("default", "orders")).verifyRestored(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+}

--- a/core/restore/secondary/task_precondition_test.go
+++ b/core/restore/secondary/task_precondition_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
@@ -107,6 +109,85 @@ func TestVerifyRestored(t *testing.T) {
 		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").
 			Return(false, errors.New("connection refused"))
 		err := taskWithBackup(cli, coll("default", "orders")).verifyRestored(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+}
+
+func cfgWith(clusterID string, pchannels ...string) *commonpb.ReplicateConfiguration {
+	return &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "other", Pchannels: []string{"other-rootcoord-dml_0"}},
+			{ClusterId: clusterID, Pchannels: pchannels},
+		},
+	}
+}
+
+func infoAt(tick uint64) *milvuspb.GetReplicateInfoResponse {
+	return &milvuspb.GetReplicateInfoResponse{
+		Checkpoint: &commonpb.ReplicateCheckpoint{TimeTick: tick},
+	}
+}
+
+func taskForTarget(cli milvus.Grpc) *Task {
+	return &Task{
+		args: TaskArgs{
+			SourceClusterID: "src",
+			TargetClusterID: "tgt",
+			Backup:          &backuppb.BackupInfo{},
+		},
+		grpc:   cli,
+		logger: zap.NewNop(),
+	}
+}
+
+func TestCheckTargetNotRestored(t *testing.T) {
+	t.Run("a newly deployed secondary reports zero on every pchannel", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().GetReplicateConfiguration(mock.Anything).
+			Return(cfgWith("tgt", "tgt-rootcoord-dml_0", "tgt-rootcoord-dml_1"), nil)
+		cli.EXPECT().GetReplicateInfo(mock.Anything, "src", "tgt-rootcoord-dml_0").Return(infoAt(0), nil)
+		cli.EXPECT().GetReplicateInfo(mock.Anything, "src", "tgt-rootcoord-dml_1").Return(infoAt(0), nil)
+		assert.NoError(t, taskForTarget(cli).checkTargetNotRestored(context.Background()))
+	})
+
+	// The case that is otherwise invisible: the collections were dropped, so
+	// nothing is listed, but the checkpoint of the restore that created them
+	// is still there.
+	t.Run("a target that was restored before is refused, naming the pchannel", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().GetReplicateConfiguration(mock.Anything).
+			Return(cfgWith("tgt", "tgt-rootcoord-dml_0", "tgt-rootcoord-dml_1"), nil)
+		cli.EXPECT().GetReplicateInfo(mock.Anything, "src", "tgt-rootcoord-dml_0").Return(infoAt(0), nil)
+		cli.EXPECT().GetReplicateInfo(mock.Anything, "src", "tgt-rootcoord-dml_1").
+			Return(infoAt(468522223459106838), nil)
+		err := taskForTarget(cli).checkTargetNotRestored(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tgt-rootcoord-dml_1")
+		assert.Contains(t, err.Error(), "restored before")
+		assert.Contains(t, err.Error(), "new secondary")
+	})
+
+	t.Run("a cluster with no replication configuration is not refused", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().GetReplicateConfiguration(mock.Anything).
+			Return(nil, errors.New("deadline exceeded"))
+		assert.NoError(t, taskForTarget(cli).checkTargetNotRestored(context.Background()))
+	})
+
+	t.Run("a configuration that does not list the target is not refused", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().GetReplicateConfiguration(mock.Anything).Return(cfgWith("someone-else"), nil)
+		assert.NoError(t, taskForTarget(cli).checkTargetNotRestored(context.Background()))
+	})
+
+	t.Run("a checkpoint that cannot be read is reported", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().GetReplicateConfiguration(mock.Anything).
+			Return(cfgWith("tgt", "tgt-rootcoord-dml_0"), nil)
+		cli.EXPECT().GetReplicateInfo(mock.Anything, "src", "tgt-rootcoord-dml_0").
+			Return(nil, errors.New("connection refused"))
+		err := taskForTarget(cli).checkTargetNotRestored(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "connection refused")
 	})

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -153,6 +153,8 @@ type Grpc interface {
 	CreateIndex(ctx context.Context, input CreateIndexInput) error
 	DropIndex(ctx context.Context, db, collName, indexName string) error
 	DropIndexProperties(ctx context.Context, db, collName, indexName string, keys []string) error
+	GetReplicateConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, error)
+	GetReplicateInfo(ctx context.Context, sourceClusterID, targetPchannel string) (*milvuspb.GetReplicateInfoResponse, error)
 	BackupRBAC(ctx context.Context) (*milvuspb.BackupRBACMetaResponse, error)
 	RestoreRBAC(ctx context.Context, rbacMeta *milvuspb.RBACMeta) error
 	ReplicateMessage(ctx context.Context, channelName string) (string, error)
@@ -1130,6 +1132,35 @@ func (g *GrpcClient) DropIndexProperties(ctx context.Context, db, collName, inde
 		return fmt.Errorf("client: drop index properties failed: %w", err)
 	}
 	return nil
+}
+
+// GetReplicateConfiguration returns the cross-cluster replication configuration
+// the cluster currently holds. A cluster that has never been given one answers
+// with an empty configuration rather than an error.
+func (g *GrpcClient) GetReplicateConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, error) {
+	ctx = g.newCtx(ctx)
+	resp, err := g.srv.GetReplicateConfiguration(ctx, &milvuspb.GetReplicateConfigurationRequest{})
+	if err := checkResponse(resp, err); err != nil {
+		return nil, fmt.Errorf("client: get replicate configuration: %w", err)
+	}
+
+	return resp.GetConfiguration(), nil
+}
+
+// GetReplicateInfo returns the replication checkpoint the cluster holds for one
+// of its OWN pchannels. Passing a pchannel that belongs to another cluster does
+// not fail: the lookup blocks until the caller's deadline.
+func (g *GrpcClient) GetReplicateInfo(ctx context.Context, sourceClusterID, targetPchannel string) (*milvuspb.GetReplicateInfoResponse, error) {
+	ctx = g.newCtx(ctx)
+	resp, err := g.srv.GetReplicateInfo(ctx, &milvuspb.GetReplicateInfoRequest{
+		SourceClusterId: sourceClusterID,
+		TargetPchannel:  targetPchannel,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("client: get replicate info of %s: %w", targetPchannel, err)
+	}
+
+	return resp, nil
 }
 
 func (g *GrpcClient) BackupRBAC(ctx context.Context) (*milvuspb.BackupRBACMetaResponse, error) {

--- a/internal/client/milvus/grpc_mock.go
+++ b/internal/client/milvus/grpc_mock.go
@@ -1875,6 +1875,142 @@ func (_c *MockGrpc_GetPersistentSegmentInfo_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// GetReplicateConfiguration provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) GetReplicateConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReplicateConfiguration")
+	}
+
+	var r0 *commonpb.ReplicateConfiguration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*commonpb.ReplicateConfiguration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *commonpb.ReplicateConfiguration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.ReplicateConfiguration)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_GetReplicateConfiguration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReplicateConfiguration'
+type MockGrpc_GetReplicateConfiguration_Call struct {
+	*mock.Call
+}
+
+// GetReplicateConfiguration is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockGrpc_Expecter) GetReplicateConfiguration(ctx any) *MockGrpc_GetReplicateConfiguration_Call {
+	return &MockGrpc_GetReplicateConfiguration_Call{Call: _e.mock.On("GetReplicateConfiguration", ctx)}
+}
+
+func (_c *MockGrpc_GetReplicateConfiguration_Call) Run(run func(ctx context.Context)) *MockGrpc_GetReplicateConfiguration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_GetReplicateConfiguration_Call) Return(replicateConfiguration *commonpb.ReplicateConfiguration, err error) *MockGrpc_GetReplicateConfiguration_Call {
+	_c.Call.Return(replicateConfiguration, err)
+	return _c
+}
+
+func (_c *MockGrpc_GetReplicateConfiguration_Call) RunAndReturn(run func(ctx context.Context) (*commonpb.ReplicateConfiguration, error)) *MockGrpc_GetReplicateConfiguration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetReplicateInfo provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) GetReplicateInfo(ctx context.Context, sourceClusterID string, targetPchannel string) (*milvuspb.GetReplicateInfoResponse, error) {
+	ret := _mock.Called(ctx, sourceClusterID, targetPchannel)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReplicateInfo")
+	}
+
+	var r0 *milvuspb.GetReplicateInfoResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*milvuspb.GetReplicateInfoResponse, error)); ok {
+		return returnFunc(ctx, sourceClusterID, targetPchannel)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *milvuspb.GetReplicateInfoResponse); ok {
+		r0 = returnFunc(ctx, sourceClusterID, targetPchannel)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetReplicateInfoResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, sourceClusterID, targetPchannel)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_GetReplicateInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReplicateInfo'
+type MockGrpc_GetReplicateInfo_Call struct {
+	*mock.Call
+}
+
+// GetReplicateInfo is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sourceClusterID string
+//   - targetPchannel string
+func (_e *MockGrpc_Expecter) GetReplicateInfo(ctx any, sourceClusterID any, targetPchannel any) *MockGrpc_GetReplicateInfo_Call {
+	return &MockGrpc_GetReplicateInfo_Call{Call: _e.mock.On("GetReplicateInfo", ctx, sourceClusterID, targetPchannel)}
+}
+
+func (_c *MockGrpc_GetReplicateInfo_Call) Run(run func(ctx context.Context, sourceClusterID string, targetPchannel string)) *MockGrpc_GetReplicateInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_GetReplicateInfo_Call) Return(getReplicateInfoResponse *milvuspb.GetReplicateInfoResponse, err error) *MockGrpc_GetReplicateInfo_Call {
+	_c.Call.Return(getReplicateInfoResponse, err)
+	return _c
+}
+
+func (_c *MockGrpc_GetReplicateInfo_Call) RunAndReturn(run func(ctx context.Context, sourceClusterID string, targetPchannel string) (*milvuspb.GetReplicateInfoResponse, error)) *MockGrpc_GetReplicateInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRestoreSnapshotState provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) GetRestoreSnapshotState(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error) {
 	ret := _mock.Called(ctx, jobID)


### PR DESCRIPTION
issue: #1176

A secondary restore ships the import job id inside the import message and then
polls the target for that job:

```go
jobID := rand.Int64()
...
body := &message.ImportMsg{ ..., JobID: jobID }
```

If the message was not applied, the target has no such job. `GetBulkInsertState`
still succeeds and reports an empty state, which is neither `Failed` nor a state
`waitBulkInsertState` is waiting for, so the loop polls every three seconds
forever. The one guard in the loop does not end it either — after an hour with
no progress it logs a warning and resets its own timer.

The state is easy to reach. `StreamClient.ttCounter` starts at zero in every
process, so every restore time-ticks its injected messages from 1, while a
secondary only moves its replicate checkpoint forward and discards anything at
or below it:

```
message is too old, message_id: 1, time_tick: 1, txn: false, current time tick: 468520367335407637
message is too old, message_id: 2, time_tick: 2, txn: false, current time tick: 468520367335407648
```

That is an ignore, not an error, so nothing is reported to the sender. A restore
that failed part way does not roll back, so retrying it is enough to get here:
the DDL, the index and the import message are all dropped and the command hangs
with nothing written and nothing logged.

This does not change how time ticks are assigned — the small ticks are
load-bearing, since `Forward` replays the backup's flush-all messages with the
source's original time ticks and the injected ones have to stay below them. It
makes the unknown-job case observable instead: an empty state that persists for
a minute ends the wait with an error that names the job and describes the reset
the target needs. Only leaving the secondary role drops the replicate
checkpoint, so re-applying the same replicate configuration does not clear it
and neither does restarting the target; that is worth saying in the error,
because it is the first thing an operator tries.

A job that is merely slow to appear is unaffected: the window only starts when
an empty state is seen, and it restarts if the job becomes known again.

### Reproduction

Two collections, two backups, two restores into the same secondary, no reset in
between:

| | first restore | second restore |
|---|---|---|
| injected `CreateCollection timestamp` | 2 | 2 |
| outcome | `restore done` | hangs; killed after 200s |
| bulk insert polls | 5 | 66, every one with an empty state |
| collection on the target | present, 200 rows | never created |

After resetting the target (force-promote to standalone primary, then configure
it as a secondary again) the identical backup restored on the first attempt.

### Tests

`TestWaitBulkInsertStateUnknownJob` covers the four cases: an always-unknown job
gives up and says how to recover, a job that is slow to appear is still waited
for, the window restarts once the job becomes known again, and a failed job
still reports its own reason.
