### PR TITLE
restore secondary: refuse early when the backup lacks its full meta

### DIFF
--- a/core/restore/secondary/database_task.go
+++ b/core/restore/secondary/database_task.go
@@ -66,7 +66,7 @@ func (dbt *databaseTask) Execute(ctx context.Context) error {
 		return broadcast.SplitIntoMutableMessage()
 	})
 	if err != nil {
-		return fmt.Errorf("collection: broadcast create collection: %w", err)
+		return fmt.Errorf("database: broadcast create database %s: %w", dbt.dbBackup.GetDbName(), err)
 	}
 
 	return nil

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand/v2"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -111,6 +113,11 @@ func (t *Task) Execute(ctx context.Context) error {
 
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreExecuting())
 
+	if err := t.checkBackupHasFullMeta(); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
+		return err
+	}
+
 	if err := t.checkTargetNotRestored(ctx); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreFail(err))
 		return err
@@ -152,6 +159,42 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreSuccess())
 	t.logger.Info("restore done")
 	return nil
+}
+
+// checkBackupHasFullMeta refuses to run against a backup whose cluster-level
+// fields are missing.
+//
+// A secondary restore broadcasts DDL on the source's control channel and
+// replays the source's flush-all messages per pchannel. Those fields are
+// written only to meta/full_meta.json; the per-level meta files do not carry
+// them, and meta.Read silently falls back to the per-level files when
+// full_meta.json is absent. Without this check the restore reads the
+// collection list fine and then fails at its first broadcast with
+// "no pch in message", which points nowhere near the cause.
+func (t *Task) checkBackupHasFullMeta() error {
+	b := t.args.Backup
+	var missing []string
+	if b.GetControlChannelName() == "" {
+		missing = append(missing, "control channel")
+	}
+	if len(b.GetPhysicalChannelNames()) == 0 {
+		missing = append(missing, "pchannel list")
+	}
+	if len(b.GetFlushAllMsgsBase64()) == 0 {
+		missing = append(missing, "flush-all messages")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("secondary: backup %q carries no %s. These are recorded only by a "+
+		"backup that flushed the source, and only in <backup_dir>/meta/full_meta.json. "+
+		"Either the backup was taken with --strategy=skip_flush or meta_only (the deprecated "+
+		"--force/-f flag means skip_flush), which by design records no flush point, or "+
+		"full_meta.json is missing where this restore reads the backup (check the copy if "+
+		"the backup was moved between buckets). A plain restore accepts such a backup; a "+
+		"secondary restore cannot, because it has no point in the source's stream to start "+
+		"replication from. Take the backup again with the default strategy",
+		b.GetName(), strings.Join(missing, ", "))
 }
 
 // checkTargetNotRestored refuses to restore into a target that has already been
@@ -229,19 +272,35 @@ func (t *Task) checkTargetNotRestored(ctx context.Context) error {
 // which silently doubles its rows.
 func (t *Task) checkTargetIsUnused(ctx context.Context) error {
 	var present []string
+	// Databases the backup will create do not exist on the target yet; that is
+	// the expected state for a newly deployed secondary, so it is reported once
+	// per database and without the error object, which otherwise reads as a
+	// failure. Any other error is a real inability to check and is warned.
+	skipped := make(map[string]int)
 	for _, coll := range t.args.Backup.GetCollectionBackups() {
 		ns := fmt.Sprintf("%s.%s", coll.GetDbName(), coll.GetCollectionName())
 		has, err := t.grpc.HasCollection(ctx, coll.GetDbName(), coll.GetCollectionName())
 		if err != nil {
-			// A database the backup will create does not exist yet, which is
-			// the expected state; anything else is reported when it is used.
-			t.logger.Info("cannot check whether the target already holds a collection, continuing",
+			if isDatabaseNotFound(err) {
+				skipped[coll.GetDbName()]++
+				continue
+			}
+			t.logger.Warn("cannot check whether the target already holds a collection, continuing",
 				zap.String("ns", ns), zap.Error(err))
 			continue
 		}
 		if has {
 			present = append(present, ns)
 		}
+	}
+	dbs := make([]string, 0, len(skipped))
+	for db := range skipped {
+		dbs = append(dbs, db)
+	}
+	sort.Strings(dbs)
+	for _, db := range dbs {
+		t.logger.Info("database does not exist on the target yet, as expected for a newly deployed secondary; skipping the duplicate-collection check for it",
+			zap.String("db", db), zap.Int("collections", skipped[db]))
 	}
 	if len(present) == 0 {
 		return nil
@@ -254,6 +313,12 @@ func (t *Task) checkTargetIsUnused(ctx context.Context) error {
 		"because their ids stay reserved while they are reclaimed and a restore of the "+
 		"same ids is then discarded without an error. To bootstrap again, deploy a new "+
 		"secondary and restore into that", present)
+}
+
+// isDatabaseNotFound reports whether err is Milvus saying the database does not
+// exist. The client surfaces it as a wrapped status error, so match the text.
+func isDatabaseNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "database not found")
 }
 
 // verifyRestored confirms the collections actually exist on the target.

--- a/core/restore/secondary/task_precondition_test.go
+++ b/core/restore/secondary/task_precondition_test.go
@@ -192,3 +192,62 @@ func TestCheckTargetNotRestored(t *testing.T) {
 		assert.Contains(t, err.Error(), "connection refused")
 	})
 }
