### PR TITLE
meta: add missing log and zap imports

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )


### PR DESCRIPTION
## What

`internal/meta/meta.go` uses `log.Warn` and `zap.String` in the per-level meta fallback (added by #1185) but never imports `internal/log` and `go.uber.org/zap`, so main does not compile:

```
# github.com/zilliztech/milvus-backup/internal/meta
internal/meta/meta.go:140:2: undefined: log
internal/meta/meta.go:141:3: undefined: zap
internal/meta/meta.go:142:3: undefined: zap
```

## Why now

This breaks the zilliz-cloud tool image build, which compiles milvus-backup from the pinned main HEAD.

## Test plan

- `go build ./...` passes
- `go test ./internal/meta/...` passes