### PR TITLE
storage: send source sas for cross-account azure snapshots

### DIFF
--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -205,7 +205,7 @@ func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 		return err
 	}
 
-	task, err := restore.NewTask(args)
+	task, err := restore.NewTask(cmd.Context(), args)
 	if err != nil {
 		return err
 	}

--- a/configs/backup-azure.yaml
+++ b/configs/backup-azure.yaml
@@ -23,6 +23,12 @@ milvus:
     # The Azure storage account, required by the azure provider. Prefer
     # MILVUS_STORAGE_ACCOUNT_NAME over writing it here.
     accountName: "<your-storage-account>"
+    # A read-scoped SAS for this account's container, for snapshot-format
+    # backups kept in a DIFFERENT storage account: Azure lets no single
+    # credential read across accounts, so Milvus copies under this token.
+    # Leave it out to have milvus-backup mint one from the account key for
+    # the duration of each task.
+    # sourceSASToken: "<your-source-sas>"
     # For azure the bucket is the blob container.
     bucketName: "milvus-data"
     rootPath: "milvus/azure-instance"

--- a/core/backup/snapshot_target.go
+++ b/core/backup/snapshot_target.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -25,14 +26,34 @@ type snapshotTarget struct {
 	// ExternalSpec carries the credentials for the target, and is empty when Milvus
 	// can reach it with its own.
 	ExternalSpec string
+
+	// SourceSASSet reports whether the spec carries a source SAS, for logging: the
+	// token itself is a secret and never appears there.
+	SourceSASSet bool
 }
 
