### PR TITLE
fix: record async backup initialization failures

### DIFF
--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -210,18 +210,23 @@ func (t *Task) closeClients() {
 	}
 }
 
-func (t *Task) Execute(ctx context.Context) error {
+func (t *Task) Execute(ctx context.Context) (err error) {
 	defer t.closeClients()
-	if err := t.initClients(); err != nil {
+	defer func() {
+		if err != nil {
+			t.taskMgr.UpdateBackupTask(t.taskID, taskmgr.SetBackupFail(err))
+		}
+	}()
+
+	if err = t.initClients(); err != nil {
 		return err
 	}
 
-	if err := t.prepare(ctx); err != nil {
+	if err = t.prepare(ctx); err != nil {
 		return err
 	}
 
-	if err := t.privateExecute(ctx); err != nil {
-		t.taskMgr.UpdateBackupTask(t.taskID, taskmgr.SetBackupFail(err))
+	if err = t.privateExecute(ctx); err != nil {
 		return err
 	}
 

--- a/core/backup/task_test.go
+++ b/core/backup/task_test.go
@@ -12,11 +12,44 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/namespace"
+	"github.com/zilliztech/milvus-backup/internal/pbconv"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
+
+func TestTask_ExecuteMarksInitClientFailure(t *testing.T) {
+	mgr := taskmgr.NewMgr()
+	require.NoError(t, mgr.AddBackupTask("task1", "backup1"))
+	params := v2.New()
+	params.Milvus.Grpc.TLSMode.Val = v2.TLSMutual
+
+	task := &Task{
+		taskID:  "task1",
+		logger:  zap.NewNop(),
+		params:  params,
+		taskMgr: mgr,
+	}
+
+	err := task.Execute(context.Background())
+	assert.ErrorContains(t, err, "client: load client cert")
+
+	view, getErr := mgr.GetBackupTask("task1")
+	require.NoError(t, getErr)
+	assert.Equal(t, backuppb.BackupTaskStateCode_BACKUP_FAIL, view.StateCode())
+	assert.Equal(t, int32(0), view.Progress())
+	assert.Contains(t, view.ErrorMessage(), "client: load client cert")
+	assert.False(t, view.EndTime().IsZero())
+
+	brief := pbconv.NewBackupInfoBrief(view, nil, 0)
+	assert.Equal(t, backuppb.BackupTaskStateCode_BACKUP_FAIL, brief.GetStateCode())
+	assert.Contains(t, brief.GetErrorMessage(), "client: load client cert")
+	assert.Greater(t, brief.GetEndTime(), int64(0))
+}
 
 func TestTask_runRBACTask(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- mark backup tasks as failed when client initialization, preparation, or execution returns an error
- persist the failure reason and end time so get_backup reports BACKUP_FAIL instead of the initial state
- add regression coverage for an initialization failure and the get_backup response mapping

## Root cause

Task.Execute only transitioned the task to BACKUP_FAIL when privateExecute failed. Errors returned earlier by initClients or prepare left the asynchronous task in BACKUP_INITIAL indefinitely.

## Testing

- go test -count=1 ./core/backup ./core/server ./internal/taskmgr