### PR TITLE
app: extract the get backup and get backup task usecases

### DIFF
--- a/app/get_backup.go
+++ b/app/get_backup.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/meta"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+)
+
+// ErrBackupNotFound reports a selector with no artifact behind it. Callers
+// that merge the artifact with the job half (the v1 get_backup contract) use
+// it to tell "no backup persisted yet" apart from a storage failure.
+var ErrBackupNotFound = errors.New("backup not found")
+
+// GetBackup reads one backup artifact: the persisted meta in the backup
+// storage. The job that produced it is a different resource with its own
+// usecase, GetBackupTask — the two are read separately so transports with a
+// split API (v2) map one endpoint to one usecase, and a transport with a
+// merged contract (v1) does the merging itself.
+type GetBackup struct {
+	cli      storage.Client
+	rootPath string
+}
+
+// NewGetBackup builds the usecase from config, creating the backup storage
+// client itself so the transports never import internal/storage. The client
+// is created per call; sharing one across calls is a lifecycle decision this
+// layer deliberately does not make.
+func NewGetBackup(ctx context.Context, params *v2.Config) (*GetBackup, error) {
+	cli, err := storage.NewBackupStorage(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("app: %w", err)
+	}
+
+	return &GetBackup{
+		cli:      cli,
+		rootPath: params.Backup.Storage.RootPath.Val,
+	}, nil
+}
+
+// Execute returns the persisted meta of the named backup and the size of its
+// meta dir. A name with nothing behind it is ErrBackupNotFound, not a silent
+// success: an in-flight job that has persisted nothing yet is answered
+// through GetBackupTask, not here.
+func (uc *GetBackup) Execute(ctx context.Context, name string) (*backuppb.BackupInfo, int64, error) {
+	if name == "" {
+		return nil, 0, fmt.Errorf("app: empty backup name")
+	}
+
+	backupDir := mpath.BackupDir(uc.rootPath, name)
+	exist, err := meta.Exist(ctx, uc.cli, backupDir)
+	if err != nil {
+		return nil, 0, fmt.Errorf("app: check backup exist %w", err)
+	}
+	if !exist {
+		return nil, 0, fmt.Errorf("app: backup %s: %w", name, ErrBackupNotFound)
+	}
+
+	metaInfo, err := meta.Read(ctx, uc.cli, backupDir)
+	if err != nil {
+		return nil, 0, fmt.Errorf("app: read backup meta %w", err)
+	}
+
+	metaSize, err := storage.Size(ctx, uc.cli, mpath.MetaDir(backupDir))
+	if err != nil {
+		return nil, 0, fmt.Errorf("app: get meta size %w", err)
+	}
+
+	return metaInfo, metaSize, nil
+}

--- a/app/get_backup_task.go
+++ b/app/get_backup_task.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// GetBackupTask reads the state of one backup job. The job half of a backup
+// lives only in the task manager, so like its sister GetRestore this usecase
+// never touches storage, there is nothing to construct and construction
+// cannot fail.
+type GetBackupTask struct {
+	taskMgr *taskmgr.Mgr
+}
+
+// NewGetBackupTask builds the usecase on the given task manager; the server
+// wiring passes the process-local one. That manager's state dies with the
+// process — an artifact whose creating process has restarted has no job half
+// anymore and is read through GetBackup alone.
+func NewGetBackupTask(taskMgr *taskmgr.Mgr) *GetBackupTask {
+	return &GetBackupTask{taskMgr: taskMgr}
+}
+
+// GetBackupTaskRequest selects the job to read. Name and ID are alternative
+// selectors; the ID wins when both are set, because only the ID can pin down
+// one of several jobs that shared the name.
+type GetBackupTaskRequest struct {
+	Name string
+	ID   string
+}
+
+// Execute returns the task manager's view of the selected job. An unknown
+// selector is taskmgr.ErrTaskNotFound, not a silent success. The task
+// manager's own view type travels unchanged, as in GetRestore: an app-defined
+// struct would only rename it.
+func (uc *GetBackupTask) Execute(ctx context.Context, req GetBackupTaskRequest) (taskmgr.BackupTaskView, error) {
+	if req.Name == "" && req.ID == "" {
+		return nil, fmt.Errorf("app: empty backup name and backup id")
+	}
+
+	if req.ID != "" {
+		task, err := uc.taskMgr.GetBackupTask(req.ID)
+		if err != nil {
+			return nil, fmt.Errorf("app: get backup task %w", err)
+		}
+		return task, nil
+	}
+
+	task, err := uc.taskMgr.GetBackupTaskByName(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("app: get backup task %w", err)
+	}
+	return task, nil
+}