-func newSnapshotTarget(milvusCfg, backupCfg storage.Config, backupDir string) (snapshotTarget, error) {
+func newSnapshotTarget(ctx context.Context, milvusCfg, backupCfg storage.Config, backupDir string) (snapshotTarget, error) {
 	uri, err := storage.SnapshotStoreURI(milvusCfg, backupCfg, mpath.BackupBundleDir(backupDir))
 	if err != nil {
 		return snapshotTarget{}, err
 	}
 	target := snapshotTarget{Path: uri, Dir: mpath.BundleDirName}
+
+	// The copy source is the Milvus instance bucket. On Azure it lives in the
+	// instance storage account, and no single principal can authorize reading a
+	// blob of another account, so a cross-account export needs a read-scoped SAS
+	// on the source — minted from (or provided with) the instance account.
+	if storage.CrossAccountAzure(milvusCfg, backupCfg) {
+		milvusCfg, err = storage.ResolveSourceSAS(ctx, milvusCfg)
+		if err != nil {
+			return snapshotTarget{}, fmt.Errorf("backup: source sas for the milvus storage: %w", err)
+		}
+		backupCfg.SourceSAS = milvusCfg.SourceSAS
+	} else if milvusCfg.SourceSAS != "" {
+		// A SAS anywhere else is a misconfiguration the server would reject, so
+		// fail here where the config key can be pointed at.
+		return snapshotTarget{}, fmt.Errorf("backup: a source sas token applies only to a snapshot copy that crosses azure storage accounts")
+	}
 
 	// With no spec Milvus writes with its own credential and lets bucket policy
 	// authorize the target, which is exactly the case when both sides are the same
@@ -46,6 +67,7 @@ func newSnapshotTarget(milvusCfg, backupCfg storage.Config, backupDir string) (s
 		return snapshotTarget{}, err
 	}
 	target.ExternalSpec = spec
+	target.SourceSASSet = backupCfg.SourceSAS != ""
 
 	return target, nil
 }

--- a/core/backup/snapshot_target_test.go
+++ b/core/backup/snapshot_target_test.go
@@ -1,6 +1,8 @@
 package backup
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +11,31 @@ import (
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 )
+
+// azureCfg builds an azure backend config for one storage account. The shared
+// key has to be a base64-decodable 256-bit value for the SDK to sign with it.
+func azureCfg(account, bucket string) storage.Config {
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	return storage.Config{
+		Provider:   v2.ProviderAzure,
+		Endpoint:   "core.windows.net:443",
+		Bucket:     bucket,
+		Credential: storage.Credential{Type: storage.Static, AK: account, SK: key, AzureAccountName: account},
+	}
+}
+
+// extfs decodes the extfs object out of an external spec json, so assertions
+// name fields instead of matching escaped json substrings.
+func extfs(t *testing.T, spec string) map[string]string {
+	t.Helper()
+
+	var parsed struct {
+		Extfs map[string]string `json:"extfs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(spec), &parsed))
+
+	return parsed.Extfs
+}
 
 func TestNewSnapshotTarget(t *testing.T) {
 	// Milvus falls back to its own credential when no spec is given, which is what to
@@ -23,7 +50,7 @@ func TestNewSnapshotTarget(t *testing.T) {
 		backupCfg := milvusCfg
 		backupCfg.Bucket = "backup-bucket"
 
-		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		target, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
 		require.NoError(t, err)
 		assert.Equal(t, "s3://backup-bucket/backup/mybackup/bundle", target.Path)
 		assert.Equal(t, "bundle", target.Dir)
@@ -40,7 +67,7 @@ func TestNewSnapshotTarget(t *testing.T) {
 		backupCfg.Bucket = "backup-bucket"
 		backupCfg.MilvusEndpoint = "milvus-minio:9000"
 
-		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		target, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
 		require.NoError(t, err)
 		assert.Equal(t, "minio://milvus-minio:9000/backup-bucket/backup/mybackup/bundle", target.Path)
 		assert.Empty(t, target.ExternalSpec)
@@ -53,10 +80,62 @@ func TestNewSnapshotTarget(t *testing.T) {
 			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
 		}
 
-		target, err := newSnapshotTarget(milvusCfg, backupCfg, "backup/mybackup")
+		target, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
 		require.NoError(t, err)
 		assert.Equal(t, "s3://backup-bucket/backup/mybackup/bundle", target.Path)
 		assert.Contains(t, target.ExternalSpec, `"access_key_id":"ak"`)
+	})
+
+	// An export whose backup container lives in another storage account reads
+	// the instance blobs under a SAS minted from the instance account's key —
+	// Milvus cannot read them with the backup credentials it is handed.
+	t.Run("CrossAccountAzureMintsASourceSAS", func(t *testing.T) {
+		milvusCfg := azureCfg("milvus-account", "milvus-bucket")
+		backupCfg := azureCfg("backup-account", "backup-bucket")
+
+		target, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "azure://backup-account.blob.core.windows.net/backup-bucket/backup/mybackup/bundle", target.Path)
+
+		spec := extfs(t, target.ExternalSpec)
+		assert.Equal(t, "backup-account", spec["access_key_id"])
+		assert.NotEmpty(t, spec["source_sas_token"])
+		assert.True(t, target.SourceSASSet)
+	})
+
+	// The explicit token stands in for a minted one, trimmed to the bare query
+	// the extfs field expects.
+	t.Run("CrossAccountAzureUsesTheExplicitSAS", func(t *testing.T) {
+		milvusCfg := azureCfg("milvus-account", "milvus-bucket")
+		milvusCfg.SourceSAS = "?sv=2024-08-04&sig=abc"
+		backupCfg := azureCfg("backup-account", "backup-bucket")
+
+		target, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
+		require.NoError(t, err)
+		assert.Equal(t, "sv=2024-08-04&sig=abc", extfs(t, target.ExternalSpec)["source_sas_token"])
+	})
+
+	// A SAS on a copy that stays within one account is a misconfiguration the
+	// server rejects, so it fails here with the config named.
+	t.Run("SameAccountWithSASFails", func(t *testing.T) {
+		milvusCfg := azureCfg("account", "milvus-bucket")
+		milvusCfg.SourceSAS = "sv=2024-08-04&sig=abc"
+		backupCfg := azureCfg("account", "backup-bucket")
+
+		_, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
+		assert.ErrorContains(t, err, "crosses azure storage accounts")
+	})
+
+	t.Run("NonAzureBackupWithSASFails", func(t *testing.T) {
+		milvusCfg := azureCfg("milvus-account", "milvus-bucket")
+		milvusCfg.SourceSAS = "sv=2024-08-04&sig=abc"
+		backupCfg := storage.Config{
+			Provider: v2.ProviderS3, Region: "us-west-2", Bucket: "backup-bucket",
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+
+		_, err := newSnapshotTarget(t.Context(), milvusCfg, backupCfg, "backup/mybackup")
+		assert.ErrorContains(t, err, "crosses azure storage accounts")
 	})
 }
 

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -252,14 +252,15 @@ func (t *Task) privateExecute(ctx context.Context) error {
 	}
 
 	if t.resolvedFormat == meta.FormatSnapshot {
-		target, err := newSnapshotTarget(t.milvusStorage.Config(), t.backupStorage.Config(), t.backupDir)
+		target, err := newSnapshotTarget(ctx, t.milvusStorage.Config(), t.backupStorage.Config(), t.backupDir)
 		if err != nil {
 			return fmt.Errorf("backup: build snapshot target: %w", err)
 		}
 		t.snapshotTarget = target
 		t.logger.Info("use snapshot format",
 			zap.String("target_path", target.Path),
-			zap.Bool("external_spec_set", target.ExternalSpec != ""))
+			zap.Bool("external_spec_set", target.ExternalSpec != ""),
+			zap.Bool("source_sas_set", target.SourceSASSet))
 	}
 
 	dbNames, collections, err := t.listDBAndNSS(ctx)

--- a/core/restore/snapshot_source.go
+++ b/core/restore/snapshot_source.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -17,14 +18,33 @@ type snapshotSource struct {
 	// externalSpec carries the credentials for the source, and is empty when Milvus can
 	// reach it with its own.
 	externalSpec string
+
+	// sourceSASSet reports whether the spec carries a source SAS, for logging: the
+	// token itself is a secret and never appears there.
+	sourceSASSet bool
 }
 
-func newSnapshotSource(milvusCfg, backupCfg storage.Config, backupDir string) (snapshotSource, error) {
+func newSnapshotSource(ctx context.Context, milvusCfg, backupCfg storage.Config, backupDir string) (snapshotSource, error) {
 	uri, err := storage.SnapshotStoreURI(milvusCfg, backupCfg, backupDir)
 	if err != nil {
 		return snapshotSource{}, err
 	}
 	source := snapshotSource{dirURI: uri}
+
+	// The copy source is the backup bucket. On Azure it lives in the backup
+	// storage account, and no single principal can authorize reading a blob of
+	// another account, so a cross-account restore needs a read-scoped SAS on the
+	// source — minted from (or provided with) the backup account.
+	if storage.CrossAccountAzure(backupCfg, milvusCfg) {
+		backupCfg, err = storage.ResolveSourceSAS(ctx, backupCfg)
+		if err != nil {
+			return snapshotSource{}, fmt.Errorf("restore: source sas for the backup storage: %w", err)
+		}
+	} else if backupCfg.SourceSAS != "" {
+		// A SAS anywhere else is a misconfiguration the server would reject, so
+		// fail here where the config key can be pointed at.
+		return snapshotSource{}, fmt.Errorf("restore: a source sas token applies only to a snapshot copy that crosses azure storage accounts")
+	}
 
 	// With no spec Milvus reads with its own credential, which is what to rely on when both
 	// sides are the same backend — it keeps the access key off the wire.
@@ -37,6 +57,7 @@ func newSnapshotSource(milvusCfg, backupCfg storage.Config, backupDir string) (s
 		return snapshotSource{}, err
 	}
 	source.externalSpec = spec
+	source.sourceSASSet = backupCfg.SourceSAS != ""
 
 	return source, nil
 }

--- a/core/restore/snapshot_source_test.go
+++ b/core/restore/snapshot_source_test.go
@@ -1,6 +1,8 @@
 package restore
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +11,31 @@ import (
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 )
+
+// azureCfg builds an azure backend config for one storage account. The shared
+// key has to be a base64-decodable 256-bit value for the SDK to sign with it.
+func azureCfg(account, bucket string) storage.Config {
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	return storage.Config{
+		Provider:   v2.ProviderAzure,
+		Endpoint:   "core.windows.net:443",
+		Bucket:     bucket,
+		Credential: storage.Credential{Type: storage.Static, AK: account, SK: key, AzureAccountName: account},
+	}
+}
+
+// extfs decodes the extfs object out of an external spec json, so assertions
+// name fields instead of matching escaped json substrings.
+func extfs(t *testing.T, spec string) map[string]string {
+	t.Helper()
+
+	var parsed struct {
+		Extfs map[string]string `json:"extfs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(spec), &parsed))
+
+	return parsed.Extfs
+}
 
 func TestNewSnapshotSource(t *testing.T) {
 	// Milvus falls back to its own credential when no spec is given, which is what to rely
@@ -23,7 +50,7 @@ func TestNewSnapshotSource(t *testing.T) {
 		backupCfg := milvusCfg
 		backupCfg.Bucket = "backup-bucket"
 
-		source, err := newSnapshotSource(milvusCfg, backupCfg, "backup/mybackup/")
+		source, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
 		require.NoError(t, err)
 		assert.Equal(t, "s3://backup-bucket/backup/mybackup", source.dirURI)
 		assert.Empty(t, source.externalSpec)
@@ -36,10 +63,62 @@ func TestNewSnapshotSource(t *testing.T) {
 			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
 		}
 
-		source, err := newSnapshotSource(milvusCfg, backupCfg, "backup/mybackup/")
+		source, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
 		require.NoError(t, err)
 		assert.Equal(t, "s3://backup-bucket/backup/mybackup", source.dirURI)
 		assert.Contains(t, source.externalSpec, `"access_key_id":"ak"`)
+	})
+
+	// A restore whose backup container lives in another storage account reads
+	// the bundle blobs under a SAS minted from the backup account's key —
+	// Milvus cannot read them with the backup credentials it is handed.
+	t.Run("CrossAccountAzureMintsASourceSAS", func(t *testing.T) {
+		milvusCfg := azureCfg("milvus-account", "milvus-bucket")
+		backupCfg := azureCfg("backup-account", "backup-bucket")
+
+		source, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
+		require.NoError(t, err)
+		assert.Equal(t, "azure://backup-account.blob.core.windows.net/backup-bucket/backup/mybackup", source.dirURI)
+
+		spec := extfs(t, source.externalSpec)
+		assert.Equal(t, "backup-account", spec["access_key_id"])
+		assert.NotEmpty(t, spec["source_sas_token"])
+		assert.True(t, source.sourceSASSet)
+	})
+
+	// The explicit token stands in for a minted one, trimmed to the bare query
+	// the extfs field expects.
+	t.Run("CrossAccountAzureUsesTheExplicitSAS", func(t *testing.T) {
+		milvusCfg := azureCfg("milvus-account", "milvus-bucket")
+		backupCfg := azureCfg("backup-account", "backup-bucket")
+		backupCfg.SourceSAS = "?sv=2024-08-04&sig=abc"
+
+		source, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
+		require.NoError(t, err)
+		assert.Equal(t, "sv=2024-08-04&sig=abc", extfs(t, source.externalSpec)["source_sas_token"])
+	})
+
+	// A SAS on a copy that stays within one account is a misconfiguration the
+	// server rejects, so it fails here with the config named.
+	t.Run("SameAccountWithSASFails", func(t *testing.T) {
+		milvusCfg := azureCfg("account", "milvus-bucket")
+		backupCfg := azureCfg("account", "backup-bucket")
+		backupCfg.SourceSAS = "sv=2024-08-04&sig=abc"
+
+		_, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
+		assert.ErrorContains(t, err, "crosses azure storage accounts")
+	})
+
+	t.Run("NonAzureMilvusWithSASFails", func(t *testing.T) {
+		milvusCfg := storage.Config{
+			Provider: v2.ProviderMinio, Endpoint: "minio:9000", Bucket: "milvus-bucket",
+			Credential: storage.Credential{Type: storage.Static, AK: "ak", SK: "sk"},
+		}
+		backupCfg := azureCfg("backup-account", "backup-bucket")
+		backupCfg.SourceSAS = "sv=2024-08-04&sig=abc"
+
+		_, err := newSnapshotSource(t.Context(), milvusCfg, backupCfg, "backup/mybackup/")
+		assert.ErrorContains(t, err, "crosses azure storage accounts")
 	})
 }
 

--- a/core/restore/task.go
+++ b/core/restore/task.go
@@ -171,7 +171,7 @@ type Task struct {
 	logger *zap.Logger
 }
 
-func NewTask(args TaskArgs) (*Task, error) {
+func NewTask(ctx context.Context, args TaskArgs) (*Task, error) {
 	// Without this an unknown format would go down the binlog path, find no segments, and
 	// report a successful restore of an empty collection.
 	format := args.Backup.GetFormat()
@@ -202,14 +202,15 @@ func NewTask(args TaskArgs) (*Task, error) {
 				zap.Strings("options", ignored))
 		}
 
-		source, err := newSnapshotSource(args.MilvusStorage.Config(), args.BackupStorage.Config(), args.BackupDir)
+		source, err := newSnapshotSource(ctx, args.MilvusStorage.Config(), args.BackupStorage.Config(), args.BackupDir)
 		if err != nil {
 			return nil, err
 		}
 		task.snapshotSource = source
 		logger.Info("restore from snapshot bundles",
 			zap.String("source_uri", source.dirURI),
-			zap.Bool("external_spec_set", source.externalSpec != ""))
+			zap.Bool("external_spec_set", source.externalSpec != ""),
+			zap.Bool("source_sas_set", source.sourceSASSet))
 	} else {
 		task.streaming = storage.UseStreaming(args.Params.Transfer.Mode.Val,
 			args.BackupStorage.Config(), args.MilvusStorage.Config())

--- a/core/restore/task_test.go
+++ b/core/restore/task_test.go
@@ -40,7 +40,7 @@ func TestNewTask_RefusesUnknownFormat(t *testing.T) {
 		Backup: &backuppb.BackupInfo{Name: "mybackup", Format: "parquet"},
 	}
 
-	task, err := NewTask(args)
+	task, err := NewTask(t.Context(), args)
 	assert.ErrorContains(t, err, "parquet")
 	assert.Nil(t, task)
 }
