### PR TITLE
app: extract the get restore usecase

### DIFF
--- a/app/get_restore.go
+++ b/app/get_restore.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// GetRestore reads the state of one restore job. Restore jobs keep all their
+// state in the task manager, so this is the thinnest usecase in the layer:
+// unlike its sister GetBackup it never touches storage, which also means
+// there is nothing to construct and construction cannot fail.
+type GetRestore struct {
+	taskMgr *taskmgr.Mgr
+}
+
+// NewGetRestore builds the usecase on the process-local task manager. The
+// manager's state dies with the process — the existing get_restore contract:
+// after a restart every task ID answers not-found.
+func NewGetRestore() *GetRestore {
+	return &GetRestore{taskMgr: taskmgr.DefaultMgr()}
+}
+
+// RestoreView is the job half alone. A restore has no artifact half of its
+// own — the backup a job produces is read through GetBackup — but it still
+// travels as an app-defined struct so transports never name the task
+// manager's types.
+type RestoreView struct {
+	Task taskmgr.RestoreTaskView
+}
+
+// Execute returns the task manager's view of the restore job with the given
+// ID. An unknown ID is an error, not a silent success.
+func (uc *GetRestore) Execute(ctx context.Context, id string) (RestoreView, error) {
+	taskView, err := uc.taskMgr.GetRestoreTask(id)
+	if err != nil {
+		return RestoreView{}, fmt.Errorf("app: get restore task %s: %w", id, err)
+	}
+
+	return RestoreView{Task: taskView}, nil
+}

--- a/app/get_restore.go
+++ b/app/get_restore.go
@@ -15,11 +15,12 @@ type GetRestore struct {
 	taskMgr *taskmgr.Mgr
 }
 
