### PR TITLE
app: extract the restore usecase

### DIFF
--- a/app/restore.go
+++ b/app/restore.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/milvus-backup/core/restore"
+	"github.com/zilliztech/milvus-backup/core/tasklet"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/log"
+	"github.com/zilliztech/milvus-backup/internal/meta"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// BackupNotFoundError reports a restore request naming a backup that has no
+// artifact in the backup storage. Transports map it to their parameter-error
+// code: the caller asked for something that is not there.
+type BackupNotFoundError struct {
+	Name string
+}
+
+func (e *BackupNotFoundError) Error() string {
+	return fmt.Sprintf("app: backup %s not found", e.Name)
+}
+
+// RestoreTaskView aliases the task manager's view of one restore job. It is
+// what a transport renders into its own wire shape; the alias exists so the
+// transports need not import internal/taskmgr just to name the type.
+type RestoreTaskView = taskmgr.RestoreTaskView
+
+// RestoreJob is one assembled restore job: its task exists and the task
+// manager knows it, but nothing has run yet. The transport decides how the
+// job executes — synchronously via Execute, or in the transport's own
+// goroutine when it restores asynchronously.
+type RestoreJob interface {
+	// Execute runs the job to completion.
+	Execute(ctx context.Context) error
+
+	// TaskID identifies the job in the task manager; TaskView takes it.
+	TaskID() string
+}
+
+// Restore restores a backup into the target Milvus.
+type Restore struct {
+	params *v2.Config
+
+	// newBackupStorage and newMilvusStorage build the two clients one restore
+	// runs on. They are per-Start calls, not constructor state: the backup
+	// client depends on the request's bucket override, which no constructor
+	// knows. They are fields so tests inject mocks instead of a real backend.
+	newBackupStorage func(ctx context.Context, bucketName string) (storage.Client, error)
+	newMilvusStorage func(ctx context.Context) (storage.Client, error)
+}
+
+// NewRestore builds the usecase from config.
+func NewRestore(params *v2.Config) *Restore {
+	return &Restore{
+		params: params,
+		newBackupStorage: func(ctx context.Context, bucketName string) (storage.Client, error) {
+			conf := storage.BackupStorageConfig(params)
+			if bucketName != "" {
+				log.Info("use bucket name from request", zap.String("bucketName", bucketName))
+				conf.Bucket = bucketName
+			}
+
+			cli, err := storage.NewClient(ctx, conf)
+			if err != nil {
+				return nil, fmt.Errorf("app: create backup storage: %w", err)
+			}
+			if err := storage.CreateBucketIfNotExist(ctx, cli, ""); err != nil {
+				return nil, fmt.Errorf("app: create backup bucket: %w", err)
+			}
+
+			return cli, nil
+		},
+		newMilvusStorage: func(ctx context.Context) (storage.Client, error) {
+			cli, err := storage.NewMilvusStorage(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("app: create milvus storage: %w", err)
+			}
+
+			return cli, nil
+		},
+	}
+}
+
+// RestoreRequest selects and shapes one restore. Plan and Option are the
+// restore task's own vocabulary on purpose: each transport translates its
+// grammar into them — the CLI from flags, v1 from its pb fields — and the two
+// grammars do not map onto each other, so there is nothing transport-neutral
+// to put here instead.
+type RestoreRequest struct {
+	// TaskID identifies the restore job in the task manager. The transport
+	// defaults it when its contract carries no id.
+	TaskID string
+	// BackupName names the backup artifact to restore.
+	BackupName string
+	// BucketName overrides the configured backup bucket when set.
+	BucketName string
+	// Path overrides the configured backup root path when set.
+	Path string
+
+	Plan   *restore.Plan
+	Option *restore.Option
+}
+
+// Start assembles the restore job and registers it with the task manager,
+// executing nothing: storage clients are created, the backup's existence is
+// checked, its meta is read and the task is built — task creation is what
+// registers the job. Execute runs the returned job; a transport that restores
+// asynchronously runs it in its own goroutine instead.
+func (uc *Restore) Start(ctx context.Context, req RestoreRequest) (RestoreJob, error) {
+	backupStorage, err := uc.newBackupStorage(ctx, req.BucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	backupRootPath := uc.params.Backup.Storage.RootPath.Val
+	if req.Path != "" {
+		log.Info("use path from request", zap.String("path", req.Path))
+		backupRootPath = req.Path
+	}
+
+	milvusStorage, err := uc.newMilvusStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	backupDir := mpath.BackupDir(backupRootPath, req.BackupName)
+	exist, err := meta.Exist(ctx, backupStorage, backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("app: %w", err)
+	}
+	if !exist {
+		return nil, &BackupNotFoundError{Name: req.BackupName}
+	}
+
+	backup, err := meta.Read(ctx, backupStorage, backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("app: read backup: %w", err)
+	}
+
+	args := restore.TaskArgs{
+		TaskID:        req.TaskID,
+		Backup:        backup,
+		Plan:          req.Plan,
+		Option:        req.Option,
+		Params:        uc.params,
+		BackupDir:     backupDir,
+		BackupStorage: backupStorage,
+		MilvusStorage: milvusStorage,
+
+		TaskMgr: taskmgr.DefaultMgr(),
+	}
+	task, err := restore.NewTask(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("app: new restore task: %w", err)
+	}
+
+	return &restoreJob{task: task, taskID: req.TaskID}, nil
+}
+
+// TaskView returns the current view of the restore job registered under
+// taskID.
+func (uc *Restore) TaskView(taskID string) (RestoreTaskView, error) {
+	view, err := taskmgr.DefaultMgr().GetRestoreTask(taskID)
+	if err != nil {
+		return nil, fmt.Errorf("app: get restore task %w", err)
+	}
+
+	return view, nil
+}
+
+// restoreJob adapts the two task implementations to RestoreJob so the
+// transports drive a job without importing the task layer.
+type restoreJob struct {
+	task   tasklet.Tasklet
+	taskID string
+}
+
+func (j *restoreJob) Execute(ctx context.Context) error { return j.task.Execute(ctx) }
+func (j *restoreJob) TaskID() string                    { return j.taskID }

--- a/app/restore_secondary.go
+++ b/app/restore_secondary.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/meta"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+
+	"github.com/zilliztech/milvus-backup/core/restore/secondary"
+)
+
+// RestoreSecondary restores a backup to a secondary cluster: it replays the
+// source cluster's DDL verbatim under the target cluster's id.
+type RestoreSecondary struct {
+	params *v2.Config
+
+	// newBackupStorage and newMilvusStorage build the two clients one restore
+	// runs on. They are per-Start calls, not constructor state, and fields so
+	// tests inject mocks instead of a real backend.
+	newBackupStorage func(ctx context.Context) (storage.Client, error)
+	newMilvusStorage func(ctx context.Context) (storage.Client, error)
+}
+
+// NewRestoreSecondary builds the usecase from config.
+func NewRestoreSecondary(params *v2.Config) *RestoreSecondary {
+	return &RestoreSecondary{
+		params: params,
+		newBackupStorage: func(ctx context.Context) (storage.Client, error) {
+			cli, err := storage.NewBackupStorage(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("app: create backup storage: %w", err)
+			}
+
+			return cli, nil
+		},
+		newMilvusStorage: func(ctx context.Context) (storage.Client, error) {
+			cli, err := storage.NewMilvusStorage(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("app: create milvus storage: %w", err)
+			}
+
+			return cli, nil
+		},
+	}
+}
+
+// RestoreSecondaryRequest selects one secondary restore.
+type RestoreSecondaryRequest struct {
+	// TaskID identifies the restore job in the task manager. The transport
+	// defaults it when its contract carries no id.
+	TaskID string
+	// BackupName names the backup artifact to restore.
+	BackupName string
+	// SourceClusterID is the cluster the backup's DDL was taken from.
+	SourceClusterID string
+	// TargetClusterID is the cluster the DDL is replayed under.
+	TargetClusterID string
+	// Path overrides the configured backup root path when set.
+	Path string
+}
+
+// Start assembles the restore job and registers it with the task manager,
+// executing nothing: the backup storage client is created, the backup's
+// existence is checked, its meta is read, the target cluster's own storage
+// client is created, and the task is built — task creation is what registers
+// the job. Execute runs the returned job; a transport that restores
+// asynchronously runs it in its own goroutine instead.
+func (uc *RestoreSecondary) Start(ctx context.Context, req RestoreSecondaryRequest) (RestoreJob, error) {
+	backupStorage, err := uc.newBackupStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	backupRootPath := uc.params.Backup.Storage.RootPath.Val
+	if req.Path != "" {
+		backupRootPath = req.Path
+	}
+
+	backupDir := mpath.BackupDir(backupRootPath, req.BackupName)
+	exist, err := meta.Exist(ctx, backupStorage, backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("app: %w", err)
+	}
+	if !exist {
+		return nil, &BackupNotFoundError{Name: req.BackupName}
+	}
+
+	backup, err := meta.Read(ctx, backupStorage, backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("app: read backup: %w", err)
+	}
+
+	milvusStorage, err := uc.newMilvusStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	args := secondary.TaskArgs{
+		TaskID: req.TaskID,
+
+		SourceClusterID: req.SourceClusterID,
+		TargetClusterID: req.TargetClusterID,
+
+		Backup:        backup,
+		Params:        uc.params,
+		BackupDir:     backupDir,
+		BackupStorage: backupStorage,
+		MilvusStorage: milvusStorage,
+
+		TaskMgr: taskmgr.DefaultMgr(),
+	}
+	task, err := secondary.NewTask(args)
+	if err != nil {
+		return nil, fmt.Errorf("app: new restore task: %w", err)
+	}
+
+	return &restoreJob{task: task, taskID: req.TaskID}, nil
+}
+
+// TaskView returns the current view of the restore job registered under
+// taskID.
+func (uc *RestoreSecondary) TaskView(taskID string) (RestoreTaskView, error) {
+	view, err := taskmgr.DefaultMgr().GetRestoreTask(taskID)
+	if err != nil {
+		return nil, fmt.Errorf("app: get restore task %w", err)
+	}
+
+	return view, nil
+}

