### PR TITLE
restore secondary: wait on each import job from the moment it is submitted

### DIFF
--- a/core/restore/secondary/coll_dml_task.go
+++ b/core/restore/secondary/coll_dml_task.go
@@ -199,34 +199,39 @@ func (dmlt *collDMLTask) Execute(ctx context.Context) (err error) {
 
 // restorePartitionNonL0 builds and sends non-L0 import messages for all partitions
 // sequentially to ensure messages arrive at each physical channel in ts order,
-// then waits for all import jobs concurrently.
+// waiting on each import job from the moment it is submitted.
 func (dmlt *collDMLTask) restorePartitionNonL0(ctx context.Context) error {
-	var jobIDs []int64
+	g, subCtx := errgroup.WithContext(ctx)
+	var count int
 	for _, partition := range dmlt.collBackup.GetPartitionBackups() {
 		nonL0Segs := lo.Filter(partition.GetSegmentBackups(), func(seg *backuppb.SegmentBackupInfo, _ int) bool {
 			return !seg.IsL0
 		})
 
-		batches, err := dmlt.nonL0SegBatches(ctx, nonL0Segs)
+		batches, err := dmlt.nonL0SegBatches(subCtx, nonL0Segs)
 		if err != nil {
 			return fmt.Errorf("secondary: build non-L0 batches for partition %s: %w", partition.GetPartitionName(), err)
 		}
 
-		ids, err := dmlt.sendBatches(ctx, partition.GetPartitionId(), batches)
+		n, err := dmlt.sendBatches(subCtx, g, partition.GetPartitionId(), batches)
+		count += n
 		if err != nil {
 			return fmt.Errorf("secondary: send non-L0 for partition %s: %w", partition.GetPartitionName(), err)
 		}
-		jobIDs = append(jobIDs, ids...)
 	}
 
-	dmlt.logger.Info("check non-l0 bulk insert jobs", zap.Int("job_count", len(jobIDs)))
-	return dmlt.checkBulkInsertJobs(ctx, jobIDs)
+	dmlt.logger.Info("check non-l0 bulk insert jobs", zap.Int("job_count", count))
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("secondary: check bulk insert jobs: %w", err)
+	}
+	return nil
 }
 
 // restorePartitionL0 builds and sends per-partition L0 import messages sequentially,