+
+func TestCheckBackupHasFullMeta(t *testing.T) {
+	full := func() *backuppb.BackupInfo {
+		return &backuppb.BackupInfo{
+			Name:                 "bk",
+			ControlChannelName:   "by-dev-rootcoord-dml_0",
+			PhysicalChannelNames: []string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1"},
+			FlushAllMsgsBase64:   map[string]string{"by-dev-rootcoord-dml_0": "AA==", "by-dev-rootcoord-dml_1": "AA=="},
+		}
+	}
+	task := func(b *backuppb.BackupInfo) *Task {
+		return &Task{args: TaskArgs{Backup: b}, logger: zap.NewNop()}
+	}
+
+	t.Run("a backup read from full_meta.json is accepted", func(t *testing.T) {
+		assert.NoError(t, task(full()).checkBackupHasFullMeta())
+	})
+
+	t.Run("a backup without a control channel is refused and full_meta.json is named", func(t *testing.T) {
+		b := full()
+		b.ControlChannelName = ""
+		err := task(b).checkBackupHasFullMeta()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "control channel")
+		assert.Contains(t, err.Error(), "meta/full_meta.json")
+		assert.Contains(t, err.Error(), "skip_flush")
+		assert.Contains(t, err.Error(), `"bk"`)
+	})
+
+	t.Run("a backup read from the per-level files is refused, naming everything absent", func(t *testing.T) {
+		err := task(&backuppb.BackupInfo{Name: "bk"}).checkBackupHasFullMeta()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "control channel, pchannel list, flush-all messages")
+	})
+
+	t.Run("a backup without flush-all messages is refused", func(t *testing.T) {
+		b := full()
+		b.FlushAllMsgsBase64 = nil
+		err := task(b).checkBackupHasFullMeta()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "flush-all messages")
+		assert.NotContains(t, err.Error(), "control channel,")
+	})
+}
+
+func TestCheckTargetIsUnusedOtherErrors(t *testing.T) {
+	t.Run("an error other than database-not-found is not a reason to refuse either", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollection(mock.Anything, "default", "orders").
+			Return(false, errors.New("rpc error: connection reset"))
+		assert.NoError(t, taskWithBackup(cli, coll("default", "orders")).checkTargetIsUnused(context.Background()))
+	})
+
+	t.Run("database-not-found is recognized in wrapped client errors", func(t *testing.T) {
+		assert.True(t, isDatabaseNotFound(errors.New(`client: has collection failed: client: operation failed: error_code:UnexpectedError reason:"database not found[database=aml_endor_db]" code:800`)))
+		assert.False(t, isDatabaseNotFound(errors.New("collection not found")))
+		assert.False(t, isDatabaseNotFound(nil))
+	})
+}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -135,6 +135,13 @@ func Read(ctx context.Context, cli storage.Client, backupDir string) (*backuppb.
 	if exist {
 		return readFromFull(ctx, backupDir, cli)
 	}
+	// The per-level files carry the collections, partitions and segments but not
+	// the cluster-level fields (control channel, pchannels, flush-all messages).
+	// A plain restore does not need those; a secondary restore cannot run without
+	// them and refuses up front, so make the fallback visible here.
+	log.Warn("full meta not found, reading per-level meta; control channel, pchannels and flush-all messages will be absent",
+		zap.String("backup_dir", backupDir),
+		zap.String("expected", mpath.MetaKey(backupDir, mpath.FullMeta)))
 	return readFromLevel(ctx, backupDir, cli)
 }
 


### PR DESCRIPTION
issue: #1186

A secondary restore broadcasts DDL on the source's control channel and replays
the source's flush-all messages per pchannel. Those fields live only in
`meta/full_meta.json`. When that file is absent, `meta.Read` silently falls back
to the per-level meta files: the collection list still loads, the preflight
checks still run, and the restore fails at its first broadcast with
`stream: no pch in message`, which points nowhere near the cause.

The same shape occurs when the backup itself never recorded them -- a backup
taken with `--strategy=skip_flush` or `meta_only` (or the deprecated `--force`)
records no flush point by design. A plain restore accepts such a backup; a
secondary restore cannot, because it has no position in the source's stream to
start replication from.

Reported on a 2.6 deployment: an 88-line restore log where the only error was
the final `no pch in message`, preceded by twenty-odd INFO lines that read like
failures. The backup's `full_meta.json` was present and held all 66 collections
and 3,435 segments, but none of the three cluster-level fields.

### Changes

- `meta.Read` logs a warning when it falls back to the per-level files, naming
  the file it expected.
- `restore secondary` checks up front that the backup carries a control channel,
  a pchannel list and flush-all messages, and refuses with a message that names
  `meta/full_meta.json` and both ways it ends up missing. This runs before any
  RPC, so it costs nothing and fires before the target is touched.
- The database-creation error said `broadcast create collection`; it now says
  `broadcast create database <name>`.
- `checkTargetIsUnused` reported every database-not-found as an INFO line with
  the full error object attached, once per collection. On the reported restore
  that was twenty-odd lines that looked like failures while being the expected
  state. It now reports once per database without the error object, and reserves
  a warning for errors that are not the expected not-found.

### Verification

Unit tests cover the new check for both the API and metastore spellings plus the
negative cases, and the not-found classification.

End to end on a 2.6 cluster, with the released binary as the control:

```
backup taken normally     create logs "use bulk flush strategy", full_meta.json
                          carries all three fields, secondary restore completes
backup without the flush  full_meta.json key set matches the reported one;
  step                    before: fails at the first broadcast with
                          "no pch in message" after 88 lines
                          after:  refused by the new check before any RPC,
                          naming full_meta.json and the strategies that skip it
backup taken normally,    still reaches the existing checkpoint check and is
  target already used     refused there, unchanged
```

`gofmt`, `golangci-lint` v2.12.2 (the CI version) over the whole tree, `go vet`,
`go build ./...` and `go test` are clean.