--- a/app/get_backup_task_test.go
+++ b/app/get_backup_task_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+func TestGetBackupTaskExecute(t *testing.T) {
+	t.Run("ByName", func(t *testing.T) {
+		mgr := taskmgr.NewMgr()
+		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
+
+		uc := NewGetBackupTask(mgr)
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{Name: "backup1"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "task-1", task.ID())
+		assert.Equal(t, "backup1", task.Name())
+	})
+
+	t.Run("ByID", func(t *testing.T) {
+		mgr := taskmgr.NewMgr()
+		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
+
+		uc := NewGetBackupTask(mgr)
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{ID: "task-1"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "task-1", task.ID())
+	})
+
+	t.Run("IDWinsOverName", func(t *testing.T) {
+		mgr := taskmgr.NewMgr()
+		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
+		require.NoError(t, mgr.AddBackupTask("task-2", "backup2"))
+
+		uc := NewGetBackupTask(mgr)
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{ID: "task-1", Name: "backup2"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "task-1", task.ID())
+		assert.Equal(t, "backup1", task.Name())
+	})
+
+	t.Run("UnknownNameIsTaskNotFound", func(t *testing.T) {
+		uc := NewGetBackupTask(taskmgr.NewMgr())
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{Name: "backup1"})
+
+		assert.Nil(t, task)
+		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
+	})
+
+	t.Run("UnknownIDIsTaskNotFound", func(t *testing.T) {
+		uc := NewGetBackupTask(taskmgr.NewMgr())
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{ID: "task-1"})
+
+		assert.Nil(t, task)
+		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
+	})
+
+	t.Run("RejectsEmptyNameAndID", func(t *testing.T) {
+		uc := NewGetBackupTask(taskmgr.NewMgr())
+		task, err := uc.Execute(context.Background(), GetBackupTaskRequest{})
+
+		assert.Nil(t, task)
+		assert.Error(t, err)
+	})
+}

--- a/app/get_backup_test.go
+++ b/app/get_backup_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+)
+
+// expectMetaExist teaches the mock client whether the backup dir has a meta
+// at all: the exist check lists the backup_meta.json key.
+func expectMetaExist(t *testing.T, cli *storage.MockClient, backupDir string, exist bool) {
+	t.Helper()
+
+	var iter *storage.MockObjectIterator
+	if exist {
+		iter = storage.NewMockObjectIterator([]storage.ObjectAttr{
+			{Key: backupDir + "/meta/backup_meta.json"},
+		})
+	} else {
+		iter = storage.NewMockObjectIterator(nil)
+	}
+	cli.EXPECT().ListPrefix(mock.Anything, backupDir+"/meta/backup_meta.json", false).Return(iter, nil)
+}
+
+// expectMetaSize teaches the mock client to answer the meta dir size probe.
+func expectMetaSize(t *testing.T, cli *storage.MockClient, backupDir string, size int64) {
+	t.Helper()
+
+	iter := storage.NewMockObjectIterator([]storage.ObjectAttr{
+		{Key: backupDir + "/meta/full_meta.json", Length: size},
+	})
+	cli.EXPECT().ListPrefix(mock.Anything, backupDir+"/meta/", true).Return(iter, nil)
+}
+
+// expectReadableBackup teaches the mock client the whole read of one backup:
+// meta exists, meta is readable, meta dir has a size.
+func expectReadableBackup(t *testing.T, cli *storage.MockClient, rootPath, name string, size int64) {
+	t.Helper()
+
+	backupDir := rootPath + "/" + name
+	expectMetaExist(t, cli, backupDir, true)
+	expectFullMeta(t, cli, backupDir, &backuppb.BackupInfo{Name: name, Size: size})
+	expectMetaSize(t, cli, backupDir, size)
+}
+
+func TestGetBackupExecute(t *testing.T) {
+	t.Run("ReadsMeta", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		expectReadableBackup(t, cli, "root", "backup1", 100)
+
+		uc := &GetBackup{cli: cli, rootPath: "root"}
+		info, metaSize, err := uc.Execute(context.Background(), "backup1")
+
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "backup1", info.GetName())
+		assert.Equal(t, int64(100), metaSize)
+	})
+
+	t.Run("NameWithNothingBehindItIsNotFound", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		expectMetaExist(t, cli, "root/backup1", false)
+
+		uc := &GetBackup{cli: cli, rootPath: "root"}
+		info, metaSize, err := uc.Execute(context.Background(), "backup1")
+
+		assert.Nil(t, info)
+		assert.Zero(t, metaSize)
+		assert.ErrorIs(t, err, ErrBackupNotFound)
+		assert.Contains(t, err.Error(), "backup1")
+	})
+
+	t.Run("RejectsEmptyName", func(t *testing.T) {
+		uc := &GetBackup{cli: storage.NewMockClient(t), rootPath: "root"}
+		info, _, err := uc.Execute(context.Background(), "")
+
+		assert.Nil(t, info)
+		assert.Error(t, err)
+	})
+
+	t.Run("FailsWhenExistCheckFails", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "root/backup1/meta/backup_meta.json", false).
+			Return(nil, errors.New("connection closed"))
+
+		uc := &GetBackup{cli: cli, rootPath: "root"}
+		info, _, err := uc.Execute(context.Background(), "backup1")
+
+		assert.Nil(t, info)
+		assert.Error(t, err)
+	})
+
+	t.Run("FailsWhenSizeProbeFails", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		backupDir := "root/backup1"
+		expectMetaExist(t, cli, backupDir, true)
+		expectFullMeta(t, cli, backupDir, &backuppb.BackupInfo{Name: "backup1"})
+		cli.EXPECT().
+			ListPrefix(mock.Anything, backupDir+"/meta/", true).
+			Return(nil, errors.New("connection closed"))
+
+		uc := &GetBackup{cli: cli, rootPath: "root"}
+		info, _, err := uc.Execute(context.Background(), "backup1")
+
+		assert.Nil(t, info)
+		assert.Error(t, err)
+	})
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -7,13 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
-	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 )
 
 // removedFlags are the get flags dropped in 0.6.