--- a/app/restore_test.go
+++ b/app/restore_test.go
@@ -1,0 +1,257 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/core/restore"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
+	"github.com/zilliztech/milvus-backup/internal/storage"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
+)
+
+// newTestRestore builds the usecase with mock client factories, so Start never
+// touches a real backend. The backup meta is served by the mock: the exist
+// check lists backup_meta.json, then the read fetches full_meta.json.
+func newTestRestore(t *testing.T, backupCli *storage.MockClient, milvusCli *storage.MockClient) *Restore {
+	t.Helper()
+
+	return &Restore{
+		params: &v2.Config{},
+		newBackupStorage: func(context.Context, string) (storage.Client, error) {
+			return backupCli, nil
+		},
+		newMilvusStorage: func(context.Context) (storage.Client, error) {
+			return milvusCli, nil
+		},
+	}
+}
+
+func newTestRestoreSecondary(t *testing.T, backupCli *storage.MockClient, milvusCli *storage.MockClient) *RestoreSecondary {
+	t.Helper()
+
+	return &RestoreSecondary{
+		params: &v2.Config{},
+		newBackupStorage: func(context.Context) (storage.Client, error) {
+			return backupCli, nil
+		},
+		newMilvusStorage: func(context.Context) (storage.Client, error) {
+			return milvusCli, nil
+		},
+	}
+}
+
+// expectBackupExists teaches the mock client that the backup dir exists: the
+// exist check lists backup_meta.json and finds it.
+func expectBackupExists(t *testing.T, cli *storage.MockClient, backupDir string) {
+	t.Helper()
+
+	key := backupDir + "meta/backup_meta.json"
+	iter := storage.NewMockObjectIterator([]storage.ObjectAttr{{Key: key, Length: 10}})
+	cli.EXPECT().ListPrefix(mock.Anything, key, false).Return(iter, nil)
+}
+
+// expectNoBackup teaches the mock client that the backup dir does not exist.
+func expectNoBackup(t *testing.T, cli *storage.MockClient, backupDir string) {
+	t.Helper()
+
+	key := backupDir + "meta/backup_meta.json"
+	iter := storage.NewMockObjectIterator(nil)
+	cli.EXPECT().ListPrefix(mock.Anything, key, false).Return(iter, nil)
+}
+
+func TestRestoreStart(t *testing.T) {
+	t.Run("AssemblesAndRegistersTheJob", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+		milvusCli := storage.NewMockClient(t)
+
+		// Path from the request overrides the configured root.
+		expectBackupExists(t, backupCli, "custom/backup1/")
+		expectFullMeta(t, backupCli, "custom/backup1",
+			&backuppb.BackupInfo{Id: "a", Name: "backup1", Format: ""})
+		// Task creation reads both clients' configs to resolve the transfer mode.
+		backupCli.EXPECT().Config().Return(storage.Config{})
+		milvusCli.EXPECT().Config().Return(storage.Config{})
+
+		uc := newTestRestore(t, backupCli, milvusCli)
+		req := RestoreRequest{
+			TaskID:     "restore_1",
+			BackupName: "backup1",
+			Path:       "custom",
+			Plan:       &restore.Plan{},
+			Option:     &restore.Option{},
+		}
+		job, err := uc.Start(context.Background(), req)
+
+		require.NoError(t, err)
+		assert.Equal(t, "restore_1", job.TaskID())
+
+		// Task creation registered the job with the task manager.
+		view, err := uc.TaskView(job.TaskID())
+		require.NoError(t, err)
+		assert.Equal(t, "restore_1", view.ID())
+		assert.Equal(t, backuppb.RestoreTaskStateCode_INITIAL, view.StateCode())
+	})
+
+	t.Run("FailsWhenBackupNotFound", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		expectNoBackup(t, backupCli, "backup1/")
+
+		uc := newTestRestore(t, backupCli, storage.NewMockClient(t))
+		_, err := uc.Start(context.Background(), RestoreRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "backup backup1 not found")
+		var notFound *BackupNotFoundError
+		assert.ErrorAs(t, err, &notFound)
+		assert.Equal(t, "backup1", notFound.Name)
+	})
+
+	t.Run("FailsWhenExistCheckFails", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		backupCli.EXPECT().
+			ListPrefix(mock.Anything, "backup1/meta/backup_meta.json", false).
+			Return(nil, errors.New("stat denied"))
+
+		uc := newTestRestore(t, backupCli, storage.NewMockClient(t))
+		_, err := uc.Start(context.Background(), RestoreRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "stat denied")
+	})
+
+	t.Run("FailsWhenMetaUnreadable", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		expectBackupExists(t, backupCli, "backup1/")
+		// The full meta cannot even be checked for existence, so the read
+		// fails instead of falling back to the per-level meta.
+		backupCli.EXPECT().
+			ListPrefix(mock.Anything, "backup1/meta/full_meta.json", false).
+			Return(nil, errors.New("read denied"))
+
+		uc := newTestRestore(t, backupCli, storage.NewMockClient(t))
+		_, err := uc.Start(context.Background(), RestoreRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "read denied")
+	})
+
+	t.Run("FailsWhenTaskRefusesTheFormat", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		expectBackupExists(t, backupCli, "backup1/")
+		expectFullMeta(t, backupCli, "backup1",
+			&backuppb.BackupInfo{Id: "a", Name: "backup1", Format: "parquet"})
+
+		uc := newTestRestore(t, backupCli, storage.NewMockClient(t))
+		_, err := uc.Start(context.Background(), RestoreRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "new restore task")
+	})
+
+	t.Run("FailsWhenBackupStorageCreationFails", func(t *testing.T) {
+		uc := &Restore{
+			params: &v2.Config{},
+			newBackupStorage: func(context.Context, string) (storage.Client, error) {
+				return nil, errors.New("dial timeout")
+			},
+		}
+
+		_, err := uc.Start(context.Background(), RestoreRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "dial timeout")
+	})
+
+	t.Run("TaskViewErrorsForUnknownTask", func(t *testing.T) {
+		uc := newTestRestore(t, storage.NewMockClient(t), storage.NewMockClient(t))
+
+		_, err := uc.TaskView("missing")
+
+		assert.ErrorIs(t, err, taskmgr.ErrTaskNotFound)
+	})
+}
+
+func TestRestoreSecondaryStart(t *testing.T) {
+	t.Run("AssemblesAndRegistersTheJob", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+		milvusCli := storage.NewMockClient(t)
+
+		expectBackupExists(t, backupCli, "backup1/")
+		expectFullMeta(t, backupCli, "backup1",
+			&backuppb.BackupInfo{Id: "a", Name: "backup1", Format: ""})
+
+		uc := newTestRestoreSecondary(t, backupCli, milvusCli)
+		req := RestoreSecondaryRequest{
+			TaskID:          "restore_1",
+			BackupName:      "backup1",
+			SourceClusterID: "source",
+			TargetClusterID: "target",
+		}
+		job, err := uc.Start(context.Background(), req)
+
+		require.NoError(t, err)
+		assert.Equal(t, "restore_1", job.TaskID())
+
+		view, err := uc.TaskView(job.TaskID())
+		require.NoError(t, err)
+		assert.Equal(t, "restore_1", view.ID())
+		assert.Equal(t, backuppb.RestoreTaskStateCode_INITIAL, view.StateCode())
+	})
+
+	t.Run("FailsWhenBackupNotFound", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		expectNoBackup(t, backupCli, "backup1/")
+
+		uc := newTestRestoreSecondary(t, backupCli, storage.NewMockClient(t))
+		_, err := uc.Start(context.Background(),
+			RestoreSecondaryRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "backup backup1 not found")
+		var notFound *BackupNotFoundError
+		assert.ErrorAs(t, err, &notFound)
+		assert.Equal(t, "backup1", notFound.Name)
+	})
+
+	t.Run("FailsWhenMilvusStorageCreationFails", func(t *testing.T) {
+		backupCli := storage.NewMockClient(t)
+
+		expectBackupExists(t, backupCli, "backup1/")
+		expectFullMeta(t, backupCli, "backup1",
+			&backuppb.BackupInfo{Id: "a", Name: "backup1", Format: ""})
+
+		uc := &RestoreSecondary{
+			params: &v2.Config{},
+			newBackupStorage: func(context.Context) (storage.Client, error) {
+				return backupCli, nil
+			},
+			newMilvusStorage: func(context.Context) (storage.Client, error) {
+				return nil, errors.New("dial timeout")
+			},
+		}
+		_, err := uc.Start(context.Background(),
+			RestoreSecondaryRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "dial timeout")
+	})
+
+	t.Run("FailsWhenBackupStorageCreationFails", func(t *testing.T) {
+		uc := &RestoreSecondary{
+			params: &v2.Config{},
+			newBackupStorage: func(context.Context) (storage.Client, error) {
+				return nil, errors.New("dial timeout")
+			},
+		}
+
+		_, err := uc.Start(context.Background(),
+			RestoreSecondaryRequest{TaskID: "restore_1", BackupName: "backup1"})
+
+		assert.ErrorContains(t, err, "dial timeout")
+	})
+}

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -10,16 +10,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/cmd/flags"
 	"github.com/zilliztech/milvus-backup/cmd/root"
 	"github.com/zilliztech/milvus-backup/core/restore"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/collref"
 	"github.com/zilliztech/milvus-backup/internal/filter"