@@ -69,7 +69,7 @@ func TestNewTask_SnapshotSource(t *testing.T) {
 		TaskMgr:       taskmgr.NewMgr(),
 	}
 
-	task, err := NewTask(args)
+	task, err := NewTask(t.Context(), args)
 	require.NoError(t, err)
 	assert.Equal(t, meta.FormatSnapshot, task.format)
 	// Both sides are the same backend, so the uri names only the bucket and Milvus

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -188,7 +188,7 @@ func (h *restoreHandler) newTask(ctx context.Context, backupDir string) (*restor
 
 		TaskMgr: taskmgr.DefaultMgr(),
 	}
-	task, err := restore.NewTask(args)
+	task, err := restore.NewTask(ctx, args)
 	if err != nil {
 		return nil, fmt.Errorf("backup: new restore task: %w", err)
 	}

--- a/internal/cfg/v2/render.go
+++ b/internal/cfg/v2/render.go
@@ -92,6 +92,10 @@ func (c *StorageConfig) inapplicableKeys() []string {
 	if c.Provider.Val != ProviderAzure {
 		skip = append(skip, c.AccountName.Keys...)
 	}
+	// sourceSASToken is the Azure-only cross-account copy grant.
+	if c.Provider.Val != ProviderAzure {
+		skip = append(skip, c.SourceSASToken.Keys...)
+	}
 	// localPath belongs to local storage and nothing else.
 	if c.Provider.Val != ProviderLocal {
 		skip = append(skip, c.LocalPath.Keys...)

--- a/internal/cfg/v2/render_test.go
+++ b/internal/cfg/v2/render_test.go
@@ -85,3 +85,17 @@ func TestRender_EtcdList(t *testing.T) {
 	assert.Contains(t, string(data), "- etcd-0:2379")
 	assert.Contains(t, string(data), "- etcd-1:2379")
 }
+
+// Azure-only identity keys stay out of a non-azure section: emitting them,
+// even empty, would fail validation on reload since a key present in a file
+// resolves as explicitly set.
+func TestRender_SkipsAzureOnlyKeys(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	data, err := Render(c, nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "accountName")
+	assert.NotContains(t, string(data), "sourceSASToken")
+}

--- a/internal/cfg/v2/storage.go
+++ b/internal/cfg/v2/storage.go
@@ -40,6 +40,16 @@ type StorageConfig struct {
 	// provider.
 	AccountName param.Value[string]
 
+	// SourceSASToken is a read-scoped SAS for this account's container, handed
+	// to Milvus as extfs.source_sas_token when a snapshot-format copy reads
+	// across Azure storage accounts: no single credential can authorize reading
+	// another account's blobs, so the source read needs one. It applies to the
+	// side the copy reads from — the milvus storage for a backup, the backup
+	// storage for a restore — and is independent of the auth type. Empty means
+	// milvus-backup mints one from this account's own credential for the
+	// duration of the task.
+	SourceSASToken param.Value[string]
+
 	// BucketName is the bucket data lives in, or the container for Azure.
 	BucketName param.Value[string]
 	RootPath   param.Value[string]
@@ -83,6 +93,8 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 		// account key belongs to, and deployments hand out the two together.
 		AccountName: param.Value[string]{Default: "", Keys: key("accountName"), EnvKeys: env("ACCOUNT_NAME")},
 
+		SourceSASToken: param.Value[string]{Default: "", Keys: key("sourceSASToken"), EnvKeys: env("SOURCE_SAS_TOKEN"), Opts: param.SecretValue},
+
 		BucketName: param.Value[string]{Default: "a-bucket", Keys: key("bucketName")},
 		RootPath:   param.Value[string]{Default: "files", Keys: key("rootPath")},
 		LocalPath:  param.Value[string]{Default: "", Keys: key("localPath")},
@@ -111,6 +123,9 @@ func newStorageConfig(keyPrefix, envPrefix string) StorageConfig {
 // deliberately left alone: backup data does not belong under the Milvus root
 // path. The Milvus-view endpoint override is left alone too: it describes how
 // one specific Milvus reaches the store, which says nothing about another.
+// SourceSASToken is left alone as well: it grants reads of one account's
+// container, so inheriting it into a section that names another account would
+// hand Milvus a token for the wrong one.
 func (c *StorageConfig) inherit(other *StorageConfig) {
 	c.Provider.Default = other.Provider.Val
 
@@ -135,7 +150,7 @@ func (c *StorageConfig) Resolve(s *param.Source) error {
 	return param.Resolve(s,
 		&c.Provider,
 		&c.Address, &c.Port, &c.Region, &c.UseSSL,
-		&c.AccountName, &c.BucketName, &c.RootPath, &c.LocalPath,
+		&c.AccountName, &c.SourceSASToken, &c.BucketName, &c.RootPath, &c.LocalPath,
 		&c.MilvusAddress, &c.MilvusPort,
 		&c.Auth.Type,
 		&c.Auth.AccessKeyID, &c.Auth.SecretAccessKey, &c.Auth.SessionToken,

--- a/internal/cfg/v2/validate.go
+++ b/internal/cfg/v2/validate.go
@@ -143,6 +143,11 @@ func (c *StorageConfig) validate() error {
 			keyOf(&c.AccountName), keyOf(&c.Provider), provider))
 	}
 
+	if provider != ProviderAzure && !c.SourceSASToken.IsDefault() {
+		errs = append(errs, fmt.Errorf("cfg: %s only applies to the azure provider, but %s is %q",
+			keyOf(&c.SourceSASToken), keyOf(&c.Provider), provider))
+	}
+
 	// localPath names the directory Milvus resolves against, which only exists
 	// for local storage; anywhere else it is a mistake, not a hint.
 	if !c.LocalPath.IsDefault() {

--- a/internal/cfg/v2/validate_test.go
+++ b/internal/cfg/v2/validate_test.go
@@ -29,6 +29,11 @@ func TestValidate_Storage(t *testing.T) {
 			wantErr: "milvus.storage.accountName only applies to the azure provider",
 		},
 		{
+			name:    "SourceSASTokenOnlyAppliesToAzure",
+			yaml:    "milvus:\n  storage:\n    provider: s3\n    sourceSASToken: sv=2024-08-04\n",
+			wantErr: "milvus.storage.sourceSASToken only applies to the azure provider",
+		},
+		{
 			name:    "LocalPathOnlyAppliesToLocal",
 			yaml:    "milvus:\n  storage:\n    provider: s3\n    localPath: /data\n",
 			wantErr: "milvus.storage.localPath only applies to the local provider",

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -55,6 +55,15 @@ type Config struct {
 
 	Bucket string
 
+	// SourceSAS is a read-scoped SAS that authorizes reading the copy source
+	// when a snapshot-format copy crosses Azure storage accounts: no single
+	// credential can read another account's blobs, so the destination-side
+	// Credential never covers the source side. It is set from the source
+	// account's own config (its explicit token, or one minted from its
+	// credential) and rendered into the extfs handed to Milvus alongside the
+	// destination credentials.
+	SourceSAS string
+
 	// MultipartCopyThresholdMiB is the file size threshold above which multipart copy is used.
 	// Default is 500 MiB if not set. GCP does not support multipart copy.
 	MultipartCopyThresholdMiB int64

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -63,6 +63,7 @@ func storageConfig(s *v2.StorageConfig, multipartCopyThresholdMiB int64) Config 
 		MilvusEndpoint:            milvusEndpoint(s),
 		Credential:                newCredential(s),
 		Bucket:                    s.BucketName.Val,
+		SourceSAS:                 s.SourceSASToken.Val,
 		MultipartCopyThresholdMiB: multipartCopyThresholdMiB,
 	}
 }

--- a/internal/storage/sas.go
+++ b/internal/storage/sas.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+// _sourceSASTTL is how long a minted source SAS stays valid. Milvus keeps the
+// spec holding it until the export or restore job goes terminal, so the token
+// has to outlive the whole copy window — the same budget the streamed-copy SAS
+// in azure.go works with.
+const _sourceSASTTL = 48 * time.Hour
+
+// CrossAccountAzure reports whether a snapshot-format copy from src to dest
+// reads an Azure blob that lives in another storage account. The accounts are
+// compared, not the endpoints: the same account reached through two endpoints
+// (a private link and the public one) is still one account, whose reads need no
+// SAS — Milvus rejects a SAS there as an input error.
+func CrossAccountAzure(src, dest Config) bool {
+	return src.Provider == v2.ProviderAzure && dest.Provider == v2.ProviderAzure &&
+		src.Credential.AzureAccountName != dest.Credential.AzureAccountName
+}
+
+// ResolveSourceSAS fills cfg.SourceSAS for a cross-account Azure copy reading
+// from cfg's account: the operator-provided token when there is one, else one
+// minted from cfg's own credential. Minting happens once per task, and the
+// token only ever leaves inside the extfs handed to Milvus.
+func ResolveSourceSAS(ctx context.Context, cfg Config) (Config, error) {
+	if cfg.SourceSAS != "" {
+		cfg.SourceSAS = strings.TrimPrefix(strings.TrimSpace(cfg.SourceSAS), "?")
+		return cfg, nil
+	}
+
+	token, err := mintSourceSAS(ctx, cfg)
+	if err != nil {
+		return cfg, fmt.Errorf("storage: mint source sas for %s: %w", cfg.Credential.AzureAccountName, err)
+	}
+	cfg.SourceSAS = token
+
+	return cfg, nil
+}
+
+// mintSourceSAS signs a container-scoped read SAS for cfg's bucket. A shared
+// key signs a service SAS locally; IAM has to go through a user delegation key,
+// which needs Entra credentials and one network call. The granted permissions
+// are what a copy source is read with: list and read the one container, nothing
+// else.
+func mintSourceSAS(ctx context.Context, cfg Config) (string, error) {
+	// Shared-key signing is a local HMAC, so the start time absorbs clock skew
+	// the same way the user-delegation path in azure.go does.
+	now := time.Now().Add(-10 * time.Second)
+	expiry := now.Add(_sourceSASTTL)
+	values := sas.BlobSignatureValues{
+		Protocol:      sas.ProtocolHTTPS,
+		StartTime:     now,
+		ExpiryTime:    expiry,
+		Permissions:   to.Ptr(sas.ContainerPermissions{Read: true, List: true}).String(),
+		ContainerName: cfg.Bucket,
+	}
+
+	switch cfg.Credential.Type {
+	case Static:
+		cred, err := azblob.NewSharedKeyCredential(cfg.Credential.AK, cfg.Credential.SK)
+		if err != nil {
+			return "", fmt.Errorf("storage: new azure shared key credential: %w", err)
+		}
+		queryParams, err := values.SignWithSharedKey(cred)
+		if err != nil {
+			return "", fmt.Errorf("storage: sign source sas: %w", err)
+		}
+		return queryParams.Encode(), nil
+	case IAM:
+		// A user delegation SAS is the only kind an IAM identity can mint; it
+		// asks the service for a delegation key first, which is the one call
+		// that needs the context.
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return "", fmt.Errorf("storage: new default azure credential: %w", err)
+		}
+		endpoint := strings.TrimSuffix(cfg.Endpoint, ":443")
+		svc, err := service.NewClient(
+			fmt.Sprintf("https://%s.blob.%s", cfg.Credential.AzureAccountName, endpoint), cred, nil)
+		if err != nil {
+			return "", fmt.Errorf("storage: new azure service client: %w", err)
+		}
+
+		info := service.KeyInfo{
+			Start:  to.Ptr(now.Format(sas.TimeFormat)),
+			Expiry: to.Ptr(expiry.Format(sas.TimeFormat)),
+		}
+		udc, err := svc.GetUserDelegationCredential(ctx, info, nil)
+		if err != nil {
+			return "", fmt.Errorf("storage: get user delegation credential: %w", err)
+		}
+
+		queryParams, err := values.SignWithUserDelegation(udc)
+		if err != nil {
+			return "", fmt.Errorf("storage: sign source sas: %w", err)
+		}
+		return queryParams.Encode(), nil
+	default:
+		return "", fmt.Errorf("storage: minting a source sas needs a shared key or iam credential, not %s", cfg.Credential.Type)
+	}
+}

--- a/internal/storage/sas_test.go
+++ b/internal/storage/sas_test.go
@@ -1,0 +1,125 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+)
+
+// azureSharedKey builds the key pair a shared-key SAS is signed with: the SDK
+// requires a base64-decodable 256-bit key, which no printable string is.
+func azureSharedKey() string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte("k"), 32))
+}
+
+func TestCrossAccountAzure(t *testing.T) {
+	azure := func(account string) Config {
+		return Config{
+			Provider:   v2.ProviderAzure,
+			Endpoint:   "core.windows.net:443",
+			Bucket:     "bucket",
+			Credential: Credential{Type: Static, AK: account, SK: azureSharedKey(), AzureAccountName: account},
+		}
+	}
+
+	tests := []struct {
+		name string
+		src  Config
+		dest Config
+		want bool
+	}{
+		{"TwoAccounts", azure("milvus-account"), azure("backup-account"), true},
+		{"OneAccount", azure("account"), azure("account"), false},
+		// The same account behind two endpoints is still one account: its
+		// reads need no SAS, and Milvus rejects one there as an input error.
+		{
+			"OneAccountTwoEndpoints", azure("account"), func() Config {
+				c := azure("account")
+				c.Endpoint = "privatelink.blob.core.windows.net:443"
+				return c
+			}(), false,
+		},
+		{"AzureToS3", azure("account"), Config{Provider: v2.ProviderS3}, false},
+		{"S3ToAzure", Config{Provider: v2.ProviderS3}, azure("account"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CrossAccountAzure(tt.src, tt.dest))
+		})
+	}
+}
+
+func TestResolveSourceSAS(t *testing.T) {
+	// An operator-provided token is passed through as the escape hatch for
+	// accounts whose key milvus-backup cannot sign with — trimmed to the bare
+	// query, which is the shape the extfs field and Milvus both expect.
+	t.Run("UsesTheExplicitToken", func(t *testing.T) {
+		cfg := Config{Provider: v2.ProviderAzure, SourceSAS: "?sv=2024-08-04&sig=abc"}
+
+		got, err := ResolveSourceSAS(t.Context(), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "sv=2024-08-04&sig=abc", got.SourceSAS)
+	})
+
+	// A shared key signs a container-scoped service SAS locally: the token is a
+	// query naming the container, the read permission, and a signature.
+	t.Run("MintsAServiceSASFromTheSharedKey", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAzure,
+			Endpoint:   "core.windows.net:443",
+			Bucket:     "milvus-bucket",
+			Credential: Credential{Type: Static, AK: "milvusaccount", SK: azureSharedKey(), AzureAccountName: "milvusaccount"},
+		}
+
+		got, err := ResolveSourceSAS(t.Context(), cfg)
+		require.NoError(t, err)
+
+		query, err := url.ParseQuery(got.SourceSAS)
+		require.NoError(t, err)
+		assert.Equal(t, "c", query.Get("sr"))
+		assert.Contains(t, query.Get("sp"), "r")
+		assert.NotEmpty(t, query.Get("sig"))
+		expiry, err := time.Parse(sas.TimeFormat, query.Get("se"))
+		require.NoError(t, err)
+		assert.True(t, expiry.After(time.Now()))
+	})
+
+	// A credential that can neither sign nor delegate leaves nothing to mint
+	// with, which is a configuration problem rather than a fallback case.
+	t.Run("MintNeedsSharedKeyOrIAM", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAzure,
+			Credential: Credential{Type: MinioCredProvider, AzureAccountName: "milvusaccount"},
+		}
+
+		_, err := ResolveSourceSAS(t.Context(), cfg)
+		assert.ErrorContains(t, err, "shared key or iam")
+	})
+
+	// The user-delegation path needs the service, so a canceled context fails
+	// it rather than minting forever.
+	t.Run("UserDelegationHonorsTheContext", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAzure,
+			Endpoint:   "core.windows.net:443",
+			Bucket:     "milvus-bucket",
+			Credential: Credential{Type: IAM, AzureAccountName: "milvusaccount"},
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err := ResolveSourceSAS(ctx, cfg)
+		assert.Error(t, err)
+	})
+}