@@ -41,23 +39,19 @@ func (o *options) validate() error {
 func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	ctx := context.Background()
 
-	backupStorage, err := storage.NewBackupStorage(ctx, params)
+	uc, err := app.NewGetBackup(ctx, params)
 	if err != nil {
-		return fmt.Errorf("create backup storage: %w", err)
+		return fmt.Errorf("cmd: create get backup usecase %w", err)
 	}
 
-	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
-	backupInfo, err := meta.Read(ctx, backupStorage, backupDir)
+	// The job half is server-process state; a CLI invocation shares no
+	// process with the server, so there is never a task to overlay.
+	info, metaSize, err := uc.Execute(ctx, o.backupName)
 	if err != nil {
-		return fmt.Errorf("read backup meta: %w", err)
+		return fmt.Errorf("cmd: get backup %w", err)
 	}
 
-	metaSize, err := storage.Size(ctx, backupStorage, mpath.MetaDir(backupDir))
-	if err != nil {
-		return fmt.Errorf("get meta size: %w", err)
-	}
-
-	brief := pbconv.NewBackupInfoBrief(nil, backupInfo, metaSize)
+	brief := pbconv.NewBackupInfoBrief(nil, info, metaSize)
 	output, err := json.MarshalIndent(brief, "", "    ")
 	if err != nil {
 		return fmt.Errorf("fail to marshal backup info: %w", err)

--- a/core/server/get_backup.go
+++ b/core/server/get_backup.go
@@ -3,23 +3,32 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
-// RestoreBackup Get backup interface
+// getBackupUC is the slice of app.GetBackup the handler needs. The consumer
+// defines it: app returns concrete types, and this narrow interface is what
+// handler tests stub out.
+type getBackupUC interface {
+	Execute(ctx context.Context, name string) (*backuppb.BackupInfo, int64, error)
+}
+
+// getBackupTaskUC is the job-half counterpart of getBackupUC, the slice of
+// app.GetBackupTask the handler needs.
+type getBackupTaskUC interface {
+	Execute(ctx context.Context, req app.GetBackupTaskRequest) (taskmgr.BackupTaskView, error)
+}
+
+// Get backup Get backup interface
 // @Summary Get backup interface
 // @Description Get the backup with the given name or id
 // @Tags Backup
@@ -29,173 +38,133 @@ import (
 // @Param backup_id query string false "backup_id"
 // @Success 200 {object} backuppb.BackupInfoResponse
 // @Router /get_backup [get]
+//
+// handleGetBackup serves the v1 contract, which merges the two resource
+// halves into one response: the persisted artifact read through GetBackup and
+// the ephemeral job read through GetBackupTask. The app layer keeps the two
+// separate on purpose; the merge rules below are v1's wire contract, not a
+// property of either resource.
 func (s *Server) handleGetBackup(c *gin.Context) {
-	request := &backuppb.GetBackupRequest{
-		RequestId:  c.GetHeader("request_id"),
-		BackupName: c.Query("backup_name"),
-		BackupId:   c.Query("backup_id"),
-		Path:       c.Query("path"),
+	requestID := c.GetHeader("request_id")
+	if requestID == "" {
+		requestID = uuid.NewString()
 	}
 
-	log.Info("receive get backup request", zap.Any("request", request))
+	name := c.Query("backup_name")
+	id := c.Query("backup_id")
+	path := c.Query("path")
+	log.Info("receive get backup request",
+		zap.String("backup_name", name), zap.String("backup_id", id), zap.String("path", path))
 
-	h := newGetBackupHandler(request, s.params)
-	resp := h.get(c.Request.Context())
+	resp := &backuppb.BackupInfoResponse{RequestId: requestID}
+	if name == "" && id == "" {
+		resp.Code = backuppb.ResponseCode_Parameter_Error
+		resp.Msg = "server: empty backup name and backup id, please set a backup name or id"
+		writeResponse(c, "get backup fail", resp)
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	taskUC, err := s.config.newGetBackupTask()
+	if err != nil {
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		writeResponse(c, "get backup fail", resp)
+		return
+	}
+	// The v1 path parameter asks for a different backup location for this
+	// call. That is a config override, not a selector: fork the loaded config
+	// with it as one more override layer, keeping the request itself
+	// selector-only. The fork is reload-equivalent, so unset backup.storage
+	// leaves still cascade from milvus.storage, and the server's own config
+	// is never mutated.
+	params := s.params
+	if path != "" {
+		params, err = params.Fork(map[string]string{"backup.storage.rootPath": path})
+		if err != nil {
+			resp.Code = backuppb.ResponseCode_Fail
+			resp.Msg = err.Error()
+			writeResponse(c, "get backup fail", resp)
+			return
+		}
+	}
+	backupUC, err := s.config.newGetBackup(ctx, params)
+	if err != nil {
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		writeResponse(c, "get backup fail", resp)
+		return
+	}
+
+	// The job half. An ID selects the job directly and resolves the backup
+	// name through it; an unknown ID has nothing to fall back to. A name only
+	// probes for a job — most backups outlive their creating process, so a
+	// miss is the common case, not an error.
+	var task taskmgr.BackupTaskView
+	if id != "" {
+		task, err = taskUC.Execute(ctx, app.GetBackupTaskRequest{ID: id})
+		if err != nil {
+			resp.Code = backuppb.ResponseCode_Fail
+			resp.Msg = err.Error()
+			writeResponse(c, "get backup fail", resp)
+			return
+		}
+		name = task.Name()
+	} else {
+		task, err = taskUC.Execute(ctx, app.GetBackupTaskRequest{Name: name})
+		switch {
+		case err == nil:
+		case errors.Is(err, taskmgr.ErrTaskNotFound):
+			task = nil
+		default:
+			resp.Code = backuppb.ResponseCode_Fail
+			resp.Msg = err.Error()
+			writeResponse(c, "get backup fail", resp)
+			return
+		}
+	}
+
+	// The artifact half. A miss is not an error either while the job is
+	// still in flight and has persisted nothing yet.
+	metaInfo, metaSize, err := backupUC.Execute(ctx, name)
+	switch {
+	case err == nil:
+	case errors.Is(err, app.ErrBackupNotFound):
+		metaInfo, metaSize = nil, 0
+	default:
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		writeResponse(c, "get backup fail", resp)
+		return
+	}
+
+	// The merge: the artifact is the source of truth, the job overlays
+	// progress. A job that reports success while its artifact is missing is
+	// an error — the backup it claims to have produced is gone. A selector
+	// with neither half behind it is not found, not success with zeros.
+	switch {
+	case metaInfo != nil:
+		// The artifact is the answer; the job, when known, overlays progress.
+	case task != nil && task.StateCode() == backuppb.BackupTaskStateCode_BACKUP_SUCCESS:
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = "server: backup task " + name + " reports success but its meta is missing"
+		writeResponse(c, "get backup fail", resp)
+		return
+	case task != nil:
+		// An in-flight or failed job that has persisted nothing yet: the
+		// job view alone is the answer.
+	default:
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = "server: backup " + name + " not found"
+		writeResponse(c, "get backup fail", resp)
+		return
+	}
+
+	resp.Code = backuppb.ResponseCode_Success
+	resp.Msg = "success"
+	resp.Data = pbconv.NewBackupInfoBrief(task, metaInfo, metaSize)
 
 	log.Info("response get backup response", zap.Any("resp", resp))
 	writeResponse(c, "get backup fail", resp)
-}
-
-type getBackupHandler struct {
-	request *backuppb.GetBackupRequest
-
-	taskMgr *taskmgr.Mgr
-
-	params *v2.Config
-
-	backupStorage storage.Client
-}
-
-func newGetBackupHandler(request *backuppb.GetBackupRequest, params *v2.Config) *getBackupHandler {
-	return &getBackupHandler{request: request, params: params, taskMgr: taskmgr.DefaultMgr()}
-}
-
-func (h *getBackupHandler) complete() {
-	if h.request.GetRequestId() == "" {
-		h.request.RequestId = uuid.NewString()
-	}
-}
-
-func (h *getBackupHandler) validate() error {
-	if h.request.GetBackupId() == "" && h.request.GetBackupName() == "" {
-		return fmt.Errorf("server: empty backup name and backup id, please set a backup name or id")
-	}
-
-	return nil
-}
-
-func (h *getBackupHandler) initClient(ctx context.Context) error {
-	cli, err := storage.NewBackupStorage(ctx, h.params)
-	if err != nil {
-		return fmt.Errorf("server: init backup storage client %w", err)
-	}
-	h.backupStorage = cli
-
-	return nil
-}
-
-func (h *getBackupHandler) getByName(ctx context.Context, backupName string) (*backuppb.BackupInfoBrief, error) {
-	// get task view from task manager
-	task, err := h.taskMgr.GetBackupTaskByName(backupName)
-	if err != nil && !errors.Is(err, taskmgr.ErrTaskNotFound) {
-		return nil, fmt.Errorf("server: get backup task %w", err)
-	}
-
-	var backup *backuppb.BackupInfo
-	var metaSize int64
-
-	if task != nil && task.StateCode() == backuppb.BackupTaskStateCode_BACKUP_SUCCESS {
-		// get backup meta from storage
-		backup, metaSize, err = h.readFromStorage(ctx, backupName)
-		if err != nil {
-			return nil, fmt.Errorf("server: get backup by name %w", err)
-		}
-	}
-
-	return pbconv.NewBackupInfoBrief(task, backup, metaSize), nil
-}
-
-func (h *getBackupHandler) get(ctx context.Context) *backuppb.BackupInfoResponse {
-	resp := &backuppb.BackupInfoResponse{RequestId: h.request.GetRequestId()}
-	if err := h.validate(); err != nil {
-		resp.Code = backuppb.ResponseCode_Parameter_Error
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	h.complete()
-
-	if err := h.initClient(ctx); err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	brief, err := h.getBrief(ctx)
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	resp.Data = brief
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "success"
-	return resp
-}
-
-func (h *getBackupHandler) readFromStorage(ctx context.Context, backupName string) (*backuppb.BackupInfo, int64, error) {
-	// get backup meta from storage
-	backupRootPath := h.params.Backup.Storage.RootPath.Val
-	if h.request.GetPath() != "" {
-		backupRootPath = h.request.GetPath()
-	}
-
-	backupDir := mpath.BackupDir(backupRootPath, backupName)
-	exist, err := meta.Exist(ctx, h.backupStorage, backupDir)
-	if err != nil {
-		return nil, 0, fmt.Errorf("server: check backup exist %w", err)
-	}
-	if !exist {
-		return nil, 0, fmt.Errorf("server: backup %s not found", backupName)
-	}
-
-	backup, err := meta.Read(ctx, h.backupStorage, backupDir)
-	if err != nil {
-		return nil, 0, fmt.Errorf("server: read backup meta %w", err)
-	}
-
-	metaSize, err := storage.Size(ctx, h.backupStorage, mpath.MetaDir(backupDir))
-	if err != nil {
-		return nil, 0, fmt.Errorf("server: get meta size %w", err)
-	}
-
-	return backup, metaSize, nil
-}
-
-func (h *getBackupHandler) getByID(ctx context.Context, backupID string) (*backuppb.BackupInfoBrief, error) {
-	// get task view from task manager
-	task, err := h.taskMgr.GetBackupTask(backupID)
-	if err != nil {
-		return nil, fmt.Errorf("server: get backup task %w", err)
-	}
-
-	var backup *backuppb.BackupInfo
-	var metaSize int64
-	if task.StateCode() == backuppb.BackupTaskStateCode_BACKUP_SUCCESS {
-		// get backup meta from storage
-		backupName := task.Name()
-		backup, metaSize, err = h.readFromStorage(ctx, backupName)
-		if err != nil {
-			return nil, fmt.Errorf("server: read backup meta %w", err)
-		}
-	}
-
-	return pbconv.NewBackupInfoBrief(task, backup, metaSize), nil
-}
-
-func (h *getBackupHandler) getBrief(ctx context.Context) (*backuppb.BackupInfoBrief, error) {
-	if h.request.GetBackupId() != "" {
-		brief, err := h.getByID(ctx, h.request.GetBackupId())
-		if err != nil {
-			return nil, fmt.Errorf("server: get backup by id %w", err)
-		}
-		return brief, nil
-	}
-
-	brief, err := h.getByName(ctx, h.request.GetBackupName())
-	if err != nil {
-		return nil, fmt.Errorf("server: get backup by name %w", err)
-	}
-	return brief, nil
 }

--- a/core/server/get_backup_test.go
+++ b/core/server/get_backup_test.go
@@ -1,0 +1,313 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/app"
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// stubGetBackup stands in for app.GetBackup: a canned artifact read, the
+// name it was called with, the params its constructor received, and a call
+// count so tests can assert whether the handler reached the action at all.
+type stubGetBackup struct {
+	name   string
+	params *v2.Config
+	info   *backuppb.BackupInfo
+	size   int64
+	err    error
+	calls  int
+}
+
+func (s *stubGetBackup) Execute(_ context.Context, name string) (*backuppb.BackupInfo, int64, error) {
+	s.name = name
+	s.calls++
+	return s.info, s.size, s.err
+}
+
+// stubGetBackupTask is the job-half counterpart of stubGetBackup, standing
+// in for app.GetBackupTask.
+type stubGetBackupTask struct {
+	req   app.GetBackupTaskRequest
+	view  taskmgr.BackupTaskView
+	err   error
+	calls int
+}
+
+func (s *stubGetBackupTask) Execute(_ context.Context, req app.GetBackupTaskRequest) (taskmgr.BackupTaskView, error) {
+	s.req = req
+	s.calls++
+	return s.view, s.err
+}
+
+// withGetBackup wires the stub as the artifact usecase. newErr simulates the
+// client-construction failure, which happens before any Execute call.
+func withGetBackup(stub *stubGetBackup, newErr error) Option {
+	return func(c *config) {
+		c.newGetBackup = func(_ context.Context, params *v2.Config) (getBackupUC, error) {
+			stub.params = params
+			return stub, newErr
+		}
+	}
+}
+
+// withGetBackupTask is the job-half counterpart of withGetBackup.
+func withGetBackupTask(stub *stubGetBackupTask, newErr error) Option {
+	return func(c *config) {
+		c.newGetBackupTask = func() (getBackupTaskUC, error) {
+			return stub, newErr
+		}
+	}
+}
+
+// noBackupTask wires the common post-restart case: no job is known for any
+// selector.
+func noBackupTask() Option {
+	return withGetBackupTask(&stubGetBackupTask{err: taskmgr.ErrTaskNotFound}, nil)
+}
+
+// newLoadedTestServer is the fork-capable counterpart of newListTestServer:
+// the params are Load'ed the way the real server's are, so a request can fork
+// them. A hand-built v2.New() has no source behind it, and Fork refuses one.
+func newLoadedTestServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+
+	params, err := v2.Load("", nil)
+	require.NoError(t, err)
+
+	s, err := New(params, opts...)
+	require.NoError(t, err)
+	gin.SetMode(gin.TestMode)
+
+	return s
+}
+
+// expectBriefRender teaches the mock job view the calls
+// pbconv.NewBackupInfoBrief makes when it renders a task half.
+func expectBriefRender(task *taskmgr.MockBackupTaskView, id, name string, state backuppb.BackupTaskStateCode) {
+	task.EXPECT().Name().Return(name)
+	task.EXPECT().ID().Return(id)
+	task.EXPECT().StateCode().Return(state)
+	task.EXPECT().ErrorMessage().Return("")
+	task.EXPECT().StartTime().Return(time.Now())
+	task.EXPECT().EndTime().Return(time.Now())
+	task.EXPECT().Progress().Return(int32(100))
+}
+
+func getBackup(t *testing.T, s *Server, query, requestID string) backuppb.BackupInfoResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/get_backup"+query, nil)
+	if requestID != "" {
+		req.Header.Set("request_id", requestID)
+	}
+	s.engine.ServeHTTP(w, req)
+
+	var resp backuppb.BackupInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	return resp
+}
+
+func TestHandleGetBackup(t *testing.T) {
+	t.Run("MergesArtifactAndJob", func(t *testing.T) {
+		task := taskmgr.NewMockBackupTaskView(t)
+		expectBriefRender(task, "task-1", "backup1", backuppb.BackupTaskStateCode_BACKUP_SUCCESS)
+
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1", Size: 100}, size: 42}
+		taskStub := &stubGetBackupTask{view: task}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(taskStub, nil))
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "success", resp.GetMsg())
+		brief := resp.GetData()
+		require.NotNil(t, brief)
+		assert.Equal(t, "backup1", brief.GetName())
+		assert.Equal(t, "task-1", brief.GetId())
+		assert.Equal(t, int64(100), brief.GetSize())
+		assert.Equal(t, int64(42), brief.GetMetaSize())
+		assert.Equal(t, backuppb.BackupTaskStateCode_BACKUP_SUCCESS, brief.GetStateCode())
+
+		assert.Equal(t, "backup1", backup.name)
+		assert.Equal(t, app.GetBackupTaskRequest{Name: "backup1"}, taskStub.req)
+	})
+
+	t.Run("PathParameterForksConfig", func(t *testing.T) {
+		// The v1 path parameter is applied as a config override, not sent
+		// through the selector-only request.
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		s := newLoadedTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1&path=other", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		require.NotNil(t, backup.params)
+		assert.Equal(t, "other", backup.params.Backup.Storage.RootPath.Val)
+		// The fork, not the server's own config, reaches the usecase.
+		assert.NotSame(t, s.params, backup.params)
+		// The server's own config stays on the default root path.
+		assert.Equal(t, "backup", s.params.Backup.Storage.RootPath.Val)
+	})
+
+	t.Run("ArtifactWithoutJob", func(t *testing.T) {
+		// The completed-backup-after-restart case: no job is known anymore,
+		// the artifact alone is the answer.
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1", Size: 100}, size: 42}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		brief := resp.GetData()
+		require.NotNil(t, brief)
+		assert.Equal(t, "backup1", brief.GetName())
+		assert.Equal(t, int64(100), brief.GetSize())
+		// No path parameter: the config travels to the usecase untouched.
+		assert.Same(t, s.params, backup.params)
+	})
+
+	t.Run("InFlightJobWithoutArtifact", func(t *testing.T) {
+		task := taskmgr.NewMockBackupTaskView(t)
+		// The same StateCode expectation serves both the handler's
+		// success check and the brief rendering.
+		expectBriefRender(task, "task-1", "backup1", backuppb.BackupTaskStateCode_BACKUP_EXECUTING)
+
+		backup := &stubGetBackup{err: app.ErrBackupNotFound}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(&stubGetBackupTask{view: task}, nil))
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		brief := resp.GetData()
+		require.NotNil(t, brief)
+		assert.Equal(t, "backup1", brief.GetName())
+		assert.Equal(t, backuppb.BackupTaskStateCode_BACKUP_EXECUTING, brief.GetStateCode())
+		assert.Zero(t, brief.GetSize())
+	})
+
+	t.Run("SuccessJobWithoutArtifactFails", func(t *testing.T) {
+		task := taskmgr.NewMockBackupTaskView(t)
+		task.EXPECT().StateCode().Return(backuppb.BackupTaskStateCode_BACKUP_SUCCESS)
+
+		backup := &stubGetBackup{err: app.ErrBackupNotFound}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(&stubGetBackupTask{view: task}, nil))
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "meta is missing")
+	})
+
+	t.Run("NeitherHalfExistsIsNotFound", func(t *testing.T) {
+		backup := &stubGetBackup{err: app.ErrBackupNotFound}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "backup1")
+		assert.Contains(t, resp.GetMsg(), "not found")
+	})
+
+	t.Run("IDResolvesBackupNameThroughJob", func(t *testing.T) {
+		task := taskmgr.NewMockBackupTaskView(t)
+		expectBriefRender(task, "task-1", "backup1", backuppb.BackupTaskStateCode_BACKUP_SUCCESS)
+
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		taskStub := &stubGetBackupTask{view: task}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(taskStub, nil))
+
+		resp := getBackup(t, s, "?backup_id=task-1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, app.GetBackupTaskRequest{ID: "task-1"}, taskStub.req)
+		assert.Equal(t, "backup1", backup.name)
+	})
+
+	t.Run("UnknownIDFailsWithoutReadingArtifact", func(t *testing.T) {
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_id=task-1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Zero(t, backup.calls)
+	})
+
+	t.Run("JobLookupFailureByNameFails", func(t *testing.T) {
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		taskStub := &stubGetBackupTask{err: errors.New("manager closed")}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(taskStub, nil))
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "manager closed")
+		assert.Zero(t, backup.calls)
+	})
+
+	t.Run("ArtifactReadFailureFails", func(t *testing.T) {
+		backup := &stubGetBackup{err: errors.New("connection closed")}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "connection closed")
+	})
+
+	t.Run("RejectsMissingNameAndIDWithoutCallingUsecases", func(t *testing.T) {
+		backup := &stubGetBackup{}
+		taskStub := &stubGetBackupTask{}
+		s := newListTestServer(t, withGetBackup(backup, nil), withGetBackupTask(taskStub, nil))
+
+		resp := getBackup(t, s, "", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "empty backup name and backup id")
+		assert.Zero(t, backup.calls)
+		assert.Zero(t, taskStub.calls)
+	})
+
+	t.Run("GeneratesRequestIdWhenMissing", func(t *testing.T) {
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.NotEmpty(t, resp.GetRequestId())
+	})
+
+	t.Run("ForwardsRequestId", func(t *testing.T) {
+		backup := &stubGetBackup{info: &backuppb.BackupInfo{Name: "backup1"}}
+		s := newListTestServer(t, withGetBackup(backup, nil), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "rid-1")
+
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+	})
+
+	t.Run("MapsArtifactConstructorErrorToFail", func(t *testing.T) {
+		s := newListTestServer(t, withGetBackup(&stubGetBackup{}, errors.New("dial timeout")), noBackupTask())
+
+		resp := getBackup(t, s, "?backup_name=backup1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "dial timeout")
+	})
+}

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -29,6 +29,15 @@ type config struct {
 
 	// newCheck is the check counterpart of newListBackups.
 	newCheck func(ctx context.Context, params *v2.Config) (checkUC, error)
+
+	// newGetBackup is the get counterpart of newListBackups.
+	newGetBackup func(ctx context.Context, params *v2.Config) (getBackupUC, error)
+
+	// newGetBackupTask is the get-backup-task counterpart of newGetRestore:
+	// job state is process-local, so there is no client to build and
+	// construction cannot fail. The error stays so the seam matches the
+	// other constructors.
+	newGetBackupTask func() (getBackupTaskUC, error)
 }
 
 func newDefaultConfig() *config {
@@ -47,6 +56,12 @@ func newDefaultConfig() *config {
 		},
 		newCheck: func(ctx context.Context, params *v2.Config) (checkUC, error) {
 			return app.NewCheck(ctx, params)
+		},
+		newGetBackup: func(ctx context.Context, params *v2.Config) (getBackupUC, error) {
+			return app.NewGetBackup(ctx, params)
+		},
+		newGetBackupTask: func() (getBackupTaskUC, error) {
+			return app.NewGetBackupTask(taskmgr.DefaultMgr()), nil
 		},
 	}
 }


