### PR TITLE
fix: restore the imports meta.go needs to compile

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )


### PR DESCRIPTION
`main` does not compile.

#1185 added a `log.Warn` call to `meta.Read` but landed without the two imports it uses:

```
internal/meta/meta.go:140:2: undefined: log
internal/meta/meta.go:141:3: undefined: zap
```

Reproduce on `main` with `go build ./...`.

This adds `go.uber.org/zap` and `internal/log` back to the import block. No behaviour change.