-// then waits for all import jobs concurrently.
+// waiting on each import job from the moment it is submitted.
 func (dmlt *collDMLTask) restorePartitionL0(ctx context.Context) error {
-	var jobIDs []int64
+	g, subCtx := errgroup.WithContext(ctx)
+	var count int
 	for _, partition := range dmlt.collBackup.GetPartitionBackups() {
 		l0Segs := lo.Filter(partition.GetSegmentBackups(), func(seg *backuppb.SegmentBackupInfo, _ int) bool {
 			return seg.IsL0
@@ -237,15 +242,18 @@ func (dmlt *collDMLTask) restorePartitionL0(ctx context.Context) error {
 			return fmt.Errorf("secondary: build L0 batches for partition %s: %w", partition.GetPartitionName(), err)
 		}
 
-		ids, err := dmlt.sendBatches(ctx, partition.GetPartitionId(), batches)
+		n, err := dmlt.sendBatches(subCtx, g, partition.GetPartitionId(), batches)
+		count += n
 		if err != nil {
 			return fmt.Errorf("secondary: send L0 for partition %s: %w", partition.GetPartitionName(), err)
 		}
-		jobIDs = append(jobIDs, ids...)
 	}
 
-	dmlt.logger.Info("check l0 bulk insert jobs", zap.Int("job_count", len(jobIDs)))
-	return dmlt.checkBulkInsertJobs(ctx, jobIDs)
+	dmlt.logger.Info("check l0 bulk insert jobs", zap.Int("job_count", count))
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("secondary: check bulk insert jobs: %w", err)
+	}
+	return nil
 }
 
 func (dmlt *collDMLTask) backupTS(vch string) (uint64, error) {
@@ -267,12 +275,12 @@ func (dmlt *collDMLTask) restoreAllPartitionL0(ctx context.Context) error {
 		return fmt.Errorf("secondary: build all partition l0 batches: %w", err)
 	}
 
-	jobIDs, err := dmlt.sendBatches(ctx, common.AllPartitionsID, batches)
-	if err != nil {
+	g, subCtx := errgroup.WithContext(ctx)
+	if _, err := dmlt.sendBatches(subCtx, g, common.AllPartitionsID, batches); err != nil {
 		return fmt.Errorf("secondary: send all partition l0: %w", err)
 	}
 
-	if err := dmlt.checkBulkInsertJobs(ctx, jobIDs); err != nil {
+	if err := g.Wait(); err != nil {
 		return fmt.Errorf("secondary: check all partition l0 jobs: %w", err)
 	}
 
@@ -281,34 +289,31 @@ func (dmlt *collDMLTask) restoreAllPartitionL0(ctx context.Context) error {
 	return nil
 }
 
-func (dmlt *collDMLTask) sendBatches(ctx context.Context, partitionID int64, batches []batch) ([]int64, error) {
-	jobIDs := make([]int64, 0, len(batches))
-	for _, b := range batches {
+// sendBatches submits every batch in order and starts waiting on each import job
+// as it is submitted, returning the number submitted.
+//
+// The waiting cannot be deferred until every batch has been sent. Submitting a
+// batch stages its binlogs first, so a collection of any size spends a long time
+// in this loop -- a 173 GB collection in 209 batches took thirty-seven minutes --
+// while the target keeps a finished job's record only for
+// dataCoord.import.taskRetention past its completion. A job submitted early
+// therefore finishes and is reclaimed long before a deferred wait would first
+// ask about it, and the restore then cannot tell a job that succeeded and was
+// forgotten from one that never ran.
+func (dmlt *collDMLTask) sendBatches(ctx context.Context, g *errgroup.Group, partitionID int64, batches []batch) (int, error) {
+	for i, b := range batches {
 		jobID, err := dmlt.sendImportMsg(ctx, partitionID, b)
 		if err != nil {
-			return nil, fmt.Errorf("secondary: send import msg: %w", err)
+			return i, fmt.Errorf("secondary: send import msg: %w", err)
 		}
-		jobIDs = append(jobIDs, jobID)
-	}
-	return jobIDs, nil
-}
-
-func (dmlt *collDMLTask) checkBulkInsertJobs(ctx context.Context, jobIDs []int64) error {
-	g, subCtx := errgroup.WithContext(ctx)
-	for _, jobID := range jobIDs {
 		g.Go(func() error {
-			if err := dmlt.checkBulkInsertJob(subCtx, jobID); err != nil {
+			if err := dmlt.checkBulkInsertJob(ctx, jobID); err != nil {
 				return fmt.Errorf("secondary: check bulk insert job %d: %w", jobID, err)
 			}
 			return nil
 		})
 	}
-
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("secondary: check bulk insert jobs: %w", err)
-	}
-
-	return nil
+	return len(batches), nil
 }
 
 func (dmlt *collDMLTask) checkBulkInsertJob(ctx context.Context, jobID int64) error {
@@ -384,17 +389,15 @@ func (dmlt *collDMLTask) waitBulkInsertState(
 				unknownSince = time.Now()
 			} else if time.Since(unknownSince) >= _bulkInsertUnknownJobTimeout {
 				return "", fmt.Errorf("secondary: the target does not know import job %d after %s, "+
-					"so the import message this restore sent was never applied. A secondary restore "+
-					"targets a newly deployed secondary and runs once: the messages it injects are "+
-					"time-ticked from 1, while a secondary only ever moves its replicate checkpoint "+
-					"forward, so a target that has already been restored discards everything a "+
-					"second restore sends. There is no way to return a used target to that state -- "+
-					"re-applying the same replicate configuration does not clear the checkpoint, "+
-					"restarting the target does not, and dropping its collections makes matters "+
-					"worse, because their ids stay reserved while the collections are being "+
-					"reclaimed and a later restore of the same ids is then discarded without an "+
-					"error. To bootstrap again, deploy a new secondary and restore into that",
-					jobID, _bulkInsertUnknownJobTimeout)
+					"so this batch cannot be confirmed either way. Two things produce this and "+
+					"they are not distinguishable from here: the import message was never "+
+					"applied, or the job ran and the target already dropped its record. A record "+
+					"is kept only for dataCoord.import.taskRetention past the job finishing, and "+
+					"success and failure are dropped alike, so a short retention loses the "+
+					"outcome rather than reporting it. Check the target's log for job %d before "+
+					"concluding anything about this batch, and raise "+
+					"dataCoord.import.taskRetention if it is below the default of 10800",
+					jobID, _bulkInsertUnknownJobTimeout, jobID)
 			}
 		} else {
 			unknownSince = time.Time{}

--- a/core/restore/secondary/coll_dml_task_test.go
+++ b/core/restore/secondary/coll_dml_task_test.go
@@ -111,6 +111,29 @@ func (r *completedRestful) GetSegmentInfo(context.Context, string, int64, int64)
 	return nil, nil
 }
 
+// countingRestful reports Completed at once and calls onCall when a job's wait
+// first asks about it.
+type countingRestful struct {
+	onCall func()
+}
+
+func (r *countingRestful) BulkInsert(context.Context, milvus.BulkInsertV2Input) (string, error) {
+	return "", nil
+}
+
+func (r *countingRestful) GetBulkInsertState(context.Context, string, string) (*milvus.GetProcessResp, error) {
+	if r.onCall != nil {
+		r.onCall()
+	}
+	resp := &milvus.GetProcessResp{}
+	resp.Data.State = string(milvus.ImportStateCompleted)
+	return resp, nil
+}
+
+func (r *countingRestful) GetSegmentInfo(context.Context, string, int64, int64) (*milvus.SegmentInfo, error) {
+	return nil, nil
+}
+
 type sequencedRestful struct {
 	mu     sync.Mutex
 	states []milvus.ImportState
@@ -462,12 +485,54 @@ func TestSendBatches(t *testing.T) {
 		{timestamp: 200, partitionDirs: []partitionDir{{insertLogDir: "/b"}}, storageVersion: 2},
 	}
 
-	jobIDs, err := task.sendBatches(context.Background(), 1, batches)
+	g, ctx := errgroup.WithContext(context.Background())
+	n, err := task.sendBatches(ctx, g, 1, batches)
 	assert.NoError(t, err)
-	assert.Len(t, jobIDs, 2)
+	assert.Equal(t, 2, n)
+	assert.NoError(t, g.Wait())
 
 	// Each batch broadcasts to all vchannels, so total messages = 2 batches * 2 vchannels.
 	assert.Len(t, stream.msgs, 4)
+}
+
+// A job's wait has to start as it is submitted: the target keeps a finished job's
+// record only briefly, so a wait deferred until every batch is out can find the
+// early jobs already gone.
+func TestSendBatchesWaitsFromSubmission(t *testing.T) {
+	vchannels := newTestVChannels()
+	collBackup := newTestCollBackup(vchannels, nil, nil)
+	stream := &recordingStream{}
+	task := newTestDMLTask(t, collBackup, stream)
+
+	started := make(chan struct{}, 8)
+	task.restfulCli = &countingRestful{onCall: func() {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}}
+
+	b := func(ts uint64, dir string) batch {
+		return batch{timestamp: ts, partitionDirs: []partitionDir{{insertLogDir: dir}}, storageVersion: 2}
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Submit one batch and nothing else. Its wait has to get going on its own.
+	n, err := task.sendBatches(ctx, g, 1, []batch{b(100, "/a")})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first job's wait had not started before any further batch was submitted")
+	}
+
+	n, err = task.sendBatches(ctx, g, 1, []batch{b(200, "/b"), b(300, "/c")})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.NoError(t, g.Wait())
 }
 
 func TestCheckBulkInsertJob_Import2PCStates(t *testing.T) {
@@ -671,12 +736,15 @@ func TestWaitBulkInsertStateUnknownJob(t *testing.T) {
 		_bulkInsertCheckInterval, _bulkInsertUnknownJobTimeout = prevInterval, prevTimeout
 	}()
 
-	t.Run("an always unknown job gives up and says how to recover", func(t *testing.T) {
+	t.Run("an always unknown job gives up without claiming a cause", func(t *testing.T) {
 		cli := &stateSequenceRestful{states: []string{""}}
 		_, err := newWaitTask(cli).waitBulkInsertReadyToCommit(context.Background(), 4242)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not know import job 4242")
-		assert.Contains(t, err.Error(), "deploy a new secondary")
+		// Success and failure are dropped alike, so neither may be claimed here.
+		assert.Contains(t, err.Error(), "cannot be confirmed either way")
+		assert.Contains(t, err.Error(), "dataCoord.import.taskRetention")
+		assert.NotContains(t, err.Error(), "deploy a new secondary")
 	})
 
 	t.Run("a job that is merely slow to appear is waited for", func(t *testing.T) {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )


### PR DESCRIPTION
The wait on a collection's import jobs was deferred until every batch had been
sent. Submitting a batch stages its binlogs first, so a large collection spends a
long time in that loop, while the target keeps a finished job's record only for
`dataCoord.import.taskRetention` past its completion. A job submitted early
finishes and is reclaimed before the deferred wait first asks about it, and the
restore fails on a job that had in fact succeeded.

## What was seen

A 173 GB collection restored in 209 batches, against a target with a 30 second
retention:

```
03:03:49  first batch staged and submitted
03:31:58  that job completes on the target — totalRows=4761633, totalSize=173265042265
03:32:38  "import job removed"  (GCRetention=30s)
03:40:25  last of the 209 batches submitted
03:40:35  the wait finally starts, eight minutes after the record was gone
03:41:35  restore fails: "the import message this restore sent was never applied"
```

The import had succeeded. The bigger the collection, the more certain this
becomes — it is not a narrow race.

## What this changes

`sendBatches` starts each job's wait as it submits it, so the gap between
submitting and first asking is seconds rather than the length of the whole
submission phase. Submission itself stays sequential, which is what keeps
messages in ts order per physical channel; only the waiting moves.

`checkBulkInsertJobs` folds into that and is gone.

## The message for an unknown job

It claimed the target had already been restored and told the reader to deploy a
new secondary. That cost an operator a cluster redeploy for nothing.

A record is dropped the same way whether the job succeeded or failed
(`UpdateJobState` sets the same cleanup ts for `Completed` and `Failed`, and
`checkGC` removes both), so neither can be inferred from its absence. The
message now says the batch cannot be confirmed either way, names
`dataCoord.import.taskRetention`, and leaves the conclusion to the target's log.

## Tests

- a job's wait starts after its own batch is submitted, with no further batches
- the unknown-job error claims no cause and names the retention setting

Full suite passes.

## Note

Based on #1191, which restores two imports `main` needs to compile. Once that
merges this reduces to the single commit. Independent of #1192.