### PR DESCRIPTION
Part of #1171
Fixes #890
Related to #742

## What

`app` gains two usecases where the server handler used to run one fused read:

- `GetBackup` reads the artifact half: the persisted meta in backup storage. `Execute(ctx, name)` takes the bare backup name — a lone selector needs no request struct, same as `GetRestore` — and returns the meta and the meta dir size; a name with nothing behind it is the new `ErrBackupNotFound` sentinel.
- `GetBackupTask` reads the job half: the task manager's view, mirroring `GetRestore`. `Execute(ctx, GetBackupTaskRequest{Name, ID})` — the ID wins when both are set, because only the ID can pin down one of several jobs that shared the name; an unknown selector is `taskmgr.ErrTaskNotFound`.

The two stay separate because they are two resources. v2's API splits "get backup" and "get backup task" into their own endpoints, and with this split each endpoint maps to exactly one usecase. The v1 `get_backup` contract merges both halves into one response, so the merge moves out of the app layer into the v1 handler:

- the artifact is the source of truth; the job overlays progress when one is known
- an in-flight or failed job that has persisted nothing yet answers with the job view alone
- a job that reports success while its artifact is missing is an error — the backup it claims to have produced is gone
- a selector with neither half behind it is an error, not success with zeros (#890)
- a completed backup queried after a restart returns its full payload (#742)

## Wiring

- usecase inputs carry selectors only; overriding where backups live is a config change, made on the `v2.Config` the usecase is built from. The v1 `path` query parameter follows that rule: the handler forks the loaded config with `backup.storage.rootPath` set to it before constructing `GetBackup`, instead of sending the path in as a call argument. The fork is reload-equivalent (#1215), so unset `backup.storage` leaves still cascade from `milvus.storage`, and the server's own config is never mutated.

- `NewGetBackup(ctx, params)` builds only the storage client; `NewGetBackupTask(taskMgr)` takes the process-local manager as a parameter, keeping `taskmgr.DefaultMgr()` out of the usecase layer. Job state needs no config and its construction cannot fail, same as `GetRestore`.
- the `get` CLI reads the artifact half only: a CLI invocation shares no process with the server, so there is never a job to overlay. It no longer imports `internal/taskmgr`, `internal/meta` or `internal/storage`.

## Tests

- `app/get_backup_test.go`: the artifact branches — meta read, not-found sentinel, path override, exist-check and size-probe failures
- `app/get_backup_task_test.go`: the job branches — by name, by ID, ID-wins-over-name, unknown selectors, empty request
- `core/server/get_backup_test.go`: httptest cases over the v1 merge contract — merged rendering, path parameter forks the config, artifact without job, in-flight job without artifact, success-job-without-artifact failure, neither-half not-found, ID-to-name resolution, parameter rejection before either usecase runs, request_id handling, constructor and read errors mapped to `Fail`


