### PR TITLE
docs: document restore privilege requirements for non-root users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cp configs/backup.yaml backup.yaml
 
 The main sections are:
 
-- `milvus`: how to reach Milvus — credentials, the gRPC endpoint and its TLS settings — and under `milvus.storage`, the storage the deployment keeps its data in. The `milvus.etcd` settings are only required when using `--backup_index_extra`.
+- `milvus`: how to reach Milvus — credentials, the gRPC endpoint and its TLS settings — and under `milvus.storage`, the storage the deployment keeps its data in. The `milvus.etcd` settings are only required when using `--backup_index_extra`. When connecting as a user other than `root`, see [Required Milvus privileges](docs/user_guide/privileges.md).
 - `backup`: where backup data is written, under `backup.storage`, and how much of the backup runs in parallel.
 - `restore`: restore concurrency and temporary file handling.
 - `transfer`: how objects move between the two storage backends.

--- a/docs/user_guide/privileges.md
+++ b/docs/user_guide/privileges.md
@@ -1,0 +1,39 @@
+# Required Milvus privileges
+
+Milvus Backup connects to Milvus as the user configured under `milvus.user` /
+`milvus.password` (default `root`). Which privileges that user needs depends on
+the deployment.
+
+## Default deployments
+
+With the default configuration nothing needs to be granted: milvus-backup
+connects as `root`, and Milvus skips privilege checks for `root` while
+`common.security.rootShouldBindRole` is `false` (the Milvus default).
+
+## Restoring as a non-root user
+
+Restore writes data through Milvus bulk import in binlog mode (`backup=true`,
+or `l0_import=true` for L0 segments). Starting with Milvus versions that
+include [milvus-io/milvus#51894](https://github.com/milvus-io/milvus/pull/51894)
+(unreleased at the time of writing), these imports require the cluster-level
+`ImportBinlog` privilege on top of the collection-level `Import` privilege.
+
+This affects deployments that run milvus-backup as a user other than `root`,
+or that set `common.security.rootShouldBindRole=true`. Without the grant,
+restore fails with a `PrivilegeNotPermitted` error naming `ImportBinlog`.
+
+Grant the privilege to a role of the connecting user. The grant must be
+cluster-scoped — both the database name and the collection name must be `*`.
+Milvus accepts a narrower scope without an error, but the grant then never
+matches and restore keeps failing:
+
+```go
+// milvus Go client
+client.OperatePrivilegeV2(ctx,
+    milvusclient.NewGrantPrivilegeV2Option(roleName, "ImportBinlog", "*").WithDbName("*"))
+```
+
+Roles carrying the built-in `admin` or `ClusterAdmin` privilege group already
+include `ImportBinlog` and need no extra grant.
+
+Backup (`create`) is unaffected: the privilege only guards import.


### PR DESCRIPTION
issue: #1183

Milvus is adding a cluster-level `ImportBinlog` privilege gate on binlog / L0
bulk import (milvus-io/milvus#51894, not yet merged). Every restore bulk insert
runs in one of those modes (`backup=true` or `l0_import=true`), so once a
deployment upgrades to a Milvus version containing that change, restore as a
non-root user — or as any user when `common.security.rootShouldBindRole=true` —
starts failing with `PrivilegeNotPermitted`, with no change on the
milvus-backup side.

This adds `docs/user_guide/privileges.md` stating:

- default `root` deployments need no action (root bypasses privilege checks
  while `rootShouldBindRole=false`, the Milvus default);
- restore needs the cluster-level `ImportBinlog` privilege on affected Milvus
  versions, on top of collection-level `Import`;
- the grant must be cluster-scoped (`db_name="*"`, `collection_name="*"`) —
  Milvus accepts a narrower scope without an error, but it never matches;
- built-in `admin` / `ClusterAdmin` roles already include the privilege;
- backup (`create`) is unaffected.

README links the page from the `milvus` configuration bullet. No code change.
The upstream PR is unreleased at the time of writing; the doc links it and can
be updated with the concrete version once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF86zcSRAaGVeZLT94UQgX