--- a/internal/storage/snapshot.go
+++ b/internal/storage/snapshot.go
@@ -164,6 +164,17 @@ func SnapshotExternalSpec(cfg Config) (string, error) {
 		return "", fmt.Errorf("storage: snapshot external spec cannot carry %s credentials", cfg.Credential.Type)
 	}
 
+	// A cross-account Azure copy reads its source under this SAS: neither the
+	// destination credential above nor the destination account's own identity
+	// can authorize reading another account's blobs, so the source read rides
+	// on the token instead. Azure is the only provider with such a grant.
+	if cfg.SourceSAS != "" {
+		if cfg.Provider != v2.ProviderAzure {
+			return "", fmt.Errorf("storage: snapshot external spec cannot carry a source sas for %s storage", cfg.Provider)
+		}
+		extfs["source_sas_token"] = cfg.SourceSAS
+	}
+
 	byts, err := json.Marshal(map[string]any{"extfs": extfs})
 	if err != nil {
 		return "", fmt.Errorf("storage: marshal snapshot external spec: %w", err)

--- a/internal/storage/snapshot_test.go
+++ b/internal/storage/snapshot_test.go
@@ -287,4 +287,31 @@ func TestSnapshotExternalSpec(t *testing.T) {
 		_, err := SnapshotExternalSpec(cfg)
 		assert.Error(t, err)
 	})
