### PR TITLE
restore secondary: qualify struct array sub-field names on restore

### DIFF
--- a/core/restore/conv/conv.go
+++ b/core/restore/conv/conv.go
@@ -3,6 +3,7 @@ package conv
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -93,12 +94,31 @@ func Fields(bakFields []*backuppb.FieldSchema) ([]*schemapb.FieldSchema, error) 
 	return fields, nil
 }
 
+// qualifySubFieldName returns the name Milvus stores a struct array's sub-field
+// under. Milvus keeps them as struct[sub] so that the same sub-field name may
+// appear in more than one struct, and hands back the bare name in
+// DescribeCollection, which is where a backup's schema comes from. Restoring
+// that schema has to put the qualification back.
+func qualifySubFieldName(structName, fieldName string) string {
+	if strings.HasPrefix(fieldName, structName+"[") && strings.HasSuffix(fieldName, "]") {
+		return fieldName
+	}
+	return fmt.Sprintf("%s[%s]", structName, fieldName)
+}
+
 func StructArrayFields(bakFields []*backuppb.StructArrayFieldSchema) ([]*schemapb.StructArrayFieldSchema, error) {
 	structArrayFields := make([]*schemapb.StructArrayFieldSchema, 0, len(bakFields))
 	for _, bakField := range bakFields {
 		fields, err := Fields(bakField.GetFields())
 		if err != nil {
 			return nil, fmt.Errorf("conv: convert struct array fields: %w", err)
+		}
+		// The proxy qualifies these on the create path, and a secondary restore
+		// does not go through the proxy, so do it here. Left bare, two structs
+		// that share a sub-field name would collide, and a search naming the
+		// field as struct[sub] would not resolve it.
+		for _, field := range fields {
+			field.Name = qualifySubFieldName(bakField.GetName(), field.GetName())
 		}
 
 		structArrayField := &schemapb.StructArrayFieldSchema{

--- a/core/restore/conv/conv_test.go
+++ b/core/restore/conv/conv_test.go
@@ -303,3 +303,69 @@ func TestPrivilegeGroups(t *testing.T) {
 	assert.Equal(t, "privilege3", restorePG[0].Privileges[0].Name)
 	assert.Equal(t, "privilege4", restorePG[0].Privileges[1].Name)
 }
+
+// Milvus stores a struct array's sub-fields as struct[sub] so the same sub-field
+// name can appear in more than one struct. DescribeCollection hands back the bare
+// name, which is what a backup carries, and a secondary restore writes the schema
+// without going through the proxy that would qualify it again.
+func TestStructArrayFieldsQualifiesSubFieldNames(t *testing.T) {
+	bak := []*backuppb.StructArrayFieldSchema{
+		{
+			FieldID: 138,
+			Name:    "duplicate_radar_struct",
+			Fields: []*backuppb.FieldSchema{
+				{FieldID: 139, Name: "chunk_number", DataType: backuppb.DataType_Int64},
+				{FieldID: 141, Name: "chunk_vector", DataType: backuppb.DataType_FloatVector},
+			},
+		},
+		{
+			FieldID: 142,
+			Name:    "title_struct",
+			Fields: []*backuppb.FieldSchema{
+				// Same sub-field names as the struct above: this is exactly what
+				// the qualification exists to keep apart.
+				{FieldID: 143, Name: "chunk_number", DataType: backuppb.DataType_Int64},
+				{FieldID: 145, Name: "chunk_vector", DataType: backuppb.DataType_FloatVector},
+			},
+		},
+	}
+
+	got, err := StructArrayFields(bak)
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+
+	names := make([]string, 0, 4)
+	for _, s := range got {
+		for _, f := range s.GetFields() {
+			names = append(names, f.GetName())
+		}
+	}
+	assert.Equal(t, []string{
+		"duplicate_radar_struct[chunk_number]",
+		"duplicate_radar_struct[chunk_vector]",
+		"title_struct[chunk_number]",
+		"title_struct[chunk_vector]",
+	}, names)
+
+	// The struct's own name is not qualified, and field ids are untouched.
+	assert.Equal(t, "duplicate_radar_struct", got[0].GetName())
+	assert.EqualValues(t, 141, got[0].GetFields()[1].GetFieldID())
+}
+
+// A backup taken from a source that already carries qualified names must not be
+// qualified twice.
+func TestStructArrayFieldsQualificationIsIdempotent(t *testing.T) {
+	bak := []*backuppb.StructArrayFieldSchema{
+		{
+			FieldID: 138,
+			Name:    "duplicate_radar_struct",
+			Fields: []*backuppb.FieldSchema{
+				{FieldID: 141, Name: "duplicate_radar_struct[chunk_vector]"},
+			},
+		},
+	}
+
+	got, err := StructArrayFields(bak)
+	assert.NoError(t, err)
+	assert.Equal(t, "duplicate_radar_struct[chunk_vector]", got[0].GetFields()[0].GetName())
+}


### PR DESCRIPTION
Milvus stores a struct array's sub-fields under `struct[sub]` so that the same sub-field name may appear in more than one struct, and the proxy is what applies that on create. `DescribeCollection` hands the bare name back, and that is where a backup's schema comes from. A secondary restore injects the create straight into the WAL, bypassing the proxy, so the bare names went in unchanged.

Read from etcd, the same collection on source and target:

```
source  duplicate_radar_struct[chunk_number]  duplicate_radar_struct[chunk_vector]
target  chunk_number                          chunk_vector
```

Nothing reports an error; the restore succeeds and leaves the collection subtly wrong. On the target a search naming the field as `struct[sub]` does not resolve it, and two structs sharing a sub-field name — `chunk_number` under both `duplicate_radar_struct` and `title_struct` in the schema that surfaced this — collide, which is the collision the qualification exists to prevent. Neither is visible until a failover promotes the secondary.

## Change

`conv.StructArrayFields` qualifies each sub-field name as `struct[sub]`, idempotently, so a backup that already carries qualified names is left alone.

`conv.Schema` is used only by the secondary restore (`coll_ddl_task.go`, `coll_dml_task.go`). The regular restore builds its own `schemapb.CollectionSchema` and creates through the proxy, which qualifies on its own, so it is unaffected — verified by checking every caller of `conv.StructArrayFields` / `conv.Fields`.

## Verified

End to end against a collection built to match the field case (struct array with `chunk_number` + `chunk_vector` sub-fields, `MAX_SIM_COSINE` index on the vector), reading `meta/root-coord/struct-array-fields/<coll>/<id>` from etcd on both clusters:

| | before | after |
|---|---|---|
| target record | 120 bytes, `chunk_number` / `chunk_vector` | 168 bytes, byte-identical to the source |

Restore completes, row count matches, both indexes `Finished` on the target.

## Tests

- two structs sharing sub-field names: all four names qualified under their own struct, struct names and field ids untouched
- already-qualified input is left alone

## Related

- Server side: milvus-io/milvus#53084 / milvus-io/milvus#53085 (qualify at the replicate ingress). This producer-side fix is needed regardless: existing servers do not have that guard, and the tool is the one sending the wrong shape.
- #1167 describes a `FieldID 0` case that #1175 has since made unreachable (a secondary restore without index extra is refused up front); it can be closed.
