### PR TITLE
storage: name the account-qualified host in azure snapshot uris

### DIFF
--- a/internal/storage/snapshot.go
+++ b/internal/storage/snapshot.go
@@ -32,17 +32,33 @@ func SnapshotURI(cfg Config, key string) (string, error) {
 		return "", err
 	}
 
-	// Azure names its service endpoint in the host and carries the account name in the
-	// extfs access_key_id, so the host is the blob. service endpoint, not the account one.
+	// Milvus's snapshot validator recognizes an Azure URI host only as the
+	// account-qualified endpoint (<account>.blob.<service-endpoint>) or the bare
+	// service endpoint, and rejects anything else as not matching the configured
+	// endpoint — so the URI names the account-qualified host. The account name is
+	// always set, since the Azure client itself needs it to build the blob
+	// service URL.
 	if cfg.Provider == v2.ProviderAzure {
-		host := endpointHost(cfg.Endpoint)
 		if cfg.MilvusEndpoint != "" {
-			host = endpointHost(cfg.MilvusEndpoint)
+			// The override names the exact host Milvus resolves, account included.
+			host := endpointHost(cfg.MilvusEndpoint)
+			if host == "" {
+				return "", fmt.Errorf("storage: snapshot uri for azure needs an endpoint")
+			}
+			return fmt.Sprintf("azure://%s/%s/%s", host, cfg.Bucket, key), nil
 		}
+		if cfg.Credential.AzureAccountName == "" {
+			return "", fmt.Errorf("storage: snapshot uri for azure needs an account name")
+		}
+		host := endpointHost(cfg.Endpoint)
 		if host == "" {
 			return "", fmt.Errorf("storage: snapshot uri for azure needs an endpoint")
 		}
-		return fmt.Sprintf("azure://blob.%s/%s/%s", host, cfg.Bucket, key), nil
+		// Milvus reports the completed export's metadata URI with the default
+		// https port dropped; drop it here too, or the backup meta's cross-check
+		// of the two spellings fails on the port alone.
+		host = strings.TrimSuffix(host, ":443")
+		return fmt.Sprintf("azure://%s.blob.%s/%s/%s", cfg.Credential.AzureAccountName, host, cfg.Bucket, key), nil
 	}
 
 	// Native GCS is reached through its own client, not an S3-compatible endpoint, so the

--- a/internal/storage/snapshot_test.go
+++ b/internal/storage/snapshot_test.go
@@ -74,18 +74,42 @@ func TestSnapshotURI(t *testing.T) {
 		assert.ErrorContains(t, err, "region")
 	})
 
-	// Azure reaches its containers through the blob. service endpoint, which the tool
-	// config holds without the blob. prefix (its own client prepends it), so the snapshot
-	// uri restores the full service host and leaves the account name to the extfs.
-	t.Run("AzureUsesAzureScheme", func(t *testing.T) {
-		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "core.windows.net:443"}
+	// Milvus's snapshot validator only accepts an Azure URI host as the
+	// account-qualified endpoint or the bare service endpoint, so the URI names
+	// <account>.blob.<service-endpoint>, with the default https port dropped to
+	// match the metadata URI Milvus reports back.
+	t.Run("AzureNamesTheAccountEndpoint", func(t *testing.T) {
+		cfg := Config{
+			Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "core.windows.net:443",
+			Credential: Credential{AzureAccountName: "azure-account"},
+		}
 		got, err := SnapshotURI(cfg, "backup/mybackup")
 		require.NoError(t, err)
-		assert.Equal(t, "azure://blob.core.windows.net:443/backup-bucket/backup/mybackup", got)
+		assert.Equal(t, "azure://azure-account.blob.core.windows.net/backup-bucket/backup/mybackup", got)
+	})
+
+	t.Run("AzureNeedsAnAccountName", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "core.windows.net:443"}
+		_, err := SnapshotURI(cfg, "backup/mybackup")
+		assert.ErrorContains(t, err, "account name")
+	})
+
+	// The Milvus-view override names the full host Milvus resolves, account
+	// prefix included, and is used verbatim.
+	t.Run("AzureMilvusEndpointOverridesTheEndpoint", func(t *testing.T) {
+		cfg := Config{
+			Provider: v2.ProviderAzure, Bucket: "backup-bucket", Endpoint: "core.windows.net:443",
+			Credential:     Credential{AzureAccountName: "azure-account"},
+			MilvusEndpoint: "other-account.blob.core.windows.net",
+		}
+		got, err := SnapshotURI(cfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "azure://other-account.blob.core.windows.net/backup-bucket/backup/mybackup", got)
 	})
 
 	t.Run("AzureNeedsAnEndpoint", func(t *testing.T) {
-		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket"}
+		cfg := Config{Provider: v2.ProviderAzure, Bucket: "backup-bucket",
+			Credential: Credential{AzureAccountName: "azure-account"}}
 		_, err := SnapshotURI(cfg, "backup/mybackup")
 		assert.ErrorContains(t, err, "endpoint")
 	})
@@ -153,16 +177,19 @@ func TestSnapshotStoreURI(t *testing.T) {
 		assert.Equal(t, "minio://other:9000/backup-bucket/backup/mybackup", got)
 	})
 
-	// Azure has no endpoint-less form, so the URI keeps the service endpoint even on
-	// the same backend.
+	// Azure has no endpoint-less form, so the URI keeps the account-qualified
+	// endpoint even on the same backend.
 	t.Run("AzureKeepsTheEndpoint", func(t *testing.T) {
-		milvusCfg := Config{Provider: v2.ProviderAzure, Endpoint: "core.windows.net", Bucket: "milvus-bucket"}
+		milvusCfg := Config{
+			Provider: v2.ProviderAzure, Endpoint: "core.windows.net", Bucket: "milvus-bucket",
+			Credential: Credential{AzureAccountName: "azure-account"},
+		}
 		backupCfg := milvusCfg
 		backupCfg.Bucket = "backup-bucket"
 
 		got, err := SnapshotStoreURI(milvusCfg, backupCfg, "backup/mybackup")
 		require.NoError(t, err)
-		assert.Equal(t, "azure://blob.core.windows.net/backup-bucket/backup/mybackup", got)
+		assert.Equal(t, "azure://azure-account.blob.core.windows.net/backup-bucket/backup/mybackup", got)
 	})
 
 	// Native GCS never carries an endpoint, so same-backend changes nothing.


### PR DESCRIPTION
## Summary

Fixes #1178

Snapshot-format backup on Azure failed Milvus's snapshot URI validation because milvus-backup built the URI host as `blob.<service-endpoint>` with no storage account name — a form the validator never accepts (it recognizes `<account>.blob.<suffix>`, the bare `<suffix>`, or an exact match with the instance's effective endpoint). The URI now names the account-qualified endpoint, matching the Milvus snapshot URI contract (`azure://<account-endpoint>/<container>/<key>`).

## Changes

- storage: build Azure snapshot URIs as `azure://<account>.blob.<service-endpoint>/<bucket>/<key>` from the configured account name, and fail fast when the account name is unset
- storage: drop the default `:443` port from the URI so it compares equal to the metadata URI Milvus reports back for the completed export
- storage: treat a `milvusAddress` override as the full host Milvus resolves (account prefix included), used verbatim
- test: cover the account-qualified form, the missing-account-name error, and the Milvus-view override

Note: with this fix, an Azure deployment whose backup container lives in a different storage account than the Milvus data (the uat3 topology in #1178) still fails at Milvus's resolver, which only supports same-account server-side copies on Azure. That is a Milvus-side limitation to track separately.