+
+	// The SAS rides next to the destination credentials: it authorizes the
+	// source read of a cross-account Azure copy, which those credentials cannot.
+	t.Run("AzureCarriesTheSourceSAS", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAzure,
+			SourceSAS:  "sv=2024-08-04&sig=abc",
+			Credential: Credential{Type: Static, AK: "backup-account", SK: "backup-key"},
+		}
+
+		spec, err := SnapshotExternalSpec(cfg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc","use_ssl":"false"}}`, spec)
+	})
+
+	// No other provider has a source-read grant, so a SAS anywhere else is a
+	// misconfiguration rather than an ignored field.
+	t.Run("RejectsSourceSASOutsideAzure", func(t *testing.T) {
+		cfg := Config{
+			Provider:   v2.ProviderAWS,
+			SourceSAS:  "sv=2024-08-04&sig=abc",
+			Credential: Credential{Type: Static, AK: "ak", SK: "sk"},
+		}
+
+		_, err := SnapshotExternalSpec(cfg)
+		assert.ErrorContains(t, err, "source sas")
+	})
 }


### PR DESCRIPTION
Fixes #1180

## What

Snapshot-format backup and restore now work when the Milvus instance bucket
and the backup container live in **different Azure storage accounts**: the
extfs handed to Milvus carries `source_sas_token`, the read-scoped SAS that
authorizes the source side of the copy (milvus-io/milvus#52770 contract).

- **Backup** (`core/backup/snapshot_target.go`): the copy source is the
  instance bucket, so the SAS is resolved from the milvus storage side.
- **Restore** (`core/restore/snapshot_source.go`): the copy source is the
  backup bucket, so the SAS is resolved from the backup storage side.
- **Minting** (`internal/storage/sas.go`): an explicit token wins; otherwise a
  container-scoped Read+List SAS is minted per task — signed locally with the
  shared key, or via a user delegation key for IAM credentials — valid for 48h,
  the same budget the streamed-copy SAS uses, since Milvus keeps the spec until
  the job goes terminal.
- **Config**: `milvus.storage.sourceSASToken` / `backup.storage.sourceSASToken`
  (secret, azure-only, env `*_STORAGE_SOURCE_SAS_TOKEN`). The field does not
  inherit across sections: a SAS is scoped to one account.

## Fail-closed rules

`CrossAccountAzure` compares storage **accounts**, not endpoints — the same
account behind a private link is not a crossing. A SAS is attached only for
azure→azure cross-account snapshot copies; a token configured for anything else
(same account, non-azure end, binlog topology) is rejected at task construction
with the rule named, matching the server's own input validation.

## No capability gating

Per the decision recorded on the issue, sending the SAS is **not** gated on
server feature detection: the field rides the snapshot feature itself, and a
server that supports snapshots but rejects the unknown extfs key fails the task
outright with that error. milvus-io/milvus#52770 landing in a release we target
remains the prerequisite for the copy to succeed.

## Tests

Unit tests cover the mint shapes (explicit passthrough incl. `?` trimming,
shared-key service SAS query fields, IAM needs shared key or delegation),
`CrossAccountAzure` (incl. same-account-two-endpoints), the extfs rendering and
its non-azure rejection, the backup/restore constructors (mint, explicit,
same-account and non-azure fail-closed), plus config validation and render
skipping. `go test ./...` and `golangci-lint` are clean.