-	"github.com/zilliztech/milvus-backup/internal/meta"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 // removedFlags are the restore flags dropped in 0.6, after 0.5 accepted them
@@ -154,63 +151,36 @@ func (o *options) renameCollectionNamesToMapper() (*restore.TableMapper, error) 
 	return newTableMapperFromCollRename(renameMap)
 }
 
-func (o *options) toArgs(params *v2.Config) (restore.TaskArgs, error) {
+// toRequest translates the flag grammar into the usecase request: the plan is
+// a parse product of flag-only inputs, so it is built here.
+func (o *options) toRequest() (app.RestoreRequest, error) {
 	plan, err := o.toPlan()
 	if err != nil {
-		return restore.TaskArgs{}, err
+		return app.RestoreRequest{}, err
 	}
 
-	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
-	if err != nil {
-		return restore.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
-	}
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
-	if err != nil {
-		return restore.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
-	}
-
-	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
-	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
-	if err != nil {
-		return restore.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)
-	}
-	if !exist {
-		return restore.TaskArgs{}, fmt.Errorf("backup %s not found", o.backupName)
-	}
-
-	backup, err := meta.Read(context.Background(), backupStorage, backupDir)
-	if err != nil {
-		return restore.TaskArgs{}, fmt.Errorf("read backup meta: %w", err)
-	}
-
-	return restore.TaskArgs{
-		TaskID:        uuid.NewString(),
-		Backup:        backup,
-		Plan:          plan,
-		Option:        o.toOption(),
-		Params:        params,
-		BackupDir:     mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName),
-		BackupStorage: backupStorage,
-		MilvusStorage: milvusStorage,
-
-		TaskMgr: taskmgr.DefaultMgr(),
+	return app.RestoreRequest{
+		TaskID:     uuid.NewString(),
+		BackupName: o.backupName,
+		Plan:       plan,
+		Option:     o.toOption(),
 	}, nil
 }
 
 func (o *options) run(cmd *cobra.Command, params *v2.Config) error {
 	start := time.Now()
 
-	args, err := o.toArgs(params)
+	req, err := o.toRequest()
 	if err != nil {
 		return err
 	}
 
-	task, err := restore.NewTask(cmd.Context(), args)
+	job, err := app.NewRestore(params).Start(cmd.Context(), req)
 	if err != nil {
 		return err
 	}
 
-	if err := task.Execute(context.Background()); err != nil {
+	if err := job.Execute(context.Background()); err != nil {
 		return err
 	}
 

--- a/cmd/restore/secondary.go
+++ b/cmd/restore/secondary.go
@@ -3,18 +3,13 @@ package restore
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/cmd/root"
-	"github.com/zilliztech/milvus-backup/core/restore/secondary"
 	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
-	"github.com/zilliztech/milvus-backup/internal/meta"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
 type secondaryOption struct {
@@ -42,59 +37,24 @@ func (o *secondaryOption) validate() error {
 	return nil
 }
 
-func (o *secondaryOption) toArgs(params *v2.Config) (secondary.TaskArgs, error) {
-	backupStorage, err := storage.NewBackupStorage(context.Background(), params)
-	if err != nil {
-		return secondary.TaskArgs{}, fmt.Errorf("create backup storage: %w", err)
-	}
-
-	backupDir := mpath.BackupDir(params.Backup.Storage.RootPath.Val, o.backupName)
-	exist, err := meta.Exist(context.Background(), backupStorage, backupDir)
-	if err != nil {
-		return secondary.TaskArgs{}, fmt.Errorf("check backup exist: %w", err)
-	}
-	if !exist {
-		return secondary.TaskArgs{}, fmt.Errorf("backup %s not found", o.backupName)
-	}
-
-	backup, err := meta.Read(context.Background(), backupStorage, backupDir)
-	if err != nil {
-		return secondary.TaskArgs{}, fmt.Errorf("read backup meta: %w", err)
-	}
-
-	milvusStorage, err := storage.NewMilvusStorage(context.Background(), params)
-	if err != nil {
-		return secondary.TaskArgs{}, fmt.Errorf("create milvus storage: %w", err)
-	}
-
-	return secondary.TaskArgs{
+func (o *secondaryOption) toRequest() app.RestoreSecondaryRequest {
+	return app.RestoreSecondaryRequest{
 		TaskID: uuid.NewString(),
+
+		BackupName: o.backupName,
 
 		SourceClusterID: o.sourceClusterID,
 		TargetClusterID: o.targetClusterID,
-
-		Backup:        backup,
-		Params:        params,
-		BackupDir:     backupDir,
-		BackupStorage: backupStorage,
-		MilvusStorage: milvusStorage,
-
-		TaskMgr: taskmgr.DefaultMgr(),
-	}, nil
+	}
 }
 
 func (o *secondaryOption) run(cmd *cobra.Command, params *v2.Config) error {
-	args, err := o.toArgs(params)
+	job, err := app.NewRestoreSecondary(params).Start(context.Background(), o.toRequest())
 	if err != nil {
 		return err
 	}
 
-	task, err := secondary.NewTask(args)
-	if err != nil {
-		return err
-	}
-
-	if err := task.Execute(context.Background()); err != nil {
+	if err := job.Execute(context.Background()); err != nil {
 		return err
 	}
 

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -26,6 +26,16 @@ type config struct {
 	// to build and construction cannot fail. The error stays so the seam
 	// matches the other constructors.
 	newGetRestore func() (getRestoreUC, error)
+
+	// newRestoreBackup builds the usecase a restore request runs through.
+	// Unlike list and delete its constructor cannot fail: the storage clients
+	// are created per Start call, once the request's own bucket override is
+	// known.
+	newRestoreBackup func(params *v2.Config) restoreBackupUC
+
+	// newRestoreSecondary is the secondary-restore counterpart of
+	// newRestoreBackup.
+	newRestoreSecondary func(params *v2.Config) restoreSecondaryUC
 }
 
 func newDefaultConfig() *config {
@@ -41,6 +51,12 @@ func newDefaultConfig() *config {
 		},
 		newGetRestore: func() (getRestoreUC, error) {
 			return app.NewGetRestore(taskmgr.DefaultMgr()), nil
+		},
+		newRestoreBackup: func(params *v2.Config) restoreBackupUC {
+			return app.NewRestore(params)
+		},
+		newRestoreSecondary: func(params *v2.Config) restoreSecondaryUC {
+			return app.NewRestoreSecondary(params)
 		},
 	}
 }

--- a/core/server/restore.go
+++ b/core/server/restore.go
@@ -12,20 +12,23 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore"
 	"github.com/zilliztech/milvus-backup/core/utils"
-	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/collref"
 	"github.com/zilliztech/milvus-backup/internal/filter"
 	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 	"github.com/zilliztech/milvus-backup/internal/validate"
 )
+
+// restoreBackupUC is the slice of app.Restore the handler needs. The consumer
+// defines it: this narrow interface is what handler tests stub out.
+type restoreBackupUC interface {
+	Start(ctx context.Context, req app.RestoreRequest) (app.RestoreJob, error)
+	TaskView(taskID string) (app.RestoreTaskView, error)
+}
 
 // RestoreBackup Restore interface
 // @Summary Restore interface
@@ -44,199 +47,149 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 		return
 	}
 
-	h := newRestoreHandler(&request, s.params)
-	resp := h.run(context.Background())
+	// The restore outlives the HTTP request, so the usecase runs detached
+	// from it, exactly as this endpoint always has.
+	resp := s.restore(context.Background(), &request)
 
 	writeResponse(c, "restore backup fail", resp)
 }
 
-type restoreHandler struct {
-	params  *v2.Config
-	request *backuppb.RestoreBackupRequest
-
-	backupStorage  storage.Client
-	backupRootPath string
-
-	milvusStorage storage.Client
-}
-
-func newRestoreHandler(request *backuppb.RestoreBackupRequest, params *v2.Config) *restoreHandler {
-	return &restoreHandler{request: request, params: params}
-}
-
-func (h *restoreHandler) run(ctx context.Context) *backuppb.RestoreBackupResponse {
-	h.complete()
-	if err := h.validate(); err != nil {
+// restore keeps the v1 contract of this endpoint: request id and task id are
+// defaulted on the request, every failure before the task exists responds
+// without a request id, and the async flag makes the server run the job in
+// its own goroutine.
+func (s *Server) restore(ctx context.Context, request *backuppb.RestoreBackupRequest) *backuppb.RestoreBackupResponse {
+	completeRestoreRequest(request)
+	if err := validateRestoreRequest(request); err != nil {
 		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Parameter_Error, Msg: err.Error()}
 	}
 
-	if err := h.initClient(ctx); err != nil {
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
-	}
-
-	backupDir := mpath.BackupDir(h.backupRootPath, h.request.GetBackupName())
-	exist, err := meta.Exist(ctx, h.backupStorage, backupDir)
-	if err != nil {
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
-	}
-	if !exist {
-		msg := fmt.Sprintf("backup %s not found", h.request.GetBackupName())
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Parameter_Error, Msg: msg}
-	}
-
-	task, err := h.newTask(ctx, backupDir)
+	req, err := newRestoreRequest(request)
 	if err != nil {
 		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
 	}
 
-	if h.request.GetAsync() {
-		return h.runAsync(task)
+	uc := s.config.newRestoreBackup(s.params)
+
+	job, err := uc.Start(ctx, *req)
+	if err != nil {
+		// A backup that is not there is the caller's mistake; everything
+		// else is the server's.
+		code := backuppb.ResponseCode_Fail
+		var notFound *app.BackupNotFoundError
+		if errors.As(err, &notFound) {
+			code = backuppb.ResponseCode_Parameter_Error
+		}
+		return &backuppb.RestoreBackupResponse{Code: code, Msg: err.Error()}
 	}
-	return h.runSync(ctx, task)
+
+	if request.GetAsync() {
+		return s.restoreAsync(uc, job, request.GetRequestId())
+	}
+
+	if err := job.Execute(ctx); err != nil {
+		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
+	}
+
+	view, err := uc.TaskView(job.TaskID())
+	if err != nil {
+		resp := &backuppb.RestoreBackupResponse{RequestId: request.GetRequestId()}
+		resp.Code = backuppb.ResponseCode_Fail
+		log.Error("get restore task fail", zap.String("taskId", job.TaskID()), zap.Error(err))
+		resp.Msg = err.Error()
+		return resp
+	}
+
+	return &backuppb.RestoreBackupResponse{
+		RequestId: request.GetRequestId(),
+		Code:      backuppb.ResponseCode_Success,
+		Msg:       "success",
+		Data:      pbconv.RestoreTaskViewToResp(view),
+	}
 }
 
-func (h *restoreHandler) validate() error {
-	if len(h.request.GetBackupName()) == 0 {
+// restoreAsync launches the job in the server's own goroutine — async is a
+// deployment concern of the HTTP server, not of the usecase — then reports
+// the freshly registered job's view.
+func (s *Server) restoreAsync(uc restoreBackupUC, job app.RestoreJob, requestID string) *backuppb.RestoreBackupResponse {
+	go func() {
+		if err := job.Execute(context.Background()); err != nil {
+			log.Error("restore backup task execute fail", zap.String("backupId", job.TaskID()), zap.Error(err))
+		}
+	}()
+
+	view, err := uc.TaskView(job.TaskID())
+	if err != nil {
+		resp := &backuppb.RestoreBackupResponse{RequestId: requestID}
+		resp.Code = backuppb.ResponseCode_Fail
+		log.Error("get restore task fail", zap.String("taskId", job.TaskID()), zap.Error(err))
+		resp.Msg = err.Error()
+		return resp
+	}
+
+	return &backuppb.RestoreBackupResponse{
+		RequestId: requestID,
+		Code:      backuppb.ResponseCode_Success,
+		Msg:       "restore backup is executing asynchronously",
+		Data:      pbconv.RestoreTaskViewToResp(view),
+	}
+}
+
+// completeRestoreRequest defaults the request id and the restore task id.
+func completeRestoreRequest(request *backuppb.RestoreBackupRequest) {
+	if len(request.GetRequestId()) == 0 {
+		request.RequestId = uuid.NewString()
+	}
+
+	if len(request.GetId()) == 0 {
+		taskID := "restore_" + fmt.Sprint(time.Now().UTC().Format("2006_01_02_15_04_05_")) + fmt.Sprint(time.Now().Nanosecond())
+		request.Id = taskID
+	}
+}
+
+func validateRestoreRequest(request *backuppb.RestoreBackupRequest) error {
+	if len(request.GetBackupName()) == 0 {
 		return errors.New("backup name is required")
 	}
 
-	if h.request.GetRestorePlan() != nil && len(h.request.GetCollectionSuffix()) != 0 {
+	if request.GetRestorePlan() != nil && len(request.GetCollectionSuffix()) != 0 {
 		return errors.New("restore plan and collection suffix cannot be set at the same time")
 	}
 
-	if h.request.GetRestorePlan() != nil && len(h.request.GetCollectionRenames()) != 0 {
+	if request.GetRestorePlan() != nil && len(request.GetCollectionRenames()) != 0 {
 		return errors.New("restore plan and collection renames cannot be set at the same time")
 	}
 
-	if len(h.request.GetCollectionSuffix()) != 0 {
-		if has := validate.HasSpecialChar(h.request.GetCollectionSuffix()); has {
+	if len(request.GetCollectionSuffix()) != 0 {
+		if has := validate.HasSpecialChar(request.GetCollectionSuffix()); has {
 			return errors.New("only alphanumeric characters and underscores are allowed in collection suffix")
 		}
 	}
 
-	if h.request.GetDropExistCollection() && h.request.GetSkipCreateCollection() {
+	if request.GetDropExistCollection() && request.GetSkipCreateCollection() {
 		return errors.New("drop_exist_collection and skip_create_collection cannot be true at the same time")
 	}
 
 	return nil
 }
 
-func (h *restoreHandler) complete() {
-	if len(h.request.GetRequestId()) == 0 {
-		h.request.RequestId = uuid.NewString()
-	}
-
-	if len(h.request.GetId()) == 0 {
-		taskID := "restore_" + fmt.Sprint(time.Now().UTC().Format("2006_01_02_15_04_05_")) + fmt.Sprint(time.Now().Nanosecond())
-		h.request.Id = taskID
-	}
-}
-
-func (h *restoreHandler) initClient(ctx context.Context) error {
-	backupCfg := storage.BackupStorageConfig(h.params)
-	if h.request.GetBucketName() != "" {
-		log.Info("use bucket name from request", zap.String("bucketName", h.request.GetBucketName()))
-		backupCfg.Bucket = h.request.GetBucketName()
-	}
-	backupStorage, err := storage.NewClient(ctx, backupCfg)
-	if err != nil {
-		return fmt.Errorf("server: create backup storage: %w", err)
-	}
-	if err := storage.CreateBucketIfNotExist(ctx, backupStorage, ""); err != nil {
-		return fmt.Errorf("server: create backup bucket: %w", err)
-	}
-
-	backupRootPath := h.params.Backup.Storage.RootPath.Val
-	if h.request.GetPath() != "" {
-		log.Info("use path from request", zap.String("path", h.request.GetPath()))
-		backupRootPath = h.request.GetPath()
-	}
-
-	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
-	if err != nil {
-		return fmt.Errorf("server: create milvus storage: %w", err)
-	}
-
-	h.backupStorage = backupStorage
-	h.milvusStorage = milvusStorage
-
-	h.backupRootPath = backupRootPath
-
-	return nil
-}
-
-func (h *restoreHandler) newTask(ctx context.Context, backupDir string) (*restore.Task, error) {
-	backup, err := meta.Read(ctx, h.backupStorage, backupDir)
-	if err != nil {
-		return nil, fmt.Errorf("server: read backup: %w", err)
-	}
-
-	plan, err := newPlanFromRequest(h.request)
+// newRestoreRequest translates the v1 pb grammar into the usecase request:
+// the plan and the option are built here because they are parse products of
+// pb-only fields, including the deprecated db_collections.
+func newRestoreRequest(request *backuppb.RestoreBackupRequest) (*app.RestoreRequest, error) {
+	plan, err := newPlanFromRequest(request)
 	if err != nil {
 		return nil, fmt.Errorf("server: create restore plan: %w", err)
 	}
 
-	args := restore.TaskArgs{
-		TaskID:        h.request.GetId(),
-		Backup:        backup,
-		Plan:          plan,
-		Option:        newOptionFromRequest(h.request),
-		Params:        h.params,
-		BackupDir:     backupDir,
-		BackupStorage: h.backupStorage,
-		MilvusStorage: h.milvusStorage,
-
-		TaskMgr: taskmgr.DefaultMgr(),
-	}
-	task, err := restore.NewTask(ctx, args)
-	if err != nil {
-		return nil, fmt.Errorf("backup: new restore task: %w", err)
-	}
-
-	return task, nil
-}
-
-func (h *restoreHandler) runSync(ctx context.Context, task *restore.Task) *backuppb.RestoreBackupResponse {
-	if err := task.Execute(ctx); err != nil {
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
-	}
-
-	resp := backuppb.RestoreBackupResponse{RequestId: h.request.GetRequestId()}
-	taskView, err := taskmgr.DefaultMgr().GetRestoreTask(h.request.GetId())
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		log.Error("get restore task fail", zap.String("taskId", h.request.GetId()), zap.Error(err))
-		resp.Msg = err.Error()
-		return &resp
-	}
-
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "success"
-	resp.Data = pbconv.RestoreTaskViewToResp(taskView)
-
-	return &resp
-}
-
-func (h *restoreHandler) runAsync(task *restore.Task) *backuppb.RestoreBackupResponse {
-	go func() {
-		if err := task.Execute(context.Background()); err != nil {
-			log.Error("restore backup task execute fail", zap.String("backupId", h.request.GetId()), zap.Error(err))
-		}
-	}()
-
-	resp := backuppb.RestoreBackupResponse{RequestId: h.request.GetRequestId()}
-	taskView, err := taskmgr.DefaultMgr().GetRestoreTask(h.request.GetId())
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		log.Error("get restore task fail", zap.String("taskId", h.request.GetId()), zap.Error(err))
-		resp.Msg = err.Error()
-		return &resp
-	}
-
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "restore backup is executing asynchronously"
-	resp.Data = pbconv.RestoreTaskViewToResp(taskView)
-	return &resp
+	return &app.RestoreRequest{
+		TaskID:     request.GetId(),
+		BackupName: request.GetBackupName(),
+		BucketName: request.GetBucketName(),
+		Path:       request.GetPath(),
+		Plan:       plan,
+		Option:     newOptionFromRequest(request),
+	}, nil
 }
 
 func newSkipParamsFromRequest(request *backuppb.RestoreBackupRequest) restore.SkipParams {

--- a/core/server/restore_secondary.go
+++ b/core/server/restore_secondary.go
@@ -10,17 +10,19 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
-	"github.com/zilliztech/milvus-backup/core/restore/secondary"
-	"github.com/zilliztech/milvus-backup/core/tasklet"
-	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/log"
-	"github.com/zilliztech/milvus-backup/internal/meta"
 	"github.com/zilliztech/milvus-backup/internal/pbconv"
-	"github.com/zilliztech/milvus-backup/internal/storage"
-	"github.com/zilliztech/milvus-backup/internal/storage/mpath"
-	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
+
+// restoreSecondaryUC is the slice of app.RestoreSecondary the handler needs.
+// The consumer defines it: this narrow interface is what handler tests stub
+// out.
+type restoreSecondaryUC interface {
+	Start(ctx context.Context, req app.RestoreSecondaryRequest) (app.RestoreJob, error)
+	TaskView(taskID string) (app.RestoreTaskView, error)
+}
 
 // RestoreBackup Restore interface
 // @Summary Restore interface
@@ -41,168 +43,50 @@ func (s *Server) handleRestoreSecondary(c *gin.Context) {
 
 	log.Info("receive restore secondary request", zap.Any("request", &request))
 
-	h := newRestoreSecondaryHandler(&request, s.params)
-	resp := h.run(c.Request.Context())
+	resp := s.restoreSecondary(c.Request.Context(), &request)
 
 	writeResponse(c, "restore secondary fail", resp)
 }
 
-func newRestoreSecondaryHandler(request *backuppb.RestoreSecondaryRequest, params *v2.Config) *restoreSecondaryHandler {
-	return &restoreSecondaryHandler{request: request, params: params}
-}
+// restoreSecondary keeps the v1 contract of this endpoint: the request id is
+// defaulted and echoed by every response, doubles as the restore task id, and
+// the async flag makes the server run the job in its own goroutine.
+func (s *Server) restoreSecondary(ctx context.Context, request *backuppb.RestoreSecondaryRequest) *backuppb.RestoreBackupResponse {
+	completeRestoreSecondaryRequest(request)
 
-type restoreSecondaryHandler struct {
-	params  *v2.Config
-	request *backuppb.RestoreSecondaryRequest
-
-	backupStorage  storage.Client
-	backupRootPath string
-}
-
-func (h *restoreSecondaryHandler) validate() error {
-	if len(h.request.GetBackupName()) == 0 {
-		return errors.New("backup name is required")
-	}
-
-	if len(h.request.GetSourceClusterID()) == 0 {
-		return errors.New("source cluster id is required")
-	}
-
-	if len(h.request.GetTargetClusterID()) == 0 {
-		return errors.New("target cluster id is required")
-	}
-
-	return nil
-}
-
-func (h *restoreSecondaryHandler) complete() {
-	if len(h.request.GetRequestId()) == 0 {
-		h.request.RequestId = uuid.NewString()
-	}
-}
-
-func (h *restoreSecondaryHandler) run(ctx context.Context) *backuppb.RestoreBackupResponse {
-	h.complete()
-
-	resp := &backuppb.RestoreBackupResponse{RequestId: h.request.GetRequestId()}
-	if err := h.validate(); err != nil {
+	resp := &backuppb.RestoreBackupResponse{RequestId: request.GetRequestId()}
+	if err := validateRestoreSecondaryRequest(request); err != nil {
 		resp.Code = backuppb.ResponseCode_Parameter_Error
 		resp.Msg = err.Error()
 		return resp
 	}
 
-	if err := h.initClient(ctx); err != nil {
+	uc := s.config.newRestoreSecondary(s.params)
+
+	job, err := uc.Start(ctx, newRestoreSecondaryRequest(request))
+	if err != nil {
+		// A backup that is not there is the caller's mistake; everything
+		// else is the server's.
 		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	backupDir := mpath.BackupDir(h.backupRootPath, h.request.GetBackupName())
-	exist, err := meta.Exist(ctx, h.backupStorage, backupDir)
-	if err != nil {
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Fail, Msg: err.Error()}
-	}
-	if !exist {
-		msg := fmt.Sprintf("backup %s not found", h.request.GetBackupName())
-		return &backuppb.RestoreBackupResponse{Code: backuppb.ResponseCode_Parameter_Error, Msg: msg}
-	}
-
-	task, err := h.newTask(ctx)
-	if err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	if h.request.GetAsync() {
-		return h.runAsync(task)
-	}
-
-	return h.runSync(ctx, task)
-}
-
-func (h *restoreSecondaryHandler) initClient(ctx context.Context) error {
-	backupStorage, err := storage.NewBackupStorage(ctx, h.params)
-	if err != nil {
-		return fmt.Errorf("server: create backup storage: %w", err)
-	}
-
-	backupRootPath := h.params.Backup.Storage.RootPath.Val
-	if len(h.request.GetPath()) != 0 {
-		backupRootPath = h.request.GetPath()
-	}
-
-	h.backupStorage = backupStorage
-	h.backupRootPath = backupRootPath
-	return nil
-}
-
-func (h *restoreSecondaryHandler) newTask(ctx context.Context) (tasklet.Tasklet, error) {
-	backup, err := meta.Read(ctx, h.backupStorage, mpath.BackupDir(h.backupRootPath, h.request.GetBackupName()))
-	if err != nil {
-		return nil, fmt.Errorf("server: read backup: %w", err)
-	}
-
-	milvusStorage, err := storage.NewMilvusStorage(ctx, h.params)
-	if err != nil {
-		return nil, fmt.Errorf("server: create milvus storage: %w", err)
-	}
-
-	args := secondary.TaskArgs{
-		TaskID: h.request.GetRequestId(),
-
-		SourceClusterID: h.request.GetSourceClusterID(),
-		TargetClusterID: h.request.GetTargetClusterID(),
-
-		Backup:        backup,
-		Params:        h.params,
-		BackupDir:     mpath.BackupDir(h.backupRootPath, h.request.GetBackupName()),
-		BackupStorage: h.backupStorage,
-		MilvusStorage: milvusStorage,
-
-		TaskMgr: taskmgr.DefaultMgr(),
-	}
-
-	task, err := secondary.NewTask(args)
-	if err != nil {
-		return nil, fmt.Errorf("backup: new restore task: %w", err)
-	}
-
-	return task, nil
-}
-
-func (h *restoreSecondaryHandler) runAsync(task tasklet.Tasklet) *backuppb.RestoreBackupResponse {
-	resp := &backuppb.RestoreBackupResponse{RequestId: h.request.GetRequestId()}
-
-	go func() {
-		if err := task.Execute(context.Background()); err != nil {
-			log.Error("restore backup task execute fail", zap.String("request_id", h.request.GetRequestId()), zap.Error(err))
+		var notFound *app.BackupNotFoundError
+		if errors.As(err, &notFound) {
+			resp.Code = backuppb.ResponseCode_Parameter_Error
 		}
-	}()
+		resp.Msg = err.Error()
+		return resp
+	}
 
-	taskView, err := taskmgr.DefaultMgr().GetRestoreTask(h.request.GetRequestId())
-	if err != nil {
+	if request.GetAsync() {
+		return s.restoreSecondaryAsync(uc, job, request.GetRequestId(), resp)
+	}
+
+	if err := job.Execute(ctx); err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
 		return resp
 	}
 
-	resp.Code = backuppb.ResponseCode_Success
-	resp.Msg = "restore backup is executing asynchronously"
-	resp.Data = pbconv.RestoreTaskViewToResp(taskView)
-	return resp
-}
-
-func (h *restoreSecondaryHandler) runSync(ctx context.Context, task tasklet.Tasklet) *backuppb.RestoreBackupResponse {
-	resp := &backuppb.RestoreBackupResponse{RequestId: h.request.GetRequestId()}
-
-	if err := task.Execute(ctx); err != nil {
-		resp.Code = backuppb.ResponseCode_Fail
-		resp.Msg = err.Error()
-		return resp
-	}
-
-	taskView, err := taskmgr.DefaultMgr().GetRestoreTask(h.request.GetRequestId())
+	view, err := uc.TaskView(job.TaskID())
 	if err != nil {
 		resp.Code = backuppb.ResponseCode_Fail
 		resp.Msg = err.Error()
@@ -211,6 +95,63 @@ func (h *restoreSecondaryHandler) runSync(ctx context.Context, task tasklet.Task
 
 	resp.Code = backuppb.ResponseCode_Success
 	resp.Msg = "success"
-	resp.Data = pbconv.RestoreTaskViewToResp(taskView)
+	resp.Data = pbconv.RestoreTaskViewToResp(view)
 	return resp
+}
+
+// restoreSecondaryAsync launches the job in the server's own goroutine —
+// async is a deployment concern of the HTTP server, not of the usecase — then
+// reports the freshly registered job's view.
+func (s *Server) restoreSecondaryAsync(uc restoreSecondaryUC, job app.RestoreJob, requestID string, resp *backuppb.RestoreBackupResponse) *backuppb.RestoreBackupResponse {
+	go func() {
+		if err := job.Execute(context.Background()); err != nil {
+			log.Error("restore backup task execute fail", zap.String("request_id", requestID), zap.Error(err))
+		}
+	}()
+
+	view, err := uc.TaskView(job.TaskID())
+	if err != nil {
+		resp.Code = backuppb.ResponseCode_Fail
+		resp.Msg = err.Error()
+		return resp
+	}
+
+	resp.Code = backuppb.ResponseCode_Success
+	resp.Msg = "restore backup is executing asynchronously"
+	resp.Data = pbconv.RestoreTaskViewToResp(view)
+	return resp
+}
+
+// completeRestoreSecondaryRequest defaults the request id. It doubles as the
+// restore task id, which is why the secondary endpoints have no separate one.
+func completeRestoreSecondaryRequest(request *backuppb.RestoreSecondaryRequest) {
+	if len(request.GetRequestId()) == 0 {
+		request.RequestId = uuid.NewString()
+	}
+}
+
+func validateRestoreSecondaryRequest(request *backuppb.RestoreSecondaryRequest) error {
+	if len(request.GetBackupName()) == 0 {
+		return errors.New("backup name is required")
+	}
+
+	if len(request.GetSourceClusterID()) == 0 {
+		return errors.New("source cluster id is required")
+	}
+
+	if len(request.GetTargetClusterID()) == 0 {
+		return errors.New("target cluster id is required")
+	}
+
+	return nil
+}
+
+func newRestoreSecondaryRequest(request *backuppb.RestoreSecondaryRequest) app.RestoreSecondaryRequest {
+	return app.RestoreSecondaryRequest{
+		TaskID:          request.GetRequestId(),
+		BackupName:      request.GetBackupName(),
+		SourceClusterID: request.GetSourceClusterID(),
+		TargetClusterID: request.GetTargetClusterID(),
+		Path:            request.GetPath(),
+	}
 }

--- a/core/server/restore_test.go
+++ b/core/server/restore_test.go
@@ -1,58 +1,58 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/zilliztech/milvus-backup/app"
 	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
 	"github.com/zilliztech/milvus-backup/core/restore"
+	v2 "github.com/zilliztech/milvus-backup/internal/cfg/v2"
 	"github.com/zilliztech/milvus-backup/internal/collref"
 	"github.com/zilliztech/milvus-backup/internal/filter"
+	"github.com/zilliztech/milvus-backup/internal/taskmgr"
 )
 
-func TestRestoreHandler_validate(t *testing.T) {
+func TestValidateRestoreRequest(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{BackupName: "backup"}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.NoError(t, err)
+		assert.NoError(t, validateRestoreRequest(request))
 	})
 
 	t.Run("BackupNameEmpty", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.Error(t, err)
+		assert.Error(t, validateRestoreRequest(request))
 	})
 
 	t.Run("DropAndNotCreate", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{BackupName: "backup", DropExistCollection: true, SkipCreateCollection: true}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.Error(t, err)
+		assert.Error(t, validateRestoreRequest(request))
 	})
 
 	t.Run("RestorePlanAndCollectionSuffix", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{BackupName: "backup", RestorePlan: &backuppb.RestorePlan{}, CollectionSuffix: "_suffix"}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.Error(t, err)
+		assert.Error(t, validateRestoreRequest(request))
 	})
 
 	t.Run("RestorePlanAndCollectionRenames", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{BackupName: "backup", RestorePlan: &backuppb.RestorePlan{}, CollectionRenames: map[string]string{"db1.coll1": "db2.coll2"}}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.Error(t, err)
+		assert.Error(t, validateRestoreRequest(request))
 	})
 
 	t.Run("InvalidCollectionSuffix", func(t *testing.T) {
 		request := &backuppb.RestoreBackupRequest{BackupName: "backup", CollectionSuffix: "invalid-suffix"}
-		h := newRestoreHandler(request, nil)
-		err := h.validate()
-		assert.Error(t, err)
+		assert.Error(t, validateRestoreRequest(request))
 	})
 }
 
@@ -415,5 +415,321 @@ func TestNewCollOverridesFromPlan(t *testing.T) {
 		}
 		result := newCollOverridesFromPlan(plan)
 		assert.Nil(t, result)
+	})
+}
+
+// stubRestoreJob stands in for app.RestoreJob: a canned error and a call
+// count, so tests can assert whether the handler ran the job at all. The
+// count is atomic because async tests poll it from the test goroutine while
+// the handler's job goroutine increments it.
+type stubRestoreJob struct {
+	executeErr error
+	calls      atomic.Int32
+}
+
+func (j *stubRestoreJob) Execute(context.Context) error {
+	j.calls.Add(1)
+	return j.executeErr
+}
+
+func (j *stubRestoreJob) TaskID() string { return "task-1" }
+
+// stubRestoreBackup stands in for app.Restore: a canned start error, the
+// request it was called with, and a call count.
+type stubRestoreBackup struct {
+	job      app.RestoreJob
+	startErr error
+	view     app.RestoreTaskView
+	viewErr  error
+
+	req   app.RestoreRequest
+	calls int
+}
+
+func (s *stubRestoreBackup) Start(_ context.Context, req app.RestoreRequest) (app.RestoreJob, error) {
+	s.calls++
+	s.req = req
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+
+	return s.job, nil
+}
+
+func (s *stubRestoreBackup) TaskView(string) (app.RestoreTaskView, error) {
+	return s.view, s.viewErr
+}
+
+// withRestoreBackup wires the stub as the restore usecase.
+func withRestoreBackup(stub *stubRestoreBackup) Option {
+	return func(c *config) {
+		c.newRestoreBackup = func(*v2.Config) restoreBackupUC { return stub }
+	}
+}
+
+// newStubRestoreView returns a task view the rendering can run over.
+func newStubRestoreView(t *testing.T) *taskmgr.MockRestoreTaskView {
+	t.Helper()
+
+	view := taskmgr.NewMockRestoreTaskView(t)
+	view.EXPECT().ID().Return("task-1").Maybe()
+	view.EXPECT().StateCode().Return(backuppb.RestoreTaskStateCode_SUCCESS).Maybe()
+	view.EXPECT().ErrorMessage().Return("").Maybe()
+	view.EXPECT().StartTime().Return(time.Unix(1, 0)).Maybe()
+	view.EXPECT().EndTime().Return(time.Unix(2, 0)).Maybe()
+	view.EXPECT().Progress().Return(int32(100)).Maybe()
+	view.EXPECT().TotalSize().Return(int64(0)).Maybe()
+	view.EXPECT().CollTasks().Return(nil).Maybe()
+
+	return view
+}
+
+func restoreBackup(t *testing.T, s *Server, body string, requestID string) backuppb.RestoreBackupResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/restore", strings.NewReader(body))
+	if requestID != "" {
+		req.Header.Set("request_id", requestID)
+	}
+	s.engine.ServeHTTP(w, req)
+
+	var resp backuppb.RestoreBackupResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	return resp
+}
+
+func TestHandleRestoreBackup(t *testing.T) {
+	t.Run("RestoresThroughTheUsecase", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreBackup{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "success", resp.GetMsg())
+		assert.Equal(t, "task-1", resp.GetData().GetId())
+		assert.Equal(t, 1, stub.calls)
+		assert.Equal(t, int32(1), job.calls.Load())
+	})
+
+	t.Run("RejectsInvalidBody", func(t *testing.T) {
+		stub := &stubRestoreBackup{}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/restore", strings.NewReader("{invalid"))
+		s.engine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("RejectsMissingNameWithoutCallingUsecase", func(t *testing.T) {
+		stub := &stubRestoreBackup{}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "backup name is required")
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("DefaultsRequestIdAndTaskId", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreBackup{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "")
+
+		// The response echoes a generated request id; the usecase got a
+		// generated task id of the endpoint's own "restore_" shape.
+		assert.NotEmpty(t, resp.GetRequestId())
+		assert.True(t, strings.HasPrefix(stub.req.TaskID, "restore_"))
+		assert.Equal(t, "backup1", stub.req.BackupName)
+	})
+
+	t.Run("ForwardsRequestId", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreBackup{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		// This endpoint takes the request id from the body field, unlike the
+		// list and delete handlers, which read the header.
+		resp := restoreBackup(t, s, `{"backup_name":"backup1","requestId":"rid-1"}`, "")
+
+		assert.Equal(t, "rid-1", resp.GetRequestId())
+	})
+
+	t.Run("MapsUnknownBackupToParameterError", func(t *testing.T) {
+		stub := &stubRestoreBackup{startErr: &app.BackupNotFoundError{Name: "backup1"}}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "backup backup1 not found")
+		assert.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("MapsStartErrorToFail", func(t *testing.T) {
+		stub := &stubRestoreBackup{startErr: errors.New("dial timeout")}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "dial timeout")
+		assert.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("MapsExecuteErrorToFail", func(t *testing.T) {
+		job := &stubRestoreJob{executeErr: errors.New("bulk insert failed")}
+		stub := &stubRestoreBackup{job: job}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "bulk insert failed")
+		assert.Equal(t, int32(1), job.calls.Load())
+	})
+
+	t.Run("MapsTaskViewErrorToFail", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreBackup{job: job, viewErr: errors.New("task mgr closed")}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "task mgr closed")
+	})
+
+	t.Run("AsyncRunsTheJobAndReportsIt", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreBackup{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreBackup(stub))
+
+		resp := restoreBackup(t, s, `{"backup_name":"backup1","async":true}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "restore backup is executing asynchronously", resp.GetMsg())
+		assert.Equal(t, "task-1", resp.GetData().GetId())
+		assert.Eventually(t, func() bool { return job.calls.Load() == 1 }, time.Second, 10*time.Millisecond)
+	})
+}
+
+// stubRestoreSecondary stands in for app.RestoreSecondary.
+type stubRestoreSecondary struct {
+	job      app.RestoreJob
+	startErr error
+	view     app.RestoreTaskView
+	viewErr  error
+
+	req   app.RestoreSecondaryRequest
+	calls int
+}
+
+func (s *stubRestoreSecondary) Start(_ context.Context, req app.RestoreSecondaryRequest) (app.RestoreJob, error) {
+	s.calls++
+	s.req = req
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+
+	return s.job, nil
+}
+
+func (s *stubRestoreSecondary) TaskView(string) (app.RestoreTaskView, error) {
+	return s.view, s.viewErr
+}
+
+// withRestoreSecondary wires the stub as the secondary restore usecase.
+func withRestoreSecondary(stub *stubRestoreSecondary) Option {
+	return func(c *config) {
+		c.newRestoreSecondary = func(*v2.Config) restoreSecondaryUC { return stub }
+	}
+}
+
+func restoreSecondary(t *testing.T, s *Server, body string, requestID string) backuppb.RestoreBackupResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/restore_secondary", strings.NewReader(body))
+	if requestID != "" {
+		req.Header.Set("request_id", requestID)
+	}
+	s.engine.ServeHTTP(w, req)
+
+	var resp backuppb.RestoreBackupResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	return resp
+}
+
+func TestHandleRestoreSecondary(t *testing.T) {
+	t.Run("RestoresThroughTheUsecase", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreSecondary{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreSecondary(stub))
+
+		resp := restoreSecondary(t, s, `{"backup_name":"backup1","sourceClusterID":"src","targetClusterID":"dst"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "success", resp.GetMsg())
+		assert.Equal(t, "task-1", resp.GetData().GetId())
+		assert.Equal(t, 1, stub.calls)
+		assert.Equal(t, int32(1), job.calls.Load())
+		// The request id doubles as the restore task id.
+		assert.NotEmpty(t, resp.GetRequestId())
+		assert.Equal(t, resp.GetRequestId(), stub.req.TaskID)
+	})
+
+	t.Run("RejectsMissingClusterIDsWithoutCallingUsecase", func(t *testing.T) {
+		stub := &stubRestoreSecondary{}
+		s := newListTestServer(t, withRestoreSecondary(stub))
+
+		resp := restoreSecondary(t, s, `{"backup_name":"backup1"}`, "")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "source cluster id is required")
+		assert.Zero(t, stub.calls)
+	})
+
+	t.Run("MapsUnknownBackupToParameterError", func(t *testing.T) {
+		stub := &stubRestoreSecondary{startErr: &app.BackupNotFoundError{Name: "backup1"}}
+		s := newListTestServer(t, withRestoreSecondary(stub))
+
+		resp := restoreSecondary(t, s, `{"backup_name":"backup1","sourceClusterID":"src","targetClusterID":"dst"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Parameter_Error, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "backup backup1 not found")
+	})
+
+	t.Run("MapsExecuteErrorToFail", func(t *testing.T) {
+		job := &stubRestoreJob{executeErr: errors.New("ddl replay failed")}
+		stub := &stubRestoreSecondary{job: job}
+		s := newListTestServer(t, withRestoreSecondary(stub))
+
+		resp := restoreSecondary(t, s, `{"backup_name":"backup1","sourceClusterID":"src","targetClusterID":"dst"}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Fail, resp.GetCode())
+		assert.Contains(t, resp.GetMsg(), "ddl replay failed")
+	})
+
+	t.Run("AsyncRunsTheJobAndReportsIt", func(t *testing.T) {
+		job := &stubRestoreJob{}
+		stub := &stubRestoreSecondary{job: job, view: newStubRestoreView(t)}
+		s := newListTestServer(t, withRestoreSecondary(stub))
+
+		resp := restoreSecondary(t, s, `{"backup_name":"backup1","sourceClusterID":"src","targetClusterID":"dst","async":true}`, "rid-1")
+
+		assert.Equal(t, backuppb.ResponseCode_Success, resp.GetCode())
+		assert.Equal(t, "restore backup is executing asynchronously", resp.GetMsg())
+		assert.Eventually(t, func() bool { return job.calls.Load() == 1 }, time.Second, 10*time.Millisecond)
 	})
 }


### PR DESCRIPTION
/kind improvement

Part of #1171.

## What

`app` gains the restore family as two usecases, `Restore` and `RestoreSecondary`, shaped like their siblings — create (#1205) and get backup (#1203). Both transports call them; only the per-transport input grammar and the v1 rendering stay behind:

- `app.NewRestore(ctx, params, taskMgr)` creates both storage clients itself, so transports never import `internal/storage`, and resolves the root path from config. `NewBackupStorage` also creates the backup bucket when it is missing — a restore may target a bucket nothing has written yet, which the old code arranged per request and the constructor now arranges per construction. `app.NewRestoreSecondary` is the same for a secondary restore. The clients are created per call, as the other usecases' are.
- `app.Restore.Start(ctx, req)` validates the request against the backup storage — the backup must exist and its meta must be readable, because a not-found backup is the caller's mistake and has to be answered before the job is registered — then builds the `restore.Task`; task creation is what registers the job, exactly as before. It returns an `app.RestoreJob`, a one-method `Run(ctx) error` interface like create's `BackupJob`, so the transports drive the job without importing the task layer. The async split follows the issue's rule: the action is synchronous, the goroutine is the HTTP server's deployment concern. A not-found backup is the shared `app.ErrBackupNotFound` sentinel from get_backup, wrapped with the name the same way.
- The v1 `bucket_name` and `path` fields are config overrides, not request options: the handler forks the loaded config with them (`backup.storage.bucketName` / `backup.storage.rootPath`) and builds the usecase from the fork, exactly as get_backup does for its path and create for its root. The override fields therefore do not exist on the usecase request, and there is no per-Start client creation — the seams are the standard `func(ctx, params) (uc, error)` shape.
- `core/server` gets `newRestoreBackup` / `newRestoreSecondary` constructor hooks on the server config (the same seam list create and the rest got), defaulting to `app.NewRestore` / `app.NewRestoreSecondary` with the process-local task manager; handler tests stub them.
- The response's task view is read through the get-restore usecase — the same usecase `/get_restore` answers from — via a small `restoreTaskView` helper. There is no `TaskView` method on the restore usecases and no view alias: the job half has one reader.
- The `/restore` handler narrows to: bind the pb request, default request id and task id, validate, translate the pb grammar into `app.RestoreRequest` (plan and option are parse products of pb-only fields, including the deprecated `db_collections`, so they are built here), fork the config when the request overrides bucket or path, build the usecase, start it, then run the job synchronously or launch it in its own goroutine with the same log line as before, and render. The same narrowing applies to `cmd/restore` and `cmd/restore/secondary`, which keep their flags, their plan building and the duration print.
- `core/restore` (and its `secondary` subpackage) is untouched; the app layer injects and drives it. `RestoreRequest.Plan`/`.Option` deliberately use the task layer's own vocabulary: each transport translates its grammar into them (flags vs pb fields), and the two grammars do not map onto each other, so there is nothing transport-neutral to put there instead.

## Semantics unchanged

Sync and async execution, the `restore_<timestamp>` task id default, `Parameter_Error` vs `Fail` mapping, the per-endpoint response quirks (the v1 `/restore` failures before the task exists respond without a request id; `/restore_secondary` failures respond with it), the async success message, the goroutine log lines, and the secondary defenses (full-meta read, index-extra preconditions inside `secondary.NewTask`) are all preserved. The `use bucket name from request` / `use path from request` log lines move with the overrides into the handler's fork block.

Five declared deltas, all smaller than the noise they replace:

1. Error precedence on `/restore` when both the request grammar and storage are broken: the old handler built the plan after the storage clients came up, so storage errors won; the plan is now translated before the usecase is built, so a malformed plan (bad `collection_renames`, unparsable `db_collections`) is reported first. The CLI already had the plan-first order, so the two transports now agree. Error codes are unaffected (both are `Fail`).
2. The two `/restore_secondary` error paths that previously responded without a request id (storage failure during the existence check, and backup not found) now respond with it, because every `Start` failure flows through one response; construction failures do too. Every other `/restore_secondary` failure already carried the id; this removes the inconsistency rather than adding one.
3. On `/restore_secondary` the target cluster's storage client is now built before the backup's existence is checked, so a broken target storage wins over a missing backup where the old order reported the missing backup. `/restore` is unaffected — both clients already came up before the existence check there.
4. The not-found answer is now the `ErrBackupNotFound` sentinel, so its text is `app: backup <name>: backup not found` (was `backup <name> not found`), matching get_backup.
5. `cmd/restore` error strings change with the moved assembly (`create backup storage: ...` → `app: create backup storage client: ...`); the `NewBackupStorage`-vs-`NewClient`+`CreateBucketIfNotExist` difference between the CLI and the old server handler collapses into one path that creates the bucket either way.

Also noted, not changed: the v1 `/restore` and `/restore_secondary` endpoints ignore the `request_id` header that their swagger comments advertise; the id comes from the body field only. Fixing that would be a behavior change, so it is left as is.

## Tests

- `app/restore_test.go`: mock-client coverage for both usecases over the struct-literal construction (the constructor creates real clients, so tests skip it as create's do) — `Start` assembles and registers the job (the view becomes visible in the usecase's own task manager with the initial state), backup not found (`ErrBackupNotFound`), existence-check failure, meta-read failure, task refusing an unknown format
- `core/server/restore_test.go`: the plan/option/filter translation tests carry over unchanged (the functions moved nowhere); new httptest handler-contract cases for both endpoints over the stubbed usecases — success and async paths, invalid body, missing name/cluster ids rejected before the usecase runs, request id and task id defaulting and forwarding, bucket and path forking the config (and no fork without them), not-found mapped to `Parameter_Error`, construction/start/run/get-restore errors mapped to `Fail`
- `internal/storage/factory_test.go`: mapping tests for the shared `storageConfig` and its two wrappers — the section a usecase's (possibly forked) params carry is what the client actually runs on, so this pins the field mapping and that `BackupStorageConfig` reads the backup section rather than the milvus one, closing the one link the handler and usecase tests deliberately stub around