-// NewGetRestore builds the usecase on the process-local task manager. The
-// manager's state dies with the process — the existing get_restore contract:
-// after a restart every task ID answers not-found.
-func NewGetRestore() *GetRestore {
-	return &GetRestore{taskMgr: taskmgr.DefaultMgr()}
+// NewGetRestore builds the usecase on the given task manager; the server
+// wiring passes the process-local one. That manager's state dies with the
+// process — the existing get_restore contract: after a restart every task
+// ID answers not-found.
+func NewGetRestore(taskMgr *taskmgr.Mgr) *GetRestore {
+	return &GetRestore{taskMgr: taskMgr}
 }
 
 // RestoreView is the job half alone. A restore has no artifact half of its

--- a/app/get_restore.go
+++ b/app/get_restore.go
@@ -23,21 +23,16 @@ func NewGetRestore(taskMgr *taskmgr.Mgr) *GetRestore {
 	return &GetRestore{taskMgr: taskMgr}
 }
 
-// RestoreView is the job half alone. A restore has no artifact half of its
-// own — the backup a job produces is read through GetBackup — but it still
-// travels as an app-defined struct so transports never name the task
-// manager's types.
-type RestoreView struct {
-	Task taskmgr.RestoreTaskView
-}
-
 // Execute returns the task manager's view of the restore job with the given
-// ID. An unknown ID is an error, not a silent success.
-func (uc *GetRestore) Execute(ctx context.Context, id string) (RestoreView, error) {
+// ID. An unknown ID is an error, not a silent success. A restore has no
+// artifact half to merge — the backup a job produces is read through
+// GetBackup — so unlike GetBackup the task manager's own view type travels
+// unchanged; an app-defined struct would only rename it.
+func (uc *GetRestore) Execute(ctx context.Context, id string) (taskmgr.RestoreTaskView, error) {
 	taskView, err := uc.taskMgr.GetRestoreTask(id)
 	if err != nil {
-		return RestoreView{}, fmt.Errorf("app: get restore task %s: %w", id, err)
+		return nil, fmt.Errorf("app: get restore task %s: %w", id, err)
 	}
 
-	return RestoreView{Task: taskView}, nil
+	return taskView, nil
 }

--- a/app/get_restore_test.go
+++ b/app/get_restore_test.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+func TestGetRestoreExecute(t *testing.T) {
+	t.Run("ReturnsTaskViewForKnownID", func(t *testing.T) {
+		mgr := taskmgr.NewMgr()
+		mgr.AddRestoreTask("task-1")
+		mgr.UpdateRestoreTask("task-1", taskmgr.SetRestoreExecuting())
+
+		uc := &GetRestore{taskMgr: mgr}
+		view, err := uc.Execute(context.Background(), "task-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, "task-1", view.Task.ID())
+		assert.Equal(t, backuppb.RestoreTaskStateCode_EXECUTING, view.Task.StateCode())
+	})
+
+	t.Run("ErrorsForUnknownID", func(t *testing.T) {
+		// An empty manager: the process has restarted, every task is gone.
+		uc := &GetRestore{taskMgr: taskmgr.NewMgr()}
+		view, err := uc.Execute(context.Background(), "task-1")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
+		assert.Contains(t, err.Error(), "task-1")
+		assert.Nil(t, view.Task)
+	})
+}

--- a/app/get_restore_test.go
+++ b/app/get_restore_test.go
@@ -21,8 +21,8 @@ func TestGetRestoreExecute(t *testing.T) {
 		view, err := uc.Execute(context.Background(), "task-1")
 
 		require.NoError(t, err)
-		assert.Equal(t, "task-1", view.Task.ID())
-		assert.Equal(t, backuppb.RestoreTaskStateCode_EXECUTING, view.Task.StateCode())
+		assert.Equal(t, "task-1", view.ID())
+		assert.Equal(t, backuppb.RestoreTaskStateCode_EXECUTING, view.StateCode())
 	})
 
 	t.Run("ErrorsForUnknownID", func(t *testing.T) {
@@ -33,6 +33,6 @@ func TestGetRestoreExecute(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
 		assert.Contains(t, err.Error(), "task-1")
-		assert.Nil(t, view.Task)
+		assert.Nil(t, view)
 	})
 }

--- a/app/get_restore_test.go
+++ b/app/get_restore_test.go
@@ -17,7 +17,7 @@ func TestGetRestoreExecute(t *testing.T) {
 		mgr.AddRestoreTask("task-1")
 		mgr.UpdateRestoreTask("task-1", taskmgr.SetRestoreExecuting())
 
-		uc := &GetRestore{taskMgr: mgr}
+		uc := NewGetRestore(mgr)
 		view, err := uc.Execute(context.Background(), "task-1")
 
 		require.NoError(t, err)
@@ -27,7 +27,7 @@ func TestGetRestoreExecute(t *testing.T) {
 
 	t.Run("ErrorsForUnknownID", func(t *testing.T) {
 		// An empty manager: the process has restarted, every task is gone.
-		uc := &GetRestore{taskMgr: taskmgr.NewMgr()}
+		uc := NewGetRestore(taskmgr.NewMgr())
 		view, err := uc.Execute(context.Background(), "task-1")
 
 		require.Error(t, err)

--- a/core/server/get_restore.go
+++ b/core/server/get_restore.go
@@ -1,18 +1,24 @@
 package server
 
 import (
-	"errors"
-	"net/http"
+	"context"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
+
+// getRestoreUC is the slice of app.GetRestore the handler needs. The consumer
+// defines it: app returns concrete types, and this narrow interface is what
+// handler tests stub out.
+type getRestoreUC interface {
+	Execute(ctx context.Context, id string) (app.RestoreView, error)
+}
 
 // GetRestore Get restore interface
 // @Summary Get restore interface
@@ -24,38 +30,41 @@ import (
 // @Success 200 {object} backuppb.RestoreBackupResponse
 // @Router /get_restore [get]
 func (s *Server) handleGetRestore(c *gin.Context) {
-	req := &backuppb.GetRestoreStateRequest{RequestId: uuid.NewString()}
+	requestID := c.GetHeader("request_id")
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
+	id := c.Query("id")
+	log.Info("receive GetRestoreStateRequest", zap.String("id", id))
 
-	req.RequestId = c.GetHeader("request_id")
-	req.Id = c.Query("id")
-	log.Info("receive GetRestoreStateRequest", zap.Any("request", req))
+	resp := &backuppb.RestoreBackupResponse{RequestId: requestID}
 
-	resp := &backuppb.RestoreBackupResponse{RequestId: req.GetRequestId()}
-
-	if req.GetId() == "" {
+	if id == "" {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = "empty restore id"
-		c.JSON(http.StatusOK, resp)
+		writeResponse(c, "get restore fail", resp)
 		return
 	}
 
-	taskView, err := taskmgr.DefaultMgr().GetRestoreTask(req.GetId())
-	if err != nil && !errors.Is(err, taskmgr.ErrTaskNotFound) {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = "restore id not exist in task manager"
-		c.JSON(http.StatusOK, resp)
-		return
-	}
+	uc, err := s.config.newGetRestore()
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
-		c.JSON(http.StatusOK, resp)
+		writeResponse(c, "get restore fail", resp)
+		return
+	}
+
+	view, err := uc.Execute(c.Request.Context(), id)
+	if err != nil {
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		writeResponse(c, "get restore fail", resp)
 		return
 	}
 
 	resp.Code = backuppb.ResponseCode_Success
 	resp.Msg = "success"
-	resp.Data = pbconv.RestoreTaskViewToResp(taskView)
+	resp.Data = pbconv.RestoreTaskViewToResp(view.Task)
 	log.Info("End to GetRestoreStateRequest", zap.Any("resp", resp))
-	c.JSON(http.StatusOK, resp)
+	writeResponse(c, "get restore fail", resp)
 }

--- a/core/server/get_restore.go
+++ b/core/server/get_restore.go
@@ -7,17 +7,17 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/log"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // getRestoreUC is the slice of app.GetRestore the handler needs. The consumer
 // defines it: app returns concrete types, and this narrow interface is what
 // handler tests stub out.
 type getRestoreUC interface {
-	Execute(ctx context.Context, id string) (app.RestoreView, error)
+	Execute(ctx context.Context, id string) (taskmgr.RestoreTaskView, error)
 }
 
 // GetRestore Get restore interface
@@ -64,7 +64,7 @@ func (s *Server) handleGetRestore(c *gin.Context) {
 
 	resp.Code = backuppb.ResponseCode_Success
 	resp.Msg = "success"
-	resp.Data = pbconv.RestoreTaskViewToResp(view.Task)
+	resp.Data = pbconv.RestoreTaskViewToResp(view)
 	log.Info("End to GetRestoreStateRequest", zap.Any("resp", resp))
 	writeResponse(c, "get restore fail", resp)
 }

--- a/core/server/get_restore_test.go
+++ b/core/server/get_restore_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/app"
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// stubGetRestore stands in for app.GetRestore: a canned view, the id it was
+// called with, and a call count so tests can assert whether the handler
+// reached the action at all.
+type stubGetRestore struct {
+	id         string
+	view       app.RestoreView
+	executeErr error
+	calls      int
+}
+
+func (s *stubGetRestore) Execute(_ context.Context, id string) (app.RestoreView, error) {
+	s.id = id
+	s.calls++
+	return s.view, s.executeErr
+}
+
+// withGetRestore wires the stub as the get-restore usecase. newErr simulates
+// the construction failure, which happens before any Execute call.
+func withGetRestore(stub *stubGetRestore, newErr error) Option {
+	return func(c *config) {
+		c.newGetRestore = func() (getRestoreUC, error) {
+			return stub, newErr
+		}
+	}
+}
+
+func getRestore(t *testing.T, s *Server, query, requestID string) backuppb.RestoreBackupResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/get_restore"+query, nil)
+	if requestID != "" {
+		req.Header.Set("request_id", requestID)
+	}
+	s.engine.ServeHTTP(w, req)
+
+	var resp backuppb.RestoreBackupResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	return resp
+}
+
+// newRestoreTaskView returns a mock task view answering every read the v1
+// rendering makes.
+func newRestoreTaskView(t *testing.T) *taskmgr.MockRestoreTaskView {
+	t.Helper()
+
+	now := time.Now()
+	task := taskmgr.NewMockRestoreTaskView(t)
+	task.EXPECT().ID().Return("task-1")
+	task.EXPECT().StateCode().Return(backuppb.RestoreTaskStateCode_EXECUTING)
+	task.EXPECT().ErrorMessage().Return("coll1 fail")
+	task.EXPECT().StartTime().Return(now)
+	task.EXPECT().EndTime().Return(now)
+	task.EXPECT().Progress().Return(int32(42))
+	task.EXPECT().CollTasks().Return(nil)
+
+	return task
+}
+
+func TestHandleGetRestore(t *testing.T) {
+	t.Run("RendersTheTaskView", func(t *testing.T) {
+		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		s := newListTestServer(t, withGetRestore(stub, nil))
+
+		resp := getRestore(t, s, "?id=task-1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "success", resp.GetMsg())
+		data := resp.GetData()
+		require.NotNil(t, data)
+		assert.Equal(t, "task-1", data.GetId())
+		assert.Equal(t, backuppb.RestoreTaskStateCode_EXECUTING, data.GetStateCode())
+		assert.Equal(t, "coll1 fail", data.GetErrorMessage())
+		assert.Equal(t, int32(42), data.GetProgress())
+		assert.Equal(t, 1, stub.calls)
+		assert.Equal(t, "task-1", stub.id)
+	})
+
+	t.Run("RejectsEmptyIDWithoutCallingUsecase", func(t *testing.T) {
+		stub := &stubGetRestore{}
+		s := newListTestServer(t, withGetRestore(stub, nil))
+
+		resp := getRestore(t, s, "", "")
+
+		// The historical contract answers Fail here, not Parameter_Error.
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Equal(t, "empty restore id", resp.GetMsg())
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("GeneratesRequestIdWhenMissing", func(t *testing.T) {
+		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		s := newListTestServer(t, withGetRestore(stub, nil))
+
+		resp := getRestore(t, s, "?id=task-1", "")
+
+		assert.NotEmpty(t, resp.GetRequestId())
+	})
+
+	t.Run("ForwardsRequestId", func(t *testing.T) {
+		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		s := newListTestServer(t, withGetRestore(stub, nil))
+
+		resp := getRestore(t, s, "?id=task-1", "rid-1")
+
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+	})
+
+	t.Run("MapsConstructorErrorToFail", func(t *testing.T) {
+		s := newListTestServer(t, withGetRestore(&stubGetRestore{}, errors.New("dial timeout")))
+
+		resp := getRestore(t, s, "?id=task-1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "dial timeout")
+	})
+
+	t.Run("MapsExecuteErrorToFail", func(t *testing.T) {
+		stub := &stubGetRestore{
+			executeErr: fmt.Errorf("app: get restore task task-1: %w", taskmgr.ErrTaskNotFound),
+		}
+		s := newListTestServer(t, withGetRestore(stub, nil))
+
+		resp := getRestore(t, s, "?id=task-1", "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "task not found")
+		assert.Equal(t, 1, stub.calls)
+	})
+}

--- a/core/server/get_restore_test.go
+++ b/core/server/get_restore_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
@@ -23,12 +22,12 @@ import (
 // reached the action at all.
 type stubGetRestore struct {
 	id         string
-	view       app.RestoreView
+	view       taskmgr.RestoreTaskView
 	executeErr error
 	calls      int
 }
 
-func (s *stubGetRestore) Execute(_ context.Context, id string) (app.RestoreView, error) {
+func (s *stubGetRestore) Execute(_ context.Context, id string) (taskmgr.RestoreTaskView, error) {
 	s.id = id
 	s.calls++
 	return s.view, s.executeErr
@@ -80,7 +79,7 @@ func newRestoreTaskView(t *testing.T) *taskmgr.MockRestoreTaskView {
 
 func TestHandleGetRestore(t *testing.T) {
 	t.Run("RendersTheTaskView", func(t *testing.T) {
-		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		stub := &stubGetRestore{view: newRestoreTaskView(t)}
 		s := newListTestServer(t, withGetRestore(stub, nil))
 
 		resp := getRestore(t, s, "?id=task-1", "")
@@ -110,7 +109,7 @@ func TestHandleGetRestore(t *testing.T) {
 	})
 
 	t.Run("GeneratesRequestIdWhenMissing", func(t *testing.T) {
-		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		stub := &stubGetRestore{view: newRestoreTaskView(t)}
 		s := newListTestServer(t, withGetRestore(stub, nil))
 
 		resp := getRestore(t, s, "?id=task-1", "")
@@ -119,7 +118,7 @@ func TestHandleGetRestore(t *testing.T) {
 	})
 
 	t.Run("ForwardsRequestId", func(t *testing.T) {
-		stub := &stubGetRestore{view: app.RestoreView{Task: newRestoreTaskView(t)}}
+		stub := &stubGetRestore{view: newRestoreTaskView(t)}
 		s := newListTestServer(t, withGetRestore(stub, nil))
 
 		resp := getRestore(t, s, "?id=task-1", "rid-1")

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -19,6 +19,12 @@ type config struct {
 
 	// newDeleteBackup is the delete counterpart of newListBackups.
 	newDeleteBackup func(ctx context.Context, params *v2.Config) (deleteBackupUC, error)
+
+	// newGetRestore is the get-restore counterpart of newListBackups. It
+	// takes no config: restore state is process-local, so there is no client
+	// to build and construction cannot fail. The error stays so the seam
+	// matches the other constructors.
+	newGetRestore func() (getRestoreUC, error)
 }
 
 func newDefaultConfig() *config {
@@ -31,6 +37,9 @@ func newDefaultConfig() *config {
 		},
 		newDeleteBackup: func(ctx context.Context, params *v2.Config) (deleteBackupUC, error) {
 			return app.NewDeleteBackup(ctx, params)
+		},
+		newGetRestore: func() (getRestoreUC, error) {
+			return app.NewGetRestore(), nil
 		},
 	}
 }

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zilliztech/milvus-backup/app"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // Config for setting params used by server.
@@ -39,7 +40,7 @@ func newDefaultConfig() *config {
 			return app.NewDeleteBackup(ctx, params)
 		},
 		newGetRestore: func() (getRestoreUC, error) {
-			return app.NewGetRestore(), nil
+			return app.NewGetRestore(taskmgr.DefaultMgr()), nil
 		},
 	}
 }


### PR DESCRIPTION
Part of #1171.

## What

`core/app` gains the `GetRestore` usecase: one struct holding only the task manager, with `Execute(ctx, id)` as the transport-neutral action — the shape #1171 sketches for it ("takes only the task manager and never touches storage"), and the thinnest usecase in the layer so far. Construction cannot fail, so unlike its siblings `NewGetRestore` takes no config and returns no error.

The `/api/v1/get_restore` handler narrows to request conversion, the usecase call, v1 rendering through `pbconv.RestoreTaskViewToResp`, and error-to-code mapping, through a `newGetRestore` constructor hook on the server config that tests stub out — the same seam list got in #1182 and delete in #1200.

- `Execute` returns the task manager's `RestoreTaskView` directly, with no app-defined wrapper: a restore has no artifact half to merge (the backup a job produces is read through GetBackup), so unlike #1203's `BackupView` a view struct would only rename the type
- `NewGetRestore` takes the task manager as a parameter instead of reading `taskmgr.DefaultMgr()` itself; the server wiring passes the process-local manager, keeping the global reference out of the usecase layer
- overlap with the open #1203 is kept minimal on purpose: `cmd/` is untouched (get_restore has no CLI path — the get_backup CLI is #1203's file), so the only shared file is `core/server/option.go`, where both PRs each add one field plus one default, a mechanical conflict

## Semantics unchanged

Request handling keeps the historical contract exactly: request_id defaults to the header value or a fresh UUID, an empty id answers `Fail` with "empty restore id" (deliberately not `Parameter_Error`), an unknown task ID is an error mapped to `Fail` rather than a silent success, and success renders the same `RestoreBackupResponse` payload as before.

Responses now go through `writeResponse` like the sibling handlers; the wire shape and status are identical, the difference is that failures are now also logged server-side.

One pre-existing oddity recorded here rather than fixed: the old handler's two error branches had their messages swapped — a non-not-found error answered the hardcoded "restore id not exist in task manager", while a not-found error answered with its own text. `Mgr.GetRestoreTask` can only return `ErrTaskNotFound` or nil, so the "other error" branch was unreachable dead code and folds away; the reachable not-found path still answers `Fail` with the error text, now carrying the `app: get restore task <id>:` prefix the layer's error convention adds.

## Tests

- `app/get_restore_test.go`: a known ID returns the task view; an unknown ID (the post-restart case) errors wrapping `taskmgr.ErrTaskNotFound`
- `core/server/get_restore_test.go`: httptest cases over the handler contract — renders the view through the v1 shape, empty id rejected with `Fail` before the usecase runs, request_id generated and forwarded, constructor and execute errors mapped to `Fail`

