### PR TITLE
backup: say which collections a skipped dynamic field task leaves incomplete

### DIFF
--- a/core/backup/meta_builder.go
+++ b/core/backup/meta_builder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -176,6 +177,25 @@ func (builder *metaBuilder) backupCollectionIDs() []int64 {
 	}
 
 	return ids
+}
+
+// dynamicSchemaCollections names the backed-up collections that have dynamic
+// schema enabled, in db.collection form. Their $meta field can only reach the
+// backup through the etcd-backed dynamic field task, so this is what a caller
+// needs in order to say which collections an absent task leaves incomplete.
+func (builder *metaBuilder) dynamicSchemaCollections() []string {
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	var names []string
+	for _, coll := range builder.data.GetCollectionBackups() {
+		if coll.GetSchema().GetEnableDynamicField() {
+			names = append(names, coll.GetDbName()+"."+coll.GetCollectionName())
+		}
+	}
+	sort.Strings(names)
+
+	return names
 }
 
 // addIndexExtraInfo merges the extra index attributes read from etcd into the

--- a/core/backup/meta_builder_test.go
+++ b/core/backup/meta_builder_test.go
@@ -399,3 +399,25 @@ func TestBuildBackupMetaCarriesFormat(t *testing.T) {
 	require.NoError(t, json.Unmarshal(byts, &got))
 	assert.Equal(t, meta.FormatSnapshot, got.GetFormat())
 }
+
+func TestMetaBuilder_DynamicSchemaCollections(t *testing.T) {
+	t.Run("names only the dynamic ones, sorted", func(t *testing.T) {
+		b := newMetaBuilder("task", "backup")
+		b.data.CollectionBackups = []*backuppb.CollectionBackupInfo{
+			{DbName: "db2", CollectionName: "z", Schema: &backuppb.CollectionSchema{EnableDynamicField: true}},
+			{DbName: "db1", CollectionName: "plain", Schema: &backuppb.CollectionSchema{}},
+			{DbName: "db1", CollectionName: "a", Schema: &backuppb.CollectionSchema{EnableDynamicField: true}},
+		}
+
+		assert.Equal(t, []string{"db1.a", "db2.z"}, b.dynamicSchemaCollections())
+	})
+
+	t.Run("empty when none has dynamic schema", func(t *testing.T) {
+		b := newMetaBuilder("task", "backup")
+		b.data.CollectionBackups = []*backuppb.CollectionBackupInfo{
+			{DbName: "db1", CollectionName: "plain", Schema: &backuppb.CollectionSchema{}},
+		}
+
+		assert.Empty(t, b.dynamicSchemaCollections())
+	})
+}

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -636,8 +636,21 @@ func (t *Task) backupIndexExtraInfo(ctx context.Context) error {
 //
 // Reuses the etcd client created for BackupIndexExtra; if etcd is not
 // configured (BackupIndexExtra disabled) the task is skipped.
+//
+// Skipping is not an error: a regular restore recreates $meta through
+// CreateCollection and never reads the stored copy. A secondary restore does
+// read it, and refuses a backup without it, so the skip is logged at warn level
+// naming the collections it leaves incomplete -- that message is the only place
+// the missing option is visible before a restore fails on it much later.
 func (t *Task) backupCollDynField(ctx context.Context) error {
 	if t.etcdCli == nil {
+		if affected := t.metaBuilder.dynamicSchemaCollections(); len(affected) > 0 {
+			t.logger.Warn("dynamic field not recorded, this backup cannot serve a secondary restore",
+				zap.Strings("collections_with_dynamic_schema", affected),
+				zap.String("reason", "index extra info is off, so there is no etcd client to read $meta with"),
+				zap.String("enable_with", "--backup_index_extra, or with_index_extra in the REST create request"))
+			return nil
+		}
 		t.logger.Info("skip backup collection dynamic field, etcd client is not initialized")
 		return nil
 	}

--- a/core/restore/secondary/funcs.go
+++ b/core/restore/secondary/funcs.go
@@ -19,7 +19,11 @@ func checkDynamicField(schema *schemapb.CollectionSchema) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("secondary: %q missing dynamic field in backup", schema.GetName())
+	return fmt.Errorf("secondary: %q has dynamic schema enabled but the backup carries no $meta "+
+		"field, so the collection cannot be recreated to match the source. Milvus does not return "+
+		"$meta from DescribeCollection, so a backup can only record it by reading etcd, which it "+
+		"does only when index extra info is enabled. Take the backup again with --backup_index_extra "+
+		"(with_index_extra in the REST create request) and milvus.etcd configured", schema.GetName())
 }
 
 func appendSysFields(schema *schemapb.CollectionSchema) {


### PR DESCRIPTION
issue: #1170

A backup taken without index extra info records no `$meta` field. That is fine for a regular restore, which lets `CreateCollection` recreate the field and never reads the stored copy — so the task is skipped rather than failed. A secondary restore does read it, and refuses a backup without it.

Nothing said so along the way. The skip was an `Info` line naming no collection, the backup reported success, and the omission only surfaced later, in a secondary restore, as

```
"test_storage" missing dynamic field in backup
```

which describes the backup's contents rather than the option that produced them. Getting from that message to `--backup_index_extra` means reading back from the restore error through `checkDynamicField`, into `backupCollDynField`, to the `if t.option.BackupIndexExtra` that gates the etcd client.

Seen on a production cluster this week: a default REST create (`{"async": true, "backup_name": "..."}`), 66 collections, restore secondary walked through more than sixty of them before failing on one — with an error that pointed at the backup rather than at the missing option.

### Changes

Neither alters what a backup does.

**Warn instead of Info when the skip actually costs something**, naming the collections with dynamic schema and the option that would have captured them. When no collection has dynamic schema the skip costs nothing and stays at `Info`.

**Say the same thing in the secondary restore error**: that the backup carries no `$meta`, why a backup can only get it from etcd, and which option to re-create it with.

### Scope

This is the smallest half of what #1170 describes — the visibility, not the contract. Refusing at create time is only sound once the user has declared secondary intent (`--for secondary`), since a backup without `$meta` is perfectly valid for a regular restore; that part belongs with the preset mechanism and is not attempted here.

gofmt, `go build ./...` and golangci-lint clean; `./core/backup/... ./core/restore/...` all pass.