### PR TITLE
storage: rename azure DeleteObject param prefix to key

### DIFF
--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -416,8 +416,8 @@ func (a *AzureClient) listPrefixNonRecursive(prefix string) (*AzureObjectHierarc
 	}}, nil
 }
 
-func (a *AzureClient) DeleteObject(ctx context.Context, prefix string) error {
-	if _, err := a.cli.DeleteBlob(ctx, a.cfg.Bucket, prefix, nil); err != nil {
+func (a *AzureClient) DeleteObject(ctx context.Context, key string) error {
+	if _, err := a.cli.DeleteBlob(ctx, a.cfg.Bucket, key, nil); err != nil {
 		return fmt.Errorf("storage: azure delete blob %w", err)
 	}
 


### PR DESCRIPTION
/kind improvement

`AzureClient.DeleteObject` deletes a single object, but its parameter was named `prefix`, unlike the other `Client` implementations (minio / local / gcp native) which all use `key`. Renamed to `key` to match the interface — no behavior change.