### PR TITLE
app: extract the create backup usecase

### DIFF
--- a/app/create.go
+++ b/app/create.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zilliztech/milvus-backup/core/backup"
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/meta"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// BackupJob is one registered create-backup run, ready to execute. Starting a
+// job and running it are separate steps so a transport that executes jobs
+// asynchronously can decide itself where the goroutine goes.
+type BackupJob interface {
+	// Run executes the job. The outcome is also recorded in the task manager,
+	// where get_backup and the task API read it from.
+	Run(ctx context.Context) error
+}
+
+// CreateBackup starts one backup job that writes an artifact into the backup
+// storage, copying from the milvus storage.
+type CreateBackup struct {
+	params *v2.Config
+
+	milvusStorage storage.Client
+	backupStorage storage.Client
+
+	taskMgr  *taskmgr.Mgr
+	rootPath string
+}
+
+// NewCreateBackup builds the usecase from config, creating both storage
+// clients itself so the transports never import internal/storage. The clients
+// are created per call; sharing them across calls is a lifecycle decision
+// this layer deliberately does not make.
+func NewCreateBackup(ctx context.Context, params *v2.Config) (*CreateBackup, error) {
+	backupStorage, err := storage.NewBackupStorage(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("app: %w", err)
+	}
+
+	milvusStorage, err := storage.NewMilvusStorage(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("app: %w", err)
+	}
+
+	return &CreateBackup{
+		params:        params,
+		milvusStorage: milvusStorage,
+		backupStorage: backupStorage,
+		taskMgr:       taskmgr.DefaultMgr(),
+		rootPath:      params.Backup.Storage.RootPath.Val,
+	}, nil
+}
+
+// CreateBackupRequest describes one backup job. It is the transport-neutral
+// whole of what the action accepts: both transports derive the task id from
+// their request-id conventions and parse their own input format into Option
+// before calling.
+type CreateBackupRequest struct {
+	// TaskID is the id the job registers under in the task manager.
+	TaskID string
+
+	// RootPath overrides the configured backup root path. Empty keeps the
+	// configured one.
+	RootPath string
+
+	// Option carries the parsed backup parameters: the artifact name the job
+	// registers under, strategy, format, collection filter, GC pause and the
+	// like. Option.BackupName is also the key the job is visible under to
+	// the task APIs, so it must be the one name the transport validated.
+	Option backup.Option
+}
+
+// BackupView keeps the two resource halves separate. Merging them is a
+// rendering decision of the transport, not a property of the action.
+type BackupView struct {
+	// Task is the job half; always known here, the job was just registered.
+	Task taskmgr.BackupTaskView
+	// Meta is the artifact half; non-nil once the job has written it.
+	Meta     *backuppb.BackupInfo
+	MetaSize int64
+}
+
+// Start registers the job in the task manager and returns it ready to run.
+// Registration is the synchronous part of starting: from here on the job is
+// visible to the task APIs under its task id and backup name. Running is a
+// separate step — Execute for the synchronous case, the transport's own
+// goroutine for the asynchronous one.
+func (uc *CreateBackup) Start(req CreateBackupRequest) (BackupJob, error) {
+	task, err := backup.NewTask(uc.toArgs(req))
+	if err != nil {
+		return nil, fmt.Errorf("app: new backup task: %w", err)
+	}
+
+	return backupJob{task: task}, nil
+}
+
+// Execute runs the job synchronously on the calling goroutine and returns the
+// view of what it produced: the task view of the job overlaid on the meta it
+// persisted, the same shape get_backup answers with.
+func (uc *CreateBackup) Execute(ctx context.Context, req CreateBackupRequest) (*BackupView, error) {
+	job, err := uc.Start(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := job.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	return uc.readView(ctx, req.TaskID, uc.backupDir(req))
+}
+
+// readView assembles the finished job's view: the task view from the manager,
+// the persisted meta and the size of the meta dir that produced it.
+func (uc *CreateBackup) readView(ctx context.Context, taskID, backupDir string) (*BackupView, error) {
+	taskView, err := uc.taskMgr.GetBackupTask(taskID)
+	if err != nil {
+		return nil, fmt.Errorf("app: get backup task: %w", err)
+	}
+
+	backupInfo, err := meta.Read(ctx, uc.backupStorage, backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("app: read backup meta: %w", err)
+	}
+
+	metaSize, err := storage.Size(ctx, uc.backupStorage, mpath.MetaDir(backupDir))
+	if err != nil {
+		return nil, fmt.Errorf("app: get meta size: %w", err)
+	}
+
+	return &BackupView{Task: taskView, Meta: backupInfo, MetaSize: metaSize}, nil
+}
+
+// backupDir resolves the artifact directory: the request's root path wins
+// over the configured one, and the artifact name comes from the option.
+func (uc *CreateBackup) backupDir(req CreateBackupRequest) string {
+	rootPath := uc.rootPath
+	if req.RootPath != "" {
+		rootPath = req.RootPath
+	}
+
+	return mpath.BackupDir(rootPath, req.Option.BackupName)
+}
+
+func (uc *CreateBackup) toArgs(req CreateBackupRequest) backup.TaskArgs {
+	return backup.TaskArgs{
+		TaskID:        req.TaskID,
+		Option:        req.Option,
+		MilvusStorage: uc.milvusStorage,
+		BackupStorage: uc.backupStorage,
+		BackupDir:     uc.backupDir(req),
+		Params:        uc.params,
+		TaskMgr:       uc.taskMgr,
+	}
+}
+
+// backupJob hides the core/backup task, the action's engine, behind the
+// interface the transports see.
+type backupJob struct {
+	task *backup.Task
+}
+
+func (j backupJob) Run(ctx context.Context) error { return j.task.Execute(ctx) }

--- a/app/create.go
+++ b/app/create.go
@@ -34,11 +34,11 @@ type CreateBackup struct {
 	rootPath string
 }
 
-// NewCreateBackup builds the usecase from config, creating both storage
-// clients itself so the transports never import internal/storage. The clients
-// are created per call; sharing them across calls is a lifecycle decision
-// this layer deliberately does not make.
-func NewCreateBackup(ctx context.Context, params *v2.Config) (*CreateBackup, error) {
+// NewCreateBackup builds the usecase from config and the given task manager,
+// creating both storage clients itself so the transports never import
+// internal/storage. The clients are created per call; sharing them across
+// calls is a lifecycle decision this layer deliberately does not make.
+func NewCreateBackup(ctx context.Context, params *v2.Config, taskMgr *taskmgr.Mgr) (*CreateBackup, error) {
 	backupStorage, err := storage.NewBackupStorage(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("app: %w", err)
@@ -53,7 +53,7 @@ func NewCreateBackup(ctx context.Context, params *v2.Config) (*CreateBackup, err
 		params:        params,
 		milvusStorage: milvusStorage,
 		backupStorage: backupStorage,
-		taskMgr:       taskmgr.DefaultMgr(),
+		taskMgr:       taskMgr,
 		rootPath:      params.Backup.Storage.RootPath.Val,
 	}, nil
 }

--- a/app/create.go
+++ b/app/create.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/zilliztech/milvus-backup/core/backup"
-	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
-	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
@@ -22,8 +20,12 @@ type BackupJob interface {
 	Run(ctx context.Context) error
 }
 
-// CreateBackup starts one backup job that writes an artifact into the backup
-// storage, copying from the milvus storage.
+// CreateBackup registers backup jobs. A job is what a create call makes: the
+// backup artifact is what a successful job leaves behind in storage, a
+// different resource with its own usecase (GetBackup). This usecase therefore
+// answers with the job and nothing of the artifact — the split the v2 API
+// draws between jobs/backup/create, which returns the job, and
+// backups/describe, which reads the artifact.
 type CreateBackup struct {
 	params *v2.Config
 
@@ -73,16 +75,6 @@ type CreateBackupRequest struct {
 	Option backup.Option
 }
 
-// BackupView keeps the two resource halves separate. Merging them is a
-// rendering decision of the transport, not a property of the action.
-type BackupView struct {
-	// Task is the job half; always known here, the job was just registered.
-	Task taskmgr.BackupTaskView
-	// Meta is the artifact half; non-nil once the job has written it.
-	Meta     *backuppb.BackupInfo
-	MetaSize int64
-}
-
 // Start registers the job in the task manager and returns it ready to run.
 // Registration is the synchronous part of starting: from here on the job is
 // visible to the task APIs under its task id and backup name. Running is a
@@ -98,9 +90,11 @@ func (uc *CreateBackup) Start(req CreateBackupRequest) (BackupJob, error) {
 }
 
 // Execute runs the job synchronously on the calling goroutine and returns the
-// view of what it produced: the task view of the job overlaid on the meta it
-// persisted, the same shape get_backup answers with.
-func (uc *CreateBackup) Execute(ctx context.Context, req CreateBackupRequest) (*BackupView, error) {
+// task manager's view of it: id, state, progress and the rest of the job half
+// — the whole answer of a create call, the shape v2's jobs/backup/create
+// responds with. Nothing of the produced artifact is read here; a transport
+// whose contract merges the two resources (v1) assembles what it needs itself.
+func (uc *CreateBackup) Execute(ctx context.Context, req CreateBackupRequest) (taskmgr.BackupTaskView, error) {
 	job, err := uc.Start(req)
 	if err != nil {
 		return nil, err
@@ -110,28 +104,12 @@ func (uc *CreateBackup) Execute(ctx context.Context, req CreateBackupRequest) (*
 		return nil, err
 	}
 
-	return uc.readView(ctx, req.TaskID, uc.backupDir(req.Option.BackupName))
-}
-
-// readView assembles the finished job's view: the task view from the manager,
-// the persisted meta and the size of the meta dir that produced it.
-func (uc *CreateBackup) readView(ctx context.Context, taskID, backupDir string) (*BackupView, error) {
-	taskView, err := uc.taskMgr.GetBackupTask(taskID)
+	view, err := uc.taskMgr.GetBackupTask(req.TaskID)
 	if err != nil {
 		return nil, fmt.Errorf("app: get backup task: %w", err)
 	}
 
-	backupInfo, err := meta.Read(ctx, uc.backupStorage, backupDir)
-	if err != nil {
-		return nil, fmt.Errorf("app: read backup meta: %w", err)
-	}
-
-	metaSize, err := storage.Size(ctx, uc.backupStorage, mpath.MetaDir(backupDir))
-	if err != nil {
-		return nil, fmt.Errorf("app: get meta size: %w", err)
-	}
-
-	return &BackupView{Task: taskView, Meta: backupInfo, MetaSize: metaSize}, nil
+	return view, nil
 }
 
 // backupDir resolves the artifact directory: the root path comes from the

--- a/app/create.go
+++ b/app/create.go
@@ -66,10 +66,6 @@ type CreateBackupRequest struct {
 	// TaskID is the id the job registers under in the task manager.
 	TaskID string
 
-	// RootPath overrides the configured backup root path. Empty keeps the
-	// configured one.
-	RootPath string
-
 	// Option carries the parsed backup parameters: the artifact name the job
 	// registers under, strategy, format, collection filter, GC pause and the
 	// like. Option.BackupName is also the key the job is visible under to
@@ -114,7 +110,7 @@ func (uc *CreateBackup) Execute(ctx context.Context, req CreateBackupRequest) (*
 		return nil, err
 	}
 
-	return uc.readView(ctx, req.TaskID, uc.backupDir(req))
+	return uc.readView(ctx, req.TaskID, uc.backupDir(req.Option.BackupName))
 }
 
 // readView assembles the finished job's view: the task view from the manager,
@@ -138,15 +134,11 @@ func (uc *CreateBackup) readView(ctx context.Context, taskID, backupDir string) 
 	return &BackupView{Task: taskView, Meta: backupInfo, MetaSize: metaSize}, nil
 }
 
-// backupDir resolves the artifact directory: the request's root path wins
-// over the configured one, and the artifact name comes from the option.
-func (uc *CreateBackup) backupDir(req CreateBackupRequest) string {
-	rootPath := uc.rootPath
-	if req.RootPath != "" {
-		rootPath = req.RootPath
-	}
-
-	return mpath.BackupDir(rootPath, req.Option.BackupName)
+// backupDir resolves the artifact directory: the root path comes from the
+// config the usecase was built with, the artifact name from the option. A
+// per-call root path is the transport forking the config, not a field here.
+func (uc *CreateBackup) backupDir(name string) string {
+	return mpath.BackupDir(uc.rootPath, name)
 }
 
 func (uc *CreateBackup) toArgs(req CreateBackupRequest) backup.TaskArgs {
@@ -155,7 +147,7 @@ func (uc *CreateBackup) toArgs(req CreateBackupRequest) backup.TaskArgs {
 		Option:        req.Option,
 		MilvusStorage: uc.milvusStorage,
 		BackupStorage: uc.backupStorage,
-		BackupDir:     uc.backupDir(req),
+		BackupDir:     uc.backupDir(req.Option.BackupName),
 		Params:        uc.params,
 		TaskMgr:       uc.taskMgr,
 	}

--- a/app/create_test.go
+++ b/app/create_test.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/core/backup"
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// expectClientConfigs teaches both mock clients the config probe NewTask does
+// to resolve the transfer mode.
+func expectClientConfigs(t *testing.T, milvusStorage, backupStorage *storage.MockClient) {
+	t.Helper()
+
+	milvusStorage.EXPECT().Config().Return(storage.Config{})
+	backupStorage.EXPECT().Config().Return(storage.Config{})
+}
+
+// expectMetaSize teaches the mock client to answer the meta dir size probe.
+func expectMetaSize(t *testing.T, cli *storage.MockClient, backupDir string, size int64) {
+	t.Helper()
+
+	iter := storage.NewMockObjectIterator([]storage.ObjectAttr{
+		{Key: backupDir + "/meta/full_meta.json", Length: size},
+	})
+	cli.EXPECT().ListPrefix(mock.Anything, backupDir+"/meta/", true).Return(iter, nil)
+}
+
+func TestCreateBackupStart(t *testing.T) {
+	t.Run("RegistersJobInTheTaskManager", func(t *testing.T) {
+		milvusStorage := storage.NewMockClient(t)
+		backupStorage := storage.NewMockClient(t)
+		expectClientConfigs(t, milvusStorage, backupStorage)
+
+		uc := &CreateBackup{
+			params:        v2.New(),
+			milvusStorage: milvusStorage,
+			backupStorage: backupStorage,
+			taskMgr:       taskmgr.NewMgr(),
+			rootPath:      "root",
+		}
+
+		job, err := uc.Start(CreateBackupRequest{TaskID: "task-1", Option: backup.Option{BackupName: "backup1"}})
+
+		require.NoError(t, err)
+		require.NotNil(t, job)
+		view, err := uc.taskMgr.GetBackupTask("task-1")
+		require.NoError(t, err)
+		assert.Equal(t, "backup1", view.Name())
+	})
+
+	t.Run("RefusesSecondLiveJobWithSameName", func(t *testing.T) {
+		milvusStorage := storage.NewMockClient(t)
+		backupStorage := storage.NewMockClient(t)
+		expectClientConfigs(t, milvusStorage, backupStorage)
+		expectClientConfigs(t, milvusStorage, backupStorage)
+
+		uc := &CreateBackup{
+			params:        v2.New(),
+			milvusStorage: milvusStorage,
+			backupStorage: backupStorage,
+			taskMgr:       taskmgr.NewMgr(),
+			rootPath:      "root",
+		}
+		_, err := uc.Start(CreateBackupRequest{TaskID: "task-1", Option: backup.Option{BackupName: "backup1"}})
+		require.NoError(t, err)
+
+		job, err := uc.Start(CreateBackupRequest{TaskID: "task-2", Option: backup.Option{BackupName: "backup1"}})
+
+		assert.Nil(t, job)
+		assert.ErrorContains(t, err, "existing task")
+	})
+}
+
+func TestCreateBackupExecute(t *testing.T) {
+	t.Run("FailsWhenStartDoes", func(t *testing.T) {
+		milvusStorage := storage.NewMockClient(t)
+		backupStorage := storage.NewMockClient(t)
+		expectClientConfigs(t, milvusStorage, backupStorage)
+		expectClientConfigs(t, milvusStorage, backupStorage)
+
+		uc := &CreateBackup{
+			params:        v2.New(),
+			milvusStorage: milvusStorage,
+			backupStorage: backupStorage,
+			taskMgr:       taskmgr.NewMgr(),
+			rootPath:      "root",
+		}
+		_, err := uc.Start(CreateBackupRequest{TaskID: "task-1", Option: backup.Option{BackupName: "backup1"}})
+		require.NoError(t, err)
+
+		view, err := uc.Execute(context.Background(), CreateBackupRequest{TaskID: "task-2", Option: backup.Option{BackupName: "backup1"}})
+
+		assert.Nil(t, view)
+		assert.ErrorContains(t, err, "existing task")
+	})
+}
+
+func TestCreateBackupReadView(t *testing.T) {
+	t.Run("AssemblesTaskAndMeta", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		expectFullMeta(t, cli, "root/backup1", &backuppb.BackupInfo{Name: "backup1", Size: 100})
+		expectMetaSize(t, cli, "root/backup1", 100)
+
+		mgr := taskmgr.NewMgr()
+		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
+
+		uc := &CreateBackup{backupStorage: cli, taskMgr: mgr, rootPath: "root"}
+		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
+
+		require.NoError(t, err)
+		require.NotNil(t, view.Task)
+		assert.Equal(t, "task-1", view.Task.ID())
+		require.NotNil(t, view.Meta)
+		assert.Equal(t, "backup1", view.Meta.GetName())
+		assert.Equal(t, int64(100), view.MetaSize)
+	})
+
+	t.Run("FailsWhenTaskUnknown", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+
+		uc := &CreateBackup{backupStorage: cli, taskMgr: taskmgr.NewMgr(), rootPath: "root"}
+		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
+
+		assert.Nil(t, view)
+		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
+	})
+
+	t.Run("FailsWhenMetaUnreadable", func(t *testing.T) {
+		cli := storage.NewMockClient(t)
+		cli.EXPECT().
+			ListPrefix(mock.Anything, "root/backup1/meta/full_meta.json", false).
+			Return(nil, errors.New("stat denied"))
+
+		mgr := taskmgr.NewMgr()
+		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
+
+		uc := &CreateBackup{backupStorage: cli, taskMgr: mgr, rootPath: "root"}
+		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
+
+		assert.Nil(t, view)
+		assert.ErrorContains(t, err, "stat denied")
+	})
+}
+
+func TestCreateBackupDir(t *testing.T) {
+	t.Run("UsesConfiguredRootPath", func(t *testing.T) {
+		uc := &CreateBackup{rootPath: "root"}
+
+		// mpath.BackupDir keeps a trailing separator, as the task expects.
+		assert.Equal(t, "root/backup1/", uc.backupDir(CreateBackupRequest{Option: backup.Option{BackupName: "backup1"}}))
+	})
+
+	t.Run("RequestRootPathWins", func(t *testing.T) {
+		uc := &CreateBackup{rootPath: "root"}
+
+		assert.Equal(t, "other/backup1/", uc.backupDir(CreateBackupRequest{Option: backup.Option{BackupName: "backup1"}, RootPath: "other"}))
+	})
+}

--- a/app/create_test.go
+++ b/app/create_test.go
@@ -2,15 +2,12 @@ package app
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zilliztech/milvus-backup/core/backup"
-	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/storage"
 	"github.com/zilliztech/milvus-backup/internal/taskmgr"
@@ -92,53 +89,6 @@ func TestCreateBackupExecute(t *testing.T) {
 
 		assert.Nil(t, view)
 		assert.ErrorContains(t, err, "existing task")
-	})
-}
-
-func TestCreateBackupReadView(t *testing.T) {
-	t.Run("AssemblesTaskAndMeta", func(t *testing.T) {
-		cli := storage.NewMockClient(t)
-		expectFullMeta(t, cli, "root/backup1", &backuppb.BackupInfo{Name: "backup1", Size: 100})
-		expectMetaSize(t, cli, "root/backup1", 100)
-
-		mgr := taskmgr.NewMgr()
-		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
-
-		uc := &CreateBackup{backupStorage: cli, taskMgr: mgr, rootPath: "root"}
-		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
-
-		require.NoError(t, err)
-		require.NotNil(t, view.Task)
-		assert.Equal(t, "task-1", view.Task.ID())
-		require.NotNil(t, view.Meta)
-		assert.Equal(t, "backup1", view.Meta.GetName())
-		assert.Equal(t, int64(100), view.MetaSize)
-	})
-
-	t.Run("FailsWhenTaskUnknown", func(t *testing.T) {
-		cli := storage.NewMockClient(t)
-
-		uc := &CreateBackup{backupStorage: cli, taskMgr: taskmgr.NewMgr(), rootPath: "root"}
-		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
-
-		assert.Nil(t, view)
-		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
-	})
-
-	t.Run("FailsWhenMetaUnreadable", func(t *testing.T) {
-		cli := storage.NewMockClient(t)
-		cli.EXPECT().
-			ListPrefix(mock.Anything, "root/backup1/meta/full_meta.json", false).
-			Return(nil, errors.New("stat denied"))
-
-		mgr := taskmgr.NewMgr()
-		require.NoError(t, mgr.AddBackupTask("task-1", "backup1"))
-
-		uc := &CreateBackup{backupStorage: cli, taskMgr: mgr, rootPath: "root"}
-		view, err := uc.readView(context.Background(), "task-1", "root/backup1")
-
-		assert.Nil(t, view)
-		assert.ErrorContains(t, err, "stat denied")
 	})
 }
 

--- a/app/create_test.go
+++ b/app/create_test.go
@@ -25,16 +25,6 @@ func expectClientConfigs(t *testing.T, milvusStorage, backupStorage *storage.Moc
 	backupStorage.EXPECT().Config().Return(storage.Config{})
 }
 
-// expectMetaSize teaches the mock client to answer the meta dir size probe.
-func expectMetaSize(t *testing.T, cli *storage.MockClient, backupDir string, size int64) {
-	t.Helper()
-
-	iter := storage.NewMockObjectIterator([]storage.ObjectAttr{
-		{Key: backupDir + "/meta/full_meta.json", Length: size},
-	})
-	cli.EXPECT().ListPrefix(mock.Anything, backupDir+"/meta/", true).Return(iter, nil)
-}
-
 func TestCreateBackupStart(t *testing.T) {
 	t.Run("RegistersJobInTheTaskManager", func(t *testing.T) {
 		milvusStorage := storage.NewMockClient(t)
@@ -156,13 +146,9 @@ func TestCreateBackupDir(t *testing.T) {
 	t.Run("UsesConfiguredRootPath", func(t *testing.T) {
 		uc := &CreateBackup{rootPath: "root"}
 
-		// mpath.BackupDir keeps a trailing separator, as the task expects.
-		assert.Equal(t, "root/backup1/", uc.backupDir(CreateBackupRequest{Option: backup.Option{BackupName: "backup1"}}))
-	})
-
-	t.Run("RequestRootPathWins", func(t *testing.T) {
-		uc := &CreateBackup{rootPath: "root"}
-
-		assert.Equal(t, "other/backup1/", uc.backupDir(CreateBackupRequest{Option: backup.Option{BackupName: "backup1"}, RootPath: "other"}))
+		// mpath.BackupDir keeps a trailing separator, as the task expects. A
+		// per-call root path is the transport forking the config, so there is
+		// no request-level override to test here.
+		assert.Equal(t, "root/backup1/", uc.backupDir("backup1"))
 	})
 }

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -9,14 +9,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/backup"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // removedFlags are the create flags dropped in 0.6, after 0.5 accepted them with
@@ -96,19 +94,19 @@ func (o *options) toFilter() (filter.Filter, error) {
 	return f, nil
 }
 
+// toOption parses the flags into the transport-neutral request option. The
+// strategy and format are already validated in validate().
 func (o *options) toOption(params *v2.Config) (backup.Option, error) {
 	f, err := o.toFilter()
 	if err != nil {
 		return backup.Option{}, err
 	}
 
-	// already validated in validate()
 	strategy, err := backup.ParseStrategy(o.strategy)
 	if err != nil {
 		return backup.Option{}, err
 	}
 
-	// already validated in validate()
 	format, err := backup.ParseFormat(o.format)
 	if err != nil {
 		return backup.Option{}, err
@@ -130,48 +128,26 @@ func (o *options) toOption(params *v2.Config) (backup.Option, error) {
 	}, nil
 }
 
-func (o *options) toArgs(params *v2.Config) (backup.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
-	if err != nil {
-		return backup.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
-	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
-	if err != nil {
-		return backup.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
-	}
-
-	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
-	option, err := o.toOption(params)
-	if err != nil {
-		return backup.TaskArgs{}, err
-	}
-
-	return backup.TaskArgs{
-		TaskID:        uuid.NewString(),
-		MilvusStorage: milvusStorage,
-		Option:        option,
-		BackupStorage: backupStorage,
-		BackupDir:     backupDir,
-		Params:        params,
-		TaskMgr:       taskmgr.DefaultMgr(),
-	}, nil
-}
-
 func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	start := time.Now()
 
-	args, err := o.toArgs(params)
+	ctx := context.Background()
+	uc, err := app.NewCreateBackup(ctx, params)
 	if err != nil {
-		return fmt.Errorf("create: convert to args: %w", err)
+		return fmt.Errorf("create: new create backup usecase: %w", err)
 	}
 
-	task, err := backup.NewTask(args)
+	opt, err := o.toOption(params)
 	if err != nil {
-		return fmt.Errorf("create: new backup task error: %w", err)
+		return fmt.Errorf("create: build option: %w", err)
 	}
 
-	if err := task.Execute(context.Background()); err != nil {
-		return fmt.Errorf("create: execute task: %w", err)
+	// The CLI reports the outcome itself and prints nothing from the view.
+	if _, err := uc.Execute(ctx, app.CreateBackupRequest{
+		TaskID: uuid.NewString(),
+		Option: opt,
+	}); err != nil {
+		return fmt.Errorf("create: execute backup: %w", err)
 	}
 
 	cmd.Println("create backup success")

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/backup"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // removedFlags are the create flags dropped in 0.6, after 0.5 accepted them with
@@ -132,7 +133,7 @@ func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	start := time.Now()
 
 	ctx := context.Background()
-	uc, err := app.NewCreateBackup(ctx, params)
+	uc, err := app.NewCreateBackup(ctx, params, taskmgr.DefaultMgr())
 	if err != nil {
 		return fmt.Errorf("create: new create backup usecase: %w", err)
 	}

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -10,19 +10,25 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/backup"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/utils"
-	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/collref"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/meta"
-	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
+
+// createBackupUC is the slice of app.CreateBackup the handler needs. The
+// consumer defines it: app returns concrete types, and this narrow interface
+// is what handler tests stub out.
+type createBackupUC interface {
+	// Execute runs the backup job synchronously and returns the finished view.
+	Execute(ctx context.Context, req app.CreateBackupRequest) (*app.BackupView, error)
+	// Start registers the job and returns it ready to run; the async flag's
+	// goroutine placement is this server's deployment decision.
+	Start(req app.CreateBackupRequest) (app.BackupJob, error)
+}
 
 // CreateBackup Create backup interface
 // @Summary Create backup interface
@@ -43,66 +49,152 @@ func (s *Server) handleCreateBackup(c *gin.Context) {
 	requestBody.RequestId = c.GetHeader("request_id")
 
 	log.Info("receive create backup request", zap.Any("request", &requestBody))
-	h := newCreateBackupHandler(&requestBody, s.params)
-	resp := h.run(c.Request.Context())
+	resp := s.createBackup(c.Request.Context(), &requestBody)
 	log.Info("response create backup response", zap.Any("resp", resp))
 	writeResponse(c, "create backup fail", resp)
 }
 
-type createBackupHandler struct {
-	params *v2.Config
-
-	request *backuppb.CreateBackupRequest
-
-	backupStorage storage.Client
-
-	milvusStorage storage.Client
-}
-
-func newCreateBackupHandler(request *backuppb.CreateBackupRequest, params *v2.Config) *createBackupHandler {
-	return &createBackupHandler{request: request, params: params}
-}
-
-func (h *createBackupHandler) complete() {
-	if h.request.GetRequestId() == "" {
-		h.request.RequestId = uuid.NewString()
+// createBackup maps the v1 request onto the create usecase and the usecase's
+// outcome onto the v1 wire shape. Binding, request_id defaulting, the
+// deprecated pb fields, name validation and the error-to-code mapping stay
+// here; the action itself lives in app.CreateBackup.
+func (s *Server) createBackup(ctx context.Context, request *backuppb.CreateBackupRequest) *backuppb.BackupInfoResponse {
+	if request.GetRequestId() == "" {
+		request.RequestId = uuid.NewString()
 	}
-}
 
-func (h *createBackupHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
+	resp := &backuppb.BackupInfoResponse{RequestId: request.GetRequestId()}
+
+	if err := backup.ValidateName(request.GetBackupName()); err != nil {
+		resp.Code = backuppb.ResponseCode_Parameter_Error
+		resp.Msg = err.Error()
+		return resp
+	}
+
+	uc, err := s.config.newCreateBackup(ctx, s.params)
 	if err != nil {
-		return err
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		return resp
 	}
-	h.backupStorage = backupStorage
 
-	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
+	req, err := s.toCreateBackupRequest(request)
 	if err != nil {
-		return err
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		return resp
 	}
-	h.milvusStorage = milvusStorage
 
-	return nil
+	if request.GetAsync() {
+		return runCreateBackupAsync(uc, request.GetRequestId(), req)
+	}
+	return runCreateBackupSync(ctx, uc, request.GetRequestId(), req)
 }
 
-func (h *createBackupHandler) toFilter() (filter.Filter, error) {
-	if h.request.GetFilter() != nil {
-		return h.filterToFilter()
+// runCreateBackupSync runs the job on the request path. The v1 success
+// response carries only code and msg: the view the usecase returns is
+// deliberately not rendered, because the historical handler computed the
+// payload and then dropped it on the floor, and the wire behavior is kept.
+func runCreateBackupSync(ctx context.Context, uc createBackupUC, requestID string, req app.CreateBackupRequest) *backuppb.BackupInfoResponse {
+	if _, err := uc.Execute(ctx, req); err != nil {
+		return &backuppb.BackupInfoResponse{
+			RequestId: requestID,
+			Code:      backuppb.ResponseCode_Fail,
+			Msg:       err.Error(),
+		}
 	}
 
-	dbCollectionsStr := utils.GetDBCollections(h.request.GetDbCollections()) //nolint:staticcheck // SA1019: deprecated field for backward compatibility
+	return &backuppb.BackupInfoResponse{Code: backuppb.ResponseCode_Success, Msg: "success"}
+}
+
+// runCreateBackupAsync starts the job and returns immediately; running it in
+// the background is this server's deployment concern, the flag only selects it.
+func runCreateBackupAsync(uc createBackupUC, requestID string, req app.CreateBackupRequest) *backuppb.BackupInfoResponse {
+	resp := &backuppb.BackupInfoResponse{RequestId: requestID}
+
+	job, err := uc.Start(req)
+	if err != nil {
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		return resp
+	}
+
+	go func() {
+		if err := job.Run(context.Background()); err != nil {
+			log.Error("create backup task execute fail", zap.String("backupId", requestID), zap.Error(err))
+		}
+	}()
+
+	resp.Code = backuppb.ResponseCode_Success
+	resp.Msg = "create backup is executing asynchronously"
+	return resp
+}
+
+// toCreateBackupRequest renders the v1 pb request into the usecase request.
+// The deprecated pb fields (db_collections, collection_names, force,
+// meta_only) keep their old meaning here: accepting or rejecting them is a
+// transport decision.
+func (s *Server) toCreateBackupRequest(request *backuppb.CreateBackupRequest) (app.CreateBackupRequest, error) {
+	f, err := toFilter(request)
+	if err != nil {
+		return app.CreateBackupRequest{}, fmt.Errorf("server: build filter: %w", err)
+	}
+
+	strategy, err := toStrategy(request)
+	if err != nil {
+		return app.CreateBackupRequest{}, fmt.Errorf("server: build strategy: %w", err)
+	}
+
+	format, err := toFormat(request)
+	if err != nil {
+		return app.CreateBackupRequest{}, fmt.Errorf("server: build format: %w", err)
+	}
+
+	manageAddr := ""
+	if request.GetGcPauseAddress() != "" {
+		manageAddr = request.GetGcPauseAddress()
+	}
+
+	rootPath := ""
+	if request.GetBackupRootPath() != "" {
+		rootPath = request.GetBackupRootPath()
+		log.Info("use backup root from request", zap.String("backup_root", rootPath))
+	}
+
+	return app.CreateBackupRequest{
+		TaskID:   request.GetRequestId(),
+		RootPath: rootPath,
+		Option: backup.Option{
+			BackupName:       request.GetBackupName(),
+			PauseGC:          request.GetGcPauseEnable() || s.params.Backup.PauseGC.Val,
+			ManageAddr:       manageAddr,
+			Strategy:         strategy,
+			Format:           format,
+			BackupRBAC:       request.GetRbac(),
+			BackupIndexExtra: request.GetWithIndexExtra(),
+			Filter:           f,
+		},
+	}, nil
+}
+
+func toFilter(request *backuppb.CreateBackupRequest) (filter.Filter, error) {
+	if request.GetFilter() != nil {
+		return pbFilterToFilter(request.GetFilter())
+	}
+
+	dbCollectionsStr := utils.GetDBCollections(request.GetDbCollections()) //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 	if len(dbCollectionsStr) > 0 {
-		return h.dbCollectionsToFilter(dbCollectionsStr)
+		return dbCollectionsToFilter(dbCollectionsStr)
 	}
 
-	if len(h.request.GetCollectionNames()) > 0 { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
-		return h.collectionNamesToFilter()
+	if len(request.GetCollectionNames()) > 0 { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
+		return collectionNamesToFilter(request.GetCollectionNames()) //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 	}
 
 	return filter.Filter{}, nil
 }
 
-func (h *createBackupHandler) dbCollectionsToFilter(dbCollectionsStr string) (filter.Filter, error) {
+func dbCollectionsToFilter(dbCollectionsStr string) (filter.Filter, error) {
 	var dbCollections map[string][]string
 	if err := json.Unmarshal([]byte(dbCollectionsStr), &dbCollections); err != nil {
 		return filter.Filter{}, fmt.Errorf("server: unmarshal dbCollections: %w", err)
@@ -124,9 +216,9 @@ func (h *createBackupHandler) dbCollectionsToFilter(dbCollectionsStr string) (fi
 	return filter.Filter{DBCollFilter: dbCollFilter}, nil
 }
 
-func (h *createBackupHandler) collectionNamesToFilter() (filter.Filter, error) {
+func collectionNamesToFilter(collectionNames []string) (filter.Filter, error) {
 	dbCollFilter := make(map[string]filter.CollFilter)
-	for _, nameStr := range h.request.GetCollectionNames() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
+	for _, nameStr := range collectionNames {
 		collRef, err := collref.Parse(nameStr)
 		if err != nil {
 			return filter.Filter{}, fmt.Errorf("server: invalid collection name %s", nameStr)
@@ -141,8 +233,8 @@ func (h *createBackupHandler) collectionNamesToFilter() (filter.Filter, error) {
 	return filter.Filter{DBCollFilter: dbCollFilter}, nil
 }
 
-func (h *createBackupHandler) filterToFilter() (filter.Filter, error) {
-	f, err := filter.FromPB(h.request.GetFilter())
+func pbFilterToFilter(pbFilter map[string]*backuppb.CollFilter) (filter.Filter, error) {
+	f, err := filter.FromPB(pbFilter)
 	if err != nil {
 		return filter.Filter{}, fmt.Errorf("server: build filter from pb: %w", err)
 	}
@@ -150,17 +242,17 @@ func (h *createBackupHandler) filterToFilter() (filter.Filter, error) {
 	return f, nil
 }
 
-func (h *createBackupHandler) toStrategy() (backup.Strategy, error) {
-	if h.request.GetStrategy() != "" {
-		return backup.ParseStrategy(h.request.GetStrategy())
+func toStrategy(request *backuppb.CreateBackupRequest) (backup.Strategy, error) {
+	if request.GetStrategy() != "" {
+		return backup.ParseStrategy(request.GetStrategy())
 	}
 
-	if h.request.GetForce() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
+	if request.GetForce() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		log.Warn("force option is deprecated, pls use strategy=skip_flush instead")
 		return backup.StrategySkipFlush, nil
 	}
 
-	if h.request.GetMetaOnly() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
+	if request.GetMetaOnly() { //nolint:staticcheck // SA1019: deprecated field for backward compatibility
 		log.Warn("meta_only option is deprecated, pls use strategy=meta_only instead")
 		return backup.StrategyMetaOnly, nil
 	}
@@ -168,166 +260,10 @@ func (h *createBackupHandler) toStrategy() (backup.Strategy, error) {
 	return backup.StrategyAuto, nil
 }
 
-func (h *createBackupHandler) toFormat() (backup.Format, error) {
-	if h.request.GetFormat() != "" {
-		return backup.ParseFormat(h.request.GetFormat())
+func toFormat(request *backuppb.CreateBackupRequest) (backup.Format, error) {
+	if request.GetFormat() != "" {
+		return backup.ParseFormat(request.GetFormat())
 	}
 
 	return backup.FormatAuto, nil
-}
-
-func (h *createBackupHandler) toOption(params *v2.Config) (backup.Option, error) {
-	f, err := h.toFilter()
-	if err != nil {
-		return backup.Option{}, fmt.Errorf("server: build filter: %w", err)
-	}
-
-	strategy, err := h.toStrategy()
-	if err != nil {
-		return backup.Option{}, fmt.Errorf("server: build strategy: %w", err)
-	}
-
-	format, err := h.toFormat()
-	if err != nil {
-		return backup.Option{}, fmt.Errorf("server: build format: %w", err)
-	}
-
-	manageAddr := ""
-	if h.request.GetGcPauseAddress() != "" {
-		manageAddr = h.request.GetGcPauseAddress()
-	}
-
-	return backup.Option{
-		BackupName:       h.request.GetBackupName(),
-		PauseGC:          h.request.GetGcPauseEnable() || params.Backup.PauseGC.Val,
-		ManageAddr:       manageAddr,
-		Strategy:         strategy,
-		Format:           format,
-		BackupRBAC:       h.request.GetRbac(),
-		BackupIndexExtra: h.request.GetWithIndexExtra(),
-		Filter:           f,
-	}, nil
-}
-
-func (h *createBackupHandler) toArgs() (backup.TaskArgs, error) {
-	option, err := h.toOption(h.params)
-	if err != nil {
-		return backup.TaskArgs{}, fmt.Errorf("server: build option: %w", err)
-	}
-
-	backupRoot := h.params.Backup.Storage.RootPath.Val
-	if h.request.GetBackupRootPath() != "" {
-		backupRoot = h.request.GetBackupRootPath()
-		log.Info("use backup root from request", zap.String("backup_root", backupRoot))
-	}
-	backupDir := mpath.BackupDir(backupRoot, h.request.GetBackupName())
-
-	return backup.TaskArgs{
-		TaskID:        h.request.GetRequestId(),
-		Option:        option,
-		MilvusStorage: h.milvusStorage,
-		BackupStorage: h.backupStorage,
-		BackupDir:     backupDir,
-		Params:        h.params,
-		TaskMgr:       taskmgr.DefaultMgr(),
-	}, nil
-}
-
-func (h *createBackupHandler) validate() error {
-	if err := backup.ValidateName(h.request.GetBackupName()); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (h *createBackupHandler) runSync(ctx context.Context, args backup.TaskArgs) *backuppb.BackupInfoResponse {
-	resp := &backuppb.BackupInfoResponse{RequestId: h.request.GetRequestId()}
-
-	task, err := backup.NewTask(args)
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-	}
-	if err := task.Execute(ctx); err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	taskView, err := taskmgr.DefaultMgr().GetBackupTask(h.request.GetRequestId())
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	backupInfo, err := meta.Read(ctx, h.backupStorage, args.BackupDir)
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	metaSize, err := storage.Size(ctx, h.backupStorage, mpath.MetaDir(args.BackupDir))
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "success"
-	resp.Data = pbconv.NewBackupInfoBrief(taskView, backupInfo, metaSize)
-
-	return &backuppb.BackupInfoResponse{Code: backuppb.ResponseCode_Success, Msg: "success"}
-}
-
-func (h *createBackupHandler) runAsync(args backup.TaskArgs) *backuppb.BackupInfoResponse {
-	resp := &backuppb.BackupInfoResponse{RequestId: h.request.GetRequestId()}
-	task, err := backup.NewTask(args)
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	go func() {
-		if err := task.Execute(context.Background()); err != nil {
-			log.Error("create backup task execute fail", zap.String("backupId", h.request.GetRequestId()), zap.Error(err))
-		}
-	}()
-
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "create backup is executing asynchronously"
-	return resp
-}
-
-func (h *createBackupHandler) run(ctx context.Context) *backuppb.BackupInfoResponse {
-	h.complete()
-
-	resp := &backuppb.BackupInfoResponse{RequestId: h.request.GetRequestId()}
-	if err := h.validate(); err != nil {
-		resp.Code = backuppb.ResponseCode_Parameter_Error
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	if err := h.initClient(ctx); err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	args, err := h.toArgs()
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	if h.request.GetAsync() {
-		return h.runAsync(args)
-	}
-	return h.runSync(ctx, args)
 }

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -17,14 +17,15 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/collref"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // createBackupUC is the slice of app.CreateBackup the handler needs. The
 // consumer defines it: app returns concrete types, and this narrow interface
 // is what handler tests stub out.
 type createBackupUC interface {
-	// Execute runs the backup job synchronously and returns the finished view.
-	Execute(ctx context.Context, req app.CreateBackupRequest) (*app.BackupView, error)
+	// Execute runs the backup job synchronously and returns the job view.
+	Execute(ctx context.Context, req app.CreateBackupRequest) (taskmgr.BackupTaskView, error)
 	// Start registers the job and returns it ready to run; the async flag's
 	// goroutine placement is this server's deployment decision.
 	Start(req app.CreateBackupRequest) (app.BackupJob, error)
@@ -109,9 +110,12 @@ func (s *Server) createBackup(ctx context.Context, request *backuppb.CreateBacku
 }
 
 // runCreateBackupSync runs the job on the request path. The v1 success
-// response carries only code and msg: the view the usecase returns is
-// deliberately not rendered, because the historical handler computed the
-// payload and then dropped it on the floor, and the wire behavior is kept.
+// response carries only code and msg, so the job view the usecase returns is
+// discarded — whatever a v1 response needs, this handler assembles itself,
+// and this one needs nothing. The historical handler additionally read the
+// persisted meta after a successful run and answered Fail when that read
+// failed, but the read only fed a payload the response then discarded, so it
+// is gone together with the payload.
 func runCreateBackupSync(ctx context.Context, uc createBackupUC, requestID string, req app.CreateBackupRequest) *backuppb.BackupInfoResponse {
 	if _, err := uc.Execute(ctx, req); err != nil {
 		return &backuppb.BackupInfoResponse{

--- a/core/server/create.go
+++ b/core/server/create.go
@@ -71,7 +71,24 @@ func (s *Server) createBackup(ctx context.Context, request *backuppb.CreateBacku
 		return resp
 	}
 
-	uc, err := s.config.newCreateBackup(ctx, s.params)
+	// The v1 backup_root_path field asks for a different backup location for
+	// this call. That is a config override, not a request option: fork the
+	// loaded config with it as one more override layer. The fork is
+	// reload-equivalent, so unset backup.storage leaves still cascade from
+	// milvus.storage, and the server's own config is never mutated.
+	params := s.params
+	if root := request.GetBackupRootPath(); root != "" {
+		log.Info("use backup root from request", zap.String("backup_root", root))
+		var err error
+		params, err = params.Fork(map[string]string{"backup.storage.rootPath": root})
+		if err != nil {
+			resp.Code = backuppb.ResponseCode_Fail
+			resp.Msg = err.Error()
+			return resp
+		}
+	}
+
+	uc, err := s.config.newCreateBackup(ctx, params)
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
@@ -155,15 +172,8 @@ func (s *Server) toCreateBackupRequest(request *backuppb.CreateBackupRequest) (a
 		manageAddr = request.GetGcPauseAddress()
 	}
 
-	rootPath := ""
-	if request.GetBackupRootPath() != "" {
-		rootPath = request.GetBackupRootPath()
-		log.Info("use backup root from request", zap.String("backup_root", rootPath))
-	}
-
 	return app.CreateBackupRequest{
-		TaskID:   request.GetRequestId(),
-		RootPath: rootPath,
+		TaskID: request.GetRequestId(),
 		Option: backup.Option{
 			BackupName:       request.GetBackupName(),
 			PauseGC:          request.GetGcPauseEnable() || s.params.Backup.PauseGC.Val,

--- a/core/server/create_test.go
+++ b/core/server/create_test.go
@@ -1,59 +1,275 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/zilliztech/milvus-backup/app"
+	"github.com/zilliztech/milvus-backup/core/backup"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 )
 
-func TestCreateBackupHandler_dbCollectionsToFilter(t *testing.T) {
-	dbColl := `{"db1":["coll1","coll2"],"db2":["coll3","coll4"],"db3":[]}`
-	h := &createBackupHandler{}
-	f, err := h.dbCollectionsToFilter(dbColl)
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]filter.CollFilter{
-		"db1": {CollName: map[string]struct{}{"coll1": {}, "coll2": {}}},
-		"db2": {CollName: map[string]struct{}{"coll3": {}, "coll4": {}}},
-		"db3": {AllowAll: true},
-	}, f.DBCollFilter)
+// stubCreateBackup stands in for app.CreateBackup: the request it was called
+// with, canned errors, and a call count so tests can assert whether the
+// handler reached the action at all. Start hands out a job that signals the
+// ran channel, so async tests can wait for the handler's goroutine.
+type stubCreateBackup struct {
+	req        app.CreateBackupRequest
+	startErr   error
+	executeErr error
+	calls      int
+	ran        chan struct{}
 }
 
-func TestCreateBackupHandler_collectionNamesToFilter(t *testing.T) {
-	h := &createBackupHandler{request: &backuppb.CreateBackupRequest{CollectionNames: []string{"coll1", "db1.coll2", "db2.coll3"}}}
-	f, err := h.collectionNamesToFilter()
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]filter.CollFilter{
-		"default": {CollName: map[string]struct{}{"coll1": {}}},
-		"db1":     {CollName: map[string]struct{}{"coll2": {}}},
-		"db2":     {CollName: map[string]struct{}{"coll3": {}}},
-	}, f.DBCollFilter)
+func (s *stubCreateBackup) Execute(_ context.Context, req app.CreateBackupRequest) (*app.BackupView, error) {
+	s.req = req
+	s.calls++
+	if s.executeErr != nil {
+		return nil, s.executeErr
+	}
+	return &app.BackupView{}, nil
 }
 
-func TestCreateBackupHandler_filterToFilter(t *testing.T) {
-	h := &createBackupHandler{request: &backuppb.CreateBackupRequest{Filter: map[string]*backuppb.CollFilter{
-		"db1": {Colls: []string{"*"}},
-		"db2": {Colls: []string{"coll1", "coll2"}},
-	}}}
-	f, err := h.filterToFilter()
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]filter.CollFilter{
-		"db1": {AllowAll: true},
-		"db2": {CollName: map[string]struct{}{"coll1": {}, "coll2": {}}},
-	}, f.DBCollFilter)
+func (s *stubCreateBackup) Start(req app.CreateBackupRequest) (app.BackupJob, error) {
+	s.req = req
+	s.calls++
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+	return stubJob{ran: s.ran}, nil
 }
 
-func TestCreateBackupHandler_toFilter(t *testing.T) {
+type stubJob struct {
+	ran chan struct{}
+}
+
+func (j stubJob) Run(context.Context) error {
+	if j.ran != nil {
+		close(j.ran)
+	}
+	return nil
+}
+
+// withCreateBackup wires the stub as the create usecase. newErr simulates the
+// client-construction failure, which happens before any action call.
+func withCreateBackup(stub *stubCreateBackup, newErr error) Option {
+	return func(c *config) {
+		c.newCreateBackup = func(context.Context, *v2.Config) (createBackupUC, error) {
+			return stub, newErr
+		}
+	}
+}
+
+func postBackup(t *testing.T, s *Server, body, requestID string) backuppb.BackupInfoResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/create", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if requestID != "" {
+		req.Header.Set("request_id", requestID)
+	}
+	s.engine.ServeHTTP(w, req)
+
+	var resp backuppb.BackupInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	return resp
+}
+
+func TestHandleCreateBackup(t *testing.T) {
+	t.Run("SyncRunsThroughTheUsecase", func(t *testing.T) {
+		stub := &stubCreateBackup{}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "success", resp.GetMsg())
+		assert.Equal(t, "backup1", stub.req.Option.BackupName)
+		assert.Equal(t, "rid-1", stub.req.TaskID)
+		assert.Equal(t, backup.StrategyAuto, stub.req.Option.Strategy)
+		assert.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("SyncSuccessResponseCarriesNoPayload", func(t *testing.T) {
+		// Preserved v1 wire behavior: the historical handler computed the
+		// backup payload and request id, then returned a bare code+msg
+		// response. The quirk is kept, not fixed, by this move-only PR.
+		stub := &stubCreateBackup{}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Empty(t, resp.GetRequestId())
+		assert.Nil(t, resp.GetData())
+	})
+
+	t.Run("GeneratesRequestIdWhenMissing", func(t *testing.T) {
+		stub := &stubCreateBackup{}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		postBackup(t, s, `{"backup_name":"backup1"}`, "")
+
+		assert.NotEmpty(t, stub.req.TaskID)
+	})
+
+	t.Run("RejectsInvalidNameWithoutCallingUsecase", func(t *testing.T) {
+		stub := &stubCreateBackup{}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"bad name"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "whitespace")
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("MapsConstructorErrorToFail", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, errors.New("dial timeout")))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "dial timeout")
+	})
+
+	t.Run("MapsRequestBuildErrorToFail", func(t *testing.T) {
+		stub := &stubCreateBackup{}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1","strategy":"bogus"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "build strategy")
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("SyncMapsExecuteErrorToFail", func(t *testing.T) {
+		stub := &stubCreateBackup{executeErr: errors.New("bucket unavailable")}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "bucket unavailable")
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+		assert.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("AsyncStartsJobAndReturnsImmediately", func(t *testing.T) {
+		stub := &stubCreateBackup{ran: make(chan struct{})}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1","async":true}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "create backup is executing asynchronously", resp.GetMsg())
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+		assert.Equal(t, "rid-1", stub.req.TaskID)
+		require.Eventually(t, func() bool {
+			select {
+			case <-stub.ran:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, time.Millisecond)
+	})
+
+	t.Run("AsyncMapsStartErrorToFail", func(t *testing.T) {
+		stub := &stubCreateBackup{startErr: errors.New("backup1 (existing task task-1)")}
+		s := newListTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1","async":true}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "existing task")
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+	})
+}
+
+func TestToCreateBackupRequest(t *testing.T) {
+	t.Run("MapsOptionFields", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
+
+		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{
+			BackupName:     "backup1",
+			RequestId:      "rid-1",
+			Rbac:           true,
+			WithIndexExtra: true,
+			GcPauseEnable:  true,
+			GcPauseAddress: "http://manage",
+			Strategy:       "skip_flush",
+			Format:         "binlog",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "rid-1", req.TaskID)
+		assert.Equal(t, "backup1", req.Option.BackupName)
+		assert.Equal(t, backup.StrategySkipFlush, req.Option.Strategy)
+		assert.Equal(t, backup.FormatBinlog, req.Option.Format)
+		assert.True(t, req.Option.BackupRBAC)
+		assert.True(t, req.Option.BackupIndexExtra)
+		assert.True(t, req.Option.PauseGC)
+		assert.Equal(t, "http://manage", req.Option.ManageAddr)
+	})
+
+	t.Run("DeprecatedForceMapsToSkipFlush", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
+
+		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{Force: true})
+
+		require.NoError(t, err)
+		assert.Equal(t, backup.StrategySkipFlush, req.Option.Strategy)
+	})
+
+	t.Run("DeprecatedMetaOnlyMapsToMetaOnly", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
+
+		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{MetaOnly: true})
+
+		require.NoError(t, err)
+		assert.Equal(t, backup.StrategyMetaOnly, req.Option.Strategy)
+	})
+
+	t.Run("ExplicitStrategyWinsOverDeprecatedFields", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
+
+		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{Strategy: "meta_only", Force: true})
+
+		require.NoError(t, err)
+		assert.Equal(t, backup.StrategyMetaOnly, req.Option.Strategy)
+	})
+
+	t.Run("BackupRootPathOverrides", func(t *testing.T) {
+		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
+
+		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{BackupRootPath: "other"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "other", req.RootPath)
+	})
+}
+
+func TestCreateBackupToFilter(t *testing.T) {
 	t.Run("FromFilter", func(t *testing.T) {
-		h := &createBackupHandler{request: &backuppb.CreateBackupRequest{Filter: map[string]*backuppb.CollFilter{
+		f, err := toFilter(&backuppb.CreateBackupRequest{Filter: map[string]*backuppb.CollFilter{
 			"db1": {Colls: []string{"*"}},
 			"db2": {Colls: []string{"coll1", "coll2"}},
-		}}}
-
-		f, err := h.toFilter()
+		}})
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]filter.CollFilter{
 			"db1": {AllowAll: true},
@@ -62,11 +278,9 @@ func TestCreateBackupHandler_toFilter(t *testing.T) {
 	})
 
 	t.Run("FromDBCollections", func(t *testing.T) {
-		h := &createBackupHandler{request: &backuppb.CreateBackupRequest{DbCollections: &structpb.Value{
+		f, err := toFilter(&backuppb.CreateBackupRequest{DbCollections: &structpb.Value{
 			Kind: &structpb.Value_StringValue{StringValue: `{"db1":["coll1","coll2"],"db2":["coll3","coll4"],"db3":[]}`},
-		}}}
-
-		f, err := h.toFilter()
+		}})
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]filter.CollFilter{
 			"db1": {CollName: map[string]struct{}{"coll1": {}, "coll2": {}}},
@@ -76,12 +290,38 @@ func TestCreateBackupHandler_toFilter(t *testing.T) {
 	})
 
 	t.Run("FromCollectionNames", func(t *testing.T) {
-		h := &createBackupHandler{request: &backuppb.CreateBackupRequest{CollectionNames: []string{"coll1", "db2.coll2"}}}
-		f, err := h.toFilter()
+		f, err := toFilter(&backuppb.CreateBackupRequest{CollectionNames: []string{"coll1", "db2.coll2"}})
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]filter.CollFilter{
 			"default": {CollName: map[string]struct{}{"coll1": {}}},
 			"db2":     {CollName: map[string]struct{}{"coll2": {}}},
 		}, f.DBCollFilter)
 	})
+
+	t.Run("EmptyRequestFiltersNothing", func(t *testing.T) {
+		f, err := toFilter(&backuppb.CreateBackupRequest{})
+		assert.NoError(t, err)
+		assert.Nil(t, f.DBCollFilter)
+	})
+}
+
+func TestCreateBackupDBCollectionsToFilter(t *testing.T) {
+	dbColl := `{"db1":["coll1","coll2"],"db2":["coll3","coll4"],"db3":[]}`
+	f, err := dbCollectionsToFilter(dbColl)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]filter.CollFilter{
+		"db1": {CollName: map[string]struct{}{"coll1": {}, "coll2": {}}},
+		"db2": {CollName: map[string]struct{}{"coll3": {}, "coll4": {}}},
+		"db3": {AllowAll: true},
+	}, f.DBCollFilter)
+}
+
+func TestCreateBackupCollectionNamesToFilter(t *testing.T) {
+	f, err := collectionNamesToFilter([]string{"coll1", "db1.coll2", "db2.coll3"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]filter.CollFilter{
+		"default": {CollName: map[string]struct{}{"coll1": {}}},
+		"db1":     {CollName: map[string]struct{}{"coll2": {}}},
+		"db2":     {CollName: map[string]struct{}{"coll3": {}}},
+	}, f.DBCollFilter)
 }

--- a/core/server/create_test.go
+++ b/core/server/create_test.go
@@ -22,11 +22,13 @@ import (
 )
 
 // stubCreateBackup stands in for app.CreateBackup: the request it was called
-// with, canned errors, and a call count so tests can assert whether the
-// handler reached the action at all. Start hands out a job that signals the
-// ran channel, so async tests can wait for the handler's goroutine.
+// with, the params its constructor received, canned errors, and a call count
+// so tests can assert whether the handler reached the action at all. Start
+// hands out a job that signals the ran channel, so async tests can wait for
+// the handler's goroutine.
 type stubCreateBackup struct {
 	req        app.CreateBackupRequest
+	params     *v2.Config
 	startErr   error
 	executeErr error
 	calls      int
@@ -66,7 +68,8 @@ func (j stubJob) Run(context.Context) error {
 // client-construction failure, which happens before any action call.
 func withCreateBackup(stub *stubCreateBackup, newErr error) Option {
 	return func(c *config) {
-		c.newCreateBackup = func(context.Context, *v2.Config) (createBackupUC, error) {
+		c.newCreateBackup = func(_ context.Context, params *v2.Config) (createBackupUC, error) {
+			stub.params = params
 			return stub, newErr
 		}
 	}
@@ -199,6 +202,34 @@ func TestHandleCreateBackup(t *testing.T) {
 		assert.Contains(t, resp.GetMsg(), "existing task")
 		assert.Equal(t, "rid-1", resp.GetRequestId())
 	})
+
+	t.Run("BackupRootPathForksConfig", func(t *testing.T) {
+		// The v1 backup_root_path field is applied as a config override, not
+		// sent through the request.
+		stub := &stubCreateBackup{}
+		s := newLoadedTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1","backup_root_path":"other"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		require.NotNil(t, stub.params)
+		assert.Equal(t, "other", stub.params.Backup.Storage.RootPath.Val)
+		// The fork, not the server's own config, reaches the usecase.
+		assert.NotSame(t, s.params, stub.params)
+		// The server's own config stays on the default root path.
+		assert.Equal(t, "backup", s.params.Backup.Storage.RootPath.Val)
+	})
+
+	t.Run("NoBackupRootPathKeepsServerConfig", func(t *testing.T) {
+		stub := &stubCreateBackup{}
+		s := newLoadedTestServer(t, withCreateBackup(stub, nil))
+
+		resp := postBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		// No backup_root_path: the config travels to the usecase untouched.
+		assert.Same(t, s.params, stub.params)
+	})
 }
 
 func TestToCreateBackupRequest(t *testing.T) {
@@ -252,15 +283,6 @@ func TestToCreateBackupRequest(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, backup.StrategyMetaOnly, req.Option.Strategy)
-	})
-
-	t.Run("BackupRootPathOverrides", func(t *testing.T) {
-		s := newListTestServer(t, withCreateBackup(&stubCreateBackup{}, nil))
-
-		req, err := s.toCreateBackupRequest(&backuppb.CreateBackupRequest{BackupRootPath: "other"})
-
-		require.NoError(t, err)
-		assert.Equal(t, "other", req.RootPath)
 	})
 }
 

--- a/core/server/create_test.go
+++ b/core/server/create_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/filter"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // stubCreateBackup stands in for app.CreateBackup: the request it was called
@@ -35,13 +36,13 @@ type stubCreateBackup struct {
 	ran        chan struct{}
 }
 
-func (s *stubCreateBackup) Execute(_ context.Context, req app.CreateBackupRequest) (*app.BackupView, error) {
+func (s *stubCreateBackup) Execute(_ context.Context, req app.CreateBackupRequest) (taskmgr.BackupTaskView, error) {
 	s.req = req
 	s.calls++
 	if s.executeErr != nil {
 		return nil, s.executeErr
 	}
-	return &app.BackupView{}, nil
+	return nil, nil
 }
 
 func (s *stubCreateBackup) Start(req app.CreateBackupRequest) (app.BackupJob, error) {

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -38,6 +38,9 @@ type config struct {
 	// construction cannot fail. The error stays so the seam matches the
 	// other constructors.
 	newGetBackupTask func() (getBackupTaskUC, error)
+
+	// newCreateBackup is the create counterpart of newListBackups.
+	newCreateBackup func(ctx context.Context, params *v2.Config) (createBackupUC, error)
 }
 
 func newDefaultConfig() *config {
@@ -62,6 +65,9 @@ func newDefaultConfig() *config {
 		},
 		newGetBackupTask: func() (getBackupTaskUC, error) {
 			return app.NewGetBackupTask(taskmgr.DefaultMgr()), nil
+		},
+		newCreateBackup: func(ctx context.Context, params *v2.Config) (createBackupUC, error) {
+			return app.NewCreateBackup(ctx, params)
 		},
 	}
 }

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -67,7 +67,7 @@ func newDefaultConfig() *config {
 			return app.NewGetBackupTask(taskmgr.DefaultMgr()), nil
 		},
 		newCreateBackup: func(ctx context.Context, params *v2.Config) (createBackupUC, error) {
-			return app.NewCreateBackup(ctx, params)
+			return app.NewCreateBackup(ctx, params, taskmgr.DefaultMgr())
 		},
 	}
 }


### PR DESCRIPTION
Part of #1171

## What

`app` gains the `CreateBackup` usecase: one struct holding the config, the two storage clients, the task manager and the backup root path, constructor-built from config. The action is *create a backup job*: a job is what a create call makes, and the backup artifact is what a successful job leaves behind — the two-resource split of the v2 API (#1124), where `jobs/backup/create` returns the job and `backups/describe` reads the artifact.

- `Start(req)` is the synchronous act of starting a job — it assembles `backup.TaskArgs` and calls `backup.NewTask`, which registers the job in the task manager, and returns the registered job ready to run behind a small `BackupJob` interface
- `Execute(ctx, req)` runs the job synchronously and answers with the task manager's view of it: id, state, progress and the rest of the job half — the shape v2's `jobs/backup/create` responds with. It never reads the persisted meta; a transport whose contract merges the two resources (v1) assembles what it needs itself

Both transports call it:

- the `create` CLI command (`cmd/create`) builds `app.NewCreateBackup` + `Execute`; flag parsing, name defaulting, validation and the printed output stay in `cmd`
- the `/api/v1/create` handler (`core/server`) renders the pb request into `app.CreateBackupRequest` — keeping the deprecated pb fields (`db_collections`, `collection_names`, `force`, `meta_only`), name validation and the error-to-code mapping — through a `newCreateBackup` constructor hook on the server config that tests stub out, the same seam list and delete got in #1182 and #1200
- the v1 `async` flag stays a server concern: the handler calls `Start` and spawns the goroutine itself (unchanged logging on failure), while taskmgr registration stays where it was, inside `backup.NewTask`. `core/backup` is not touched
- `NewCreateBackup` takes the task manager as a parameter instead of reading `taskmgr.DefaultMgr()` itself; `cmd/create` and the server wiring pass the process-local manager, keeping the global reference out of the usecase layer

Rebased on top of the config fork (#1215): the v1 `backup_root_path` field is applied as a config override, not a request field. The handler forks the loaded config with `backup.storage.rootPath` as one more override layer — the same move `get_backup` makes for its `path` parameter in #1203 — and the forked params are what `NewCreateBackup` builds the usecase from, so `CreateBackupRequest` carries no root path and the usecase reads it from its params. The fork is reload-equivalent, so unset `backup.storage` leaves still cascade from `milvus.storage`, and the server's own config is never mutated. The artifact directory for a given request is the same as before the rebase.

## Semantics unchanged

The v1 wire shape is kept, including its quirks:

- the sync success response still carries only `code` and `msg` — no payload and no `request_id`. The usecase now answers with the job view alone, and the v1 contract needs nothing from it, so the handler discards it; anything a v1 response does need, the handler assembles itself
- `request_id` defaulting, error-to-code mapping (`Parameter_Error` for a bad name, `Fail` for everything else, `request_id` echoed on failures), filter/strategy/format precedence and the deprecated-field fallbacks are unchanged
- async behavior is unchanged: same response message (`create backup is executing asynchronously`), same `request_id` echo, task still registered synchronously in the default task manager before the goroutine starts

Two pre-existing bugs were found and are **not** fixed here:

- empty `backup_name` still panics in `backup.ValidateName` and lands on gin's recovery as a 500, exactly as before

Two deliberate behavioral deltas, both limited to error paths:

- the sync path used to fall through from a `backup.NewTask` error into `task.Execute` on a nil task — a guaranteed panic. The usecase returns that error instead, so a job whose registration fails now answers `Fail` with the error message
- the old sync path read the task view, the persisted meta and the meta size after a successful run and answered `Fail` when any of those reads failed — even though the backup had already succeeded — all to build a brief it then discarded. That read only ever fed the discarded payload, so it is gone together with the payload: a successful backup now always answers success

## Tests

- `app/create_test.go`: `Start` registers the job in the task manager and refuses a second live job for the same backup name; `Execute` propagates the start failure; the artifact dir is the configured root path plus the option's name
- `core/server/create_test.go`: httptest cases over the handler contract — sync runs through the usecase and the success response carries no payload (quirk pinned), request_id generated and forwarded, invalid name rejected with `Parameter_Error` before the usecase runs, constructor/build/execute/start errors mapped to `Fail`, async starts the job and returns immediately, `backup_root_path` forks the loaded config while the server's own config stays on the default root path (and without the field the config travels to the usecase untouched); plus the pb→option rendering incl. deprecated `force`/`meta_only` and the three filter sources