### PR TITLE
restore secondary: wait for a collection to exist before importing into it

### DIFF
--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -53,6 +53,10 @@ var (
 	// collection the restore created is not there.
 	_restoreVerifyTimeout  = 30 * time.Second
 	_restoreVerifyInterval = 3 * time.Second
+	// How long to wait, per collection, for a create the restore has just sent
+	// to become visible on the target before starting to import into it.
+	_collCreateTimeout  = 30 * time.Second
+	_collCreateInterval = 1 * time.Second
 )
 
 type partitionDir struct {

--- a/core/restore/secondary/task.go
+++ b/core/restore/secondary/task.go
@@ -467,6 +467,11 @@ func (t *Task) runCollTask(ctx context.Context, dbBackup *backuppb.DatabaseBacku
 		return fmt.Errorf("secondary: execute collection ddl task: %w", err)
 	}
 
+	if err := t.waitCollCreated(ctx, ns, collBackup.GetCollectionId()); err != nil {
+		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreCollFail(ns, err))
+		return err
+	}
+
 	dmlTask := newCollDMLTask(dmlArgs, collBackup)
 	if err := dmlTask.Execute(ctx); err != nil {
 		t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreCollFail(ns, err))
@@ -482,6 +487,47 @@ func (t *Task) runCollTask(ctx context.Context, dbBackup *backuppb.DatabaseBacku
 	t.taskMgr.UpdateRestoreTask(t.args.TaskID, taskmgr.SetRestoreCollSuccess(ns))
 
 	return nil
+}
+
+// waitCollCreated blocks until the collection this restore just created is
+// usable on the target, and fails the collection if it never becomes so.
+//
+// The DDL is not applied where it is sent. createColl returns once the create
+// message is queued for the target's replicate stream, which says nothing about
+// whether the target has accepted it, let alone applied it. Everything after it
+// -- the import above all -- depends on the collection actually being there, and
+// an import submitted against a collection the target does not have is accepted
+// and then killed partway through, reported as the collection having been
+// dropped. Waiting here turns that into a failure at the point of the cause.
+func (t *Task) waitCollCreated(ctx context.Context, ns namespace.NS, collectionID int64) error {
+	deadline := time.Now().Add(_collCreateTimeout)
+	for {
+		has, err := t.grpc.HasCollectionByID(ctx, collectionID)
+		if err != nil {
+			return fmt.Errorf("secondary: wait for collection %s (id %d): %w", ns, collectionID, err)
+		}
+		if has {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(_collCreateInterval):
+		}
+	}
+
+	return fmt.Errorf("secondary: collection %s (id %d) is still not on the target %s after "+
+		"its create was sent, so the create had no effect. A secondary restore replays the "+
+		"source's create with the source's collection id, and the target keeps that id "+
+		"reserved for as long as a collection that held it is being reclaimed -- dropping "+
+		"the collections on the target does not release their ids, and a create of a "+
+		"reserved id is discarded without an error. Restore into a newly deployed "+
+		"secondary, and check with birdwatcher that none of the backup's collection ids "+
+		"are present there in any state, dropped included",
+		ns, collectionID, _collCreateTimeout)
 }
 
 func (t *Task) loadTaskArgs() loadTaskArgs {

--- a/core/restore/secondary/task_precondition_test.go
+++ b/core/restore/secondary/task_precondition_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/client/milvus"
+	"github.com/zilliztech/milvus-backup/internal/namespace"
 )
 
 func taskWithBackup(cli milvus.Grpc, colls ...*backuppb.CollectionBackupInfo) *Task {
@@ -249,5 +250,55 @@ func TestCheckTargetIsUnusedOtherErrors(t *testing.T) {
 		assert.True(t, isDatabaseNotFound(errors.New(`client: has collection failed: client: operation failed: error_code:UnexpectedError reason:"database not found[database=aml_endor_db]" code:800`)))
 		assert.False(t, isDatabaseNotFound(errors.New("collection not found")))
 		assert.False(t, isDatabaseNotFound(nil))
+	})
+}
+
+func TestWaitCollCreated(t *testing.T) {
+	prevTimeout, prevInterval := _collCreateTimeout, _collCreateInterval
+	_collCreateTimeout, _collCreateInterval = 30*time.Millisecond, time.Millisecond
+	defer func() {
+		_collCreateTimeout, _collCreateInterval = prevTimeout, prevInterval
+	}()
+
+	ns := namespace.New("default", "orders")
+
+	t.Run("a collection that is already there returns at once", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollectionByID(mock.Anything, int64(7)).Return(true, nil).Once()
+		assert.NoError(t, taskWithBackup(cli).waitCollCreated(context.Background(), ns, 7))
+	})
+
+	t.Run("a collection that appears late is waited for", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		var calls int
+		cli.EXPECT().HasCollectionByID(mock.Anything, int64(7)).
+			RunAndReturn(func(context.Context, int64) (bool, error) {
+				calls++
+				return calls > 2, nil
+			})
+		assert.NoError(t, taskWithBackup(cli).waitCollCreated(context.Background(), ns, 7))
+		assert.Equal(t, 3, calls)
+	})
+
+	// The whole point: the create was sent, the target reported no error, and the
+	// collection is not there. Importing into it would be accepted and then killed
+	// partway through, blaming the collection for having been dropped.
+	t.Run("a collection that never appears fails before the import", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollectionByID(mock.Anything, int64(7)).Return(false, nil)
+		err := taskWithBackup(cli).waitCollCreated(context.Background(), ns, 7)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "default.orders")
+		assert.Contains(t, err.Error(), "7")
+		assert.Contains(t, err.Error(), "reserved")
+	})
+
+	t.Run("an error reaching the target is reported as such", func(t *testing.T) {
+		cli := milvus.NewMockGrpc(t)
+		cli.EXPECT().HasCollectionByID(mock.Anything, int64(7)).
+			Return(false, errors.New("connection refused")).Once()
+		err := taskWithBackup(cli).waitCollCreated(context.Background(), ns, 7)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection refused")
 	})
 }

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -141,6 +141,7 @@ type Grpc interface {
 	FlushAll(ctx context.Context) (*milvuspb.FlushAllResponse, error)
 	ListCollections(ctx context.Context, db string) (*milvuspb.ShowCollectionsResponse, error)
 	HasCollection(ctx context.Context, db, collName string) (bool, error)
+	HasCollectionByID(ctx context.Context, collectionID int64) (bool, error)
 	BulkInsert(ctx context.Context, input GrpcBulkInsertInput) (int64, error)
 	GetBulkInsertState(ctx context.Context, taskID int64) (*milvuspb.GetImportStateResponse, error)
 	CreateCollection(ctx context.Context, input CreateCollectionInput) error
@@ -167,6 +168,11 @@ type Grpc interface {
 	RestoreExternalSnapshot(ctx context.Context, input RestoreExternalSnapshotInput) (int64, error)
 	GetRestoreSnapshotState(ctx context.Context, jobID int64) (*milvuspb.RestoreSnapshotInfo, error)
 }
+
+// _collectionNotFoundCode is merr.ErrCollectionNotFound's code. Newer servers
+// report it in Status.Code while older ones set the legacy CollectionNotExists
+// error code, so both are treated as the collection being absent.
+const _collectionNotFoundCode = 100
 
 const (
 	_authorizationHeader = `authorization`
@@ -849,6 +855,29 @@ func (g *GrpcClient) HasCollection(ctx context.Context, db, collName string) (bo
 		return false, fmt.Errorf("client: has collection failed: %w", err)
 	}
 	return resp.GetValue(), nil
+}
+
+// HasCollectionByID reports whether the collection with this id is usable on the
+// server. DescribeCollection resolves by id when the name is left empty, and the
+// server answers from the same view a restore's own writes are checked against:
+// a collection that exists but is not in the created state -- one that is still
+// being reclaimed after a drop, say -- reads as absent here, which is what the
+// caller needs to know.
+func (g *GrpcClient) HasCollectionByID(ctx context.Context, collectionID int64) (bool, error) {
+	resp, err := g.srv.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{CollectionID: collectionID})
+	if err != nil {
+		return false, fmt.Errorf("client: has collection by id failed: %w", err)
+	}
+	// Absent is an answer, not a failure: it is what the caller is asking about.
+	//nolint:staticcheck // SA1019: GetErrorCode is needed for backward compatibility with older Milvus versions
+	if resp.GetStatus().GetErrorCode() == commonpb.ErrorCode_CollectionNotExists ||
+		resp.GetStatus().GetCode() == _collectionNotFoundCode {
+		return false, nil
+	}
+	if err := checkResponse(resp, nil); err != nil {
+		return false, fmt.Errorf("client: has collection by id failed: %w", err)
+	}
+	return true, nil
 }
 
 type GrpcBulkInsertInput struct {

--- a/internal/client/milvus/grpc_mock.go
+++ b/internal/client/milvus/grpc_mock.go
@@ -2211,6 +2211,72 @@ func (_c *MockGrpc_HasCollection_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// HasCollectionByID provides a mock function for the type MockGrpc
+func (_mock *MockGrpc) HasCollectionByID(ctx context.Context, collectionID int64) (bool, error) {
+	ret := _mock.Called(ctx, collectionID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasCollectionByID")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (bool, error)); ok {
+		return returnFunc(ctx, collectionID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) bool); ok {
+		r0 = returnFunc(ctx, collectionID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, collectionID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGrpc_HasCollectionByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasCollectionByID'
+type MockGrpc_HasCollectionByID_Call struct {
+	*mock.Call
+}
+
+// HasCollectionByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - collectionID int64
+func (_e *MockGrpc_Expecter) HasCollectionByID(ctx any, collectionID any) *MockGrpc_HasCollectionByID_Call {
+	return &MockGrpc_HasCollectionByID_Call{Call: _e.mock.On("HasCollectionByID", ctx, collectionID)}
+}
+
+func (_c *MockGrpc_HasCollectionByID_Call) Run(run func(ctx context.Context, collectionID int64)) *MockGrpc_HasCollectionByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGrpc_HasCollectionByID_Call) Return(b bool, err error) *MockGrpc_HasCollectionByID_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockGrpc_HasCollectionByID_Call) RunAndReturn(run func(ctx context.Context, collectionID int64) (bool, error)) *MockGrpc_HasCollectionByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HasFeature provides a mock function for the type MockGrpc
 func (_mock *MockGrpc) HasFeature(flag FeatureFlag) bool {
 	ret := _mock.Called(flag)

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )


### PR DESCRIPTION
`restore secondary` submits a collection's import right after sending its create,
without confirming the target has applied it. `createColl` returns once the
create is queued for the replicate stream, which says nothing about whether the
target accepted it, let alone applied it — on a local run the import follows ten
milliseconds later.

When the create has no effect, the import is submitted anyway. The target
accepts it and kills it partway through, reporting that the collection was
dropped, which sends the reader to the collection's data rather than to the
create that never took.

## Where this came from

A restore into a target that had previously held the same collections. The
collections were dropped before restoring, but their ids stay reserved while
they are being reclaimed, so RootCoord skipped the replayed creates as already
done:

```
04:33:29.636  [rootcoord/meta_table.go] "collection already created, skip add collection to meta table" [collectionID=...]
04:33:42.107  [datacoord/import_checker.go] "Import job has failed" [reason="collection ... dropped"]
```

Thirteen seconds separate the create being discarded from the import being
killed, and nothing in between reports a problem. Nine collections were affected
across three attempts.

## What this changes

`runCollTask` now waits, between the DDL and the DML, for the collection to be
usable on the target, and fails the collection if it never becomes so. The wait
is keyed by collection id, not name: a secondary restore replays the source's
id, and that is what the import references.

`HasCollectionByID` is added for it. `DescribeCollection` resolves by id when the
name is left empty (`describeCollectionTask.PreExecute` allows it explicitly) and
answers from the same view the import's own check uses, so a collection that
exists but is not in the created state — one still being reclaimed after a drop —
reads as absent, which is what the caller needs to know. Absent is an answer
rather than a failure, matched on the status code rather than the message text.

The error names the collection, its id, and what to do about it.

## Verified

Against a target instrumented to hold a freshly created collection back from
that lookup, reproducing the field condition, same backup and same target both
times:

| | before | after |
|---|---|---|
| import polls issued | 602 | **0** |
| time to failure | 60s | 30s |
| what the error blames | the target having already been restored | the create that had no effect, named |

Unit tests cover the collection being present, appearing late, never appearing,
and the lookup itself failing.

## Note

Based on #1191, which restores two imports `main` needs to compile. Once that
merges this reduces to the single commit.
