### PR TITLE
cfg: add Config.Fork for map-based overrides on a frozen copy

### DIFF
--- a/internal/cfg/param/source.go
+++ b/internal/cfg/param/source.go
@@ -23,20 +23,29 @@ type Source struct {
 	override     map[string]string
 	overrideKeys []string
 
+	// noEnv disables environment lookups. A source built from an
+	// already-resolved rendering (a config fork) must not pick up process
+	// variables on the second pass: its YAML layer is the resolved state.
+	noEnv bool
+
 	configFile map[string]any
 }
 
-// NewSource reads configPath and flattens it into dotted lower-case keys.
-// An empty configPath yields a source backed by overrides and env only.
-func NewSource(configPath string, overrides map[string]string) (*Source, error) {
+func newSource(overrides map[string]string) *Source {
 	s := &Source{override: make(map[string]string, len(overrides)), configFile: map[string]any{}}
-
 	for k, v := range overrides {
 		s.override[strings.ToLower(k)] = v
 		s.overrideKeys = append(s.overrideKeys, k)
 	}
 	slices.Sort(s.overrideKeys)
 
+	return s
+}
+
+// NewSource reads configPath and flattens it into dotted lower-case keys.
+// An empty configPath yields a source backed by overrides and env only.
+func NewSource(configPath string, overrides map[string]string) (*Source, error) {
+	s := newSource(overrides)
 	if configPath == "" {
 		return s, nil
 	}
@@ -49,20 +58,42 @@ func NewSource(configPath string, overrides map[string]string) (*Source, error) 
 	if err != nil {
 		return nil, fmt.Errorf("cfg: read config file %s: %w", resolved, err)
 	}
+	if err := s.setYAML(raw); err != nil {
+		return nil, fmt.Errorf("cfg: config file %s: %w", resolved, err)
+	}
+	s.path = resolved
 
+	return s, nil
+}
+
+// NewSourceYAML builds a source from YAML held in memory instead of a file on
+// disk, and disables environment lookups: the YAML is a rendering of an
+// already-resolved configuration, so a process variable must not leak into the
+// second resolution pass.
+func NewSourceYAML(raw []byte, overrides map[string]string) (*Source, error) {
+	s := newSource(overrides)
+	s.noEnv = true
+	if err := s.setYAML(raw); err != nil {
+		return nil, fmt.Errorf("cfg: in-memory yaml: %w", err)
+	}
+
+	return s, nil
+}
+
+// setYAML decodes raw and flattens it into dotted lower-case keys.
+func (s *Source) setYAML(raw []byte) error {
 	var decoded any
 	if err := yaml.Unmarshal(raw, &decoded); err != nil {
-		return nil, fmt.Errorf("cfg: parse yaml %s: %w", resolved, err)
+		return fmt.Errorf("parse yaml: %w", err)
 	}
 
 	out := map[string]any{}
 	if err := flattenAny("", decoded, out); err != nil {
-		return nil, fmt.Errorf("cfg: flatten yaml %s: %w", resolved, err)
+		return fmt.Errorf("flatten yaml: %w", err)
 	}
-	s.path = resolved
 	s.configFile = out
 
-	return s, nil
+	return nil
 }
 
 func (s *Source) lookupOverride(key string) (string, bool) {
@@ -71,6 +102,9 @@ func (s *Source) lookupOverride(key string) (string, bool) {
 }
 
 func (s *Source) lookupEnv(key string) (string, bool) {
+	if s.noEnv {
+		return "", false
+	}
 	val, ok := os.LookupEnv(key)
 	return val, ok
 }

--- a/internal/cfg/v2/fork.go
+++ b/internal/cfg/v2/fork.go
@@ -1,0 +1,138 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// Fork derives an independent copy of c with overrides applied, spelled the
+// --set way: dotted config keys (or credential environment names) mapped to
+// string values.
+//
+// A fork is a frozen copy, not a re-load: every leaf keeps the receiver's
+// resolved value and provenance unless the override map names it, the process
+// environment is not consulted, and backup.storage does not re-inherit from an
+// overridden milvus.storage — overrides apply to leaves, and nothing cascades.
+// A nil or empty map yields a validated deep copy.
+//
+// An unknown key is an error, not a warning: unlike a --set on the command
+// line, a programmatic caller has no "keep going anyway" case, so a
+// misspelling is a bug worth failing on. The derived configuration is
+// validated before it is returned, so a fork either differs from c exactly at
+// the overridden keys or fails outright.
+func (c *Config) Fork(overrides map[string]string) (*Config, error) {
+	if err := checkForkKeys(c, overrides); err != nil {
+		return nil, err
+	}
+
+	raw, err := Render(c, nil)
+	if err != nil {
+		return nil, err
+	}
+	src, err := param.NewSourceYAML(raw, overrides)
+	if err != nil {
+		return nil, fmt.Errorf("cfg: fork config: %w", err)
+	}
+
+	forked := New()
+	if err := forked.Resolve(src); err != nil {
+		return nil, fmt.Errorf("cfg: fork config: %w", err)
+	}
+	// Re-resolution is only the application mechanism: it parses and stamps
+	// the overridden leaves, but it also re-derives every other leaf from the
+	// rendered values, losing the original provenance and re-running storage
+	// inheritance. Restore each leaf the map does not name from the receiver,
+	// so the fork differs from it exactly at the overridden keys.
+	restoreUntouched(c, forked, overrides)
+
+	if err := forked.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg: fork config: %w", err)
+	}
+
+	return forked, nil
+}
+
+// checkForkKeys rejects every override key the schema does not declare, with a
+// migration hint when one names a v1 key.
+func checkForkKeys(c *Config, overrides map[string]string) error {
+	configKeys, envNames := param.DeclaredKeys(c)
+
+	var errs []error
+	for _, key := range slices.Sorted(maps.Keys(overrides)) {
+		k := strings.ToLower(key)
+		if _, ok := configKeys[k]; ok {
+			continue
+		}
+		if _, ok := envNames[k]; ok {
+			continue
+		}
+		errs = append(errs, errors.New(unknownForkKey(key)))
+	}
+
+	return errors.Join(errs...)
+}
+
+func unknownForkKey(key string) string {
+	to, isLegacy := Migration(key)
+	switch {
+	case isLegacy && to == "":
+		return fmt.Sprintf("cfg: fork override %q is a v1 key that was removed in v2", key)
+	case isLegacy:
+		return fmt.Sprintf("cfg: fork override %q is a v1 key, use %s instead", key, to)
+	default:
+		return fmt.Sprintf("cfg: fork override %q matches no v2 config key or credential environment name", key)
+	}
+}
+
+// restoreUntouched copies every leaf the override map does not name from
+// parent to forked. Walk visits both trees in the same deterministic field
+// order, so pairing them by index is safe.
+func restoreUntouched(parent, forked *Config, overrides map[string]string) {
+	overridden := make(map[string]struct{}, len(overrides))
+	for key := range overrides {
+		overridden[strings.ToLower(key)] = struct{}{}
+	}
+
+	var parents []reflect.Value
+	param.Walk(parent, func(_ string, f param.Field) {
+		parents = append(parents, reflect.ValueOf(f).Elem())
+	})
+
+	i := 0
+	param.Walk(forked, func(_ string, f param.Field) {
+		p := parents[i]
+		i++
+		if namesOverridden(f, overridden) {
+			return
+		}
+		reflect.ValueOf(f).Elem().Set(p)
+		// The struct copy shares the list backing array with the parent; clone
+		// it so the two configurations are independent.
+		if l, ok := f.(*param.List); ok {
+			l.Val = slices.Clone(l.Val)
+		}
+	})
+}
+
+// namesOverridden reports whether the override map names f, by config key or
+// by environment name — the two spellings a resolution lookup accepts.
+func namesOverridden(f param.Field, overridden map[string]struct{}) bool {
+	for _, key := range f.ConfigKeys() {
+		if _, ok := overridden[strings.ToLower(key)]; ok {
+			return true
+		}
+	}
+	for _, key := range f.EnvNames() {
+		if _, ok := overridden[strings.ToLower(key)]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/cfg/v2/fork_test.go
+++ b/internal/cfg/v2/fork_test.go
@@ -1,0 +1,219 @@
+package v2
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// leafValues flattens a configuration into Go field path -> resolved value, so
+// two configurations can be compared leaf by leaf.
+func leafValues(c *Config) map[string]any {
+	out := map[string]any{}
+	param.Walk(c, func(name string, f param.Field) { out[name] = f.YAMLValue() })
+
+	return out
+}
+
+// leafDiff returns the names of the leaves whose resolved values differ
+// between a and b.
+func leafDiff(a, b *Config) []string {
+	av, bv := leafValues(a), leafValues(b)
+
+	var diff []string
+	for name, v := range av {
+		if !assert.ObjectsAreEqual(v, bv[name]) {
+			diff = append(diff, name)
+		}
+	}
+
+	return diff
+}
+
+func TestFork_FrozenCopy(t *testing.T) {
+	parent, err := Load(filepath.Join("testdata", "complete.yaml"), map[string]string{"milvus.password": "supersecret123"})
+	require.NoError(t, err)
+
+	forked, err := parent.Fork(nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, leafDiff(parent, forked))
+
+	// Provenance is preserved as-is: a --set value stays an override, a file
+	// value stays file-sourced, an untouched leaf stays defaulted.
+	assert.Equal(t, param.Used{Kind: param.SourceOverride, Key: "milvus.password"}, forked.Milvus.Password.Used)
+	assert.Equal(t, param.Used{Kind: param.SourceConfigFile, Key: "milvus.grpc.address"}, forked.Milvus.Grpc.Address.Used)
+	// complete.yaml leaves milvusAddress unset; its empty value survives the
+	// render round trip, and the fork still reports it as defaulted.
+	assert.Equal(t, param.SourceDefault, forked.Milvus.Storage.MilvusAddress.Used.Kind)
+}
+
+func TestFork_OverrideApplies(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	forked, err := parent.Fork(map[string]string{"backup.storage.rootPath": "req-path"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "req-path", forked.Backup.Storage.RootPath.Val)
+	assert.Equal(t, param.Used{Kind: param.SourceOverride, Key: "backup.storage.rootpath"}, forked.Backup.Storage.RootPath.Used)
+
+	// The fork differs from its parent at exactly the overridden leaf.
+	assert.Equal(t, []string{"Backup.Storage.RootPath"}, leafDiff(parent, forked))
+}
+
+// An override may name a credential by its environment name, the way --set
+// accepts both spellings.
+func TestFork_OverrideByEnvName(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	forked, err := parent.Fork(map[string]string{"MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY": "forked-sk"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "forked-sk", forked.Milvus.Storage.Auth.SecretAccessKey.Val)
+	assert.Equal(t, param.Used{Kind: param.SourceOverride, Key: "milvus_storage_auth_secret_access_key"},
+		forked.Milvus.Storage.Auth.SecretAccessKey.Used)
+	assert.Equal(t, []string{"Milvus.Storage.Auth.SecretAccessKey"}, leafDiff(parent, forked))
+}
+
+// Overriding milvus.storage must not cascade into backup.storage: a fork
+// overrides leaves, it does not re-run inheritance.
+func TestFork_NoCascade(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+	require.Equal(t, "a-bucket", parent.Backup.Storage.BucketName.Val) // inherited from milvus.storage
+
+	forked, err := parent.Fork(map[string]string{"milvus.storage.bucketName": "other-bucket"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "other-bucket", forked.Milvus.Storage.BucketName.Val)
+	assert.Equal(t, "a-bucket", forked.Backup.Storage.BucketName.Val)
+	assert.Equal(t, []string{"Milvus.Storage.BucketName"}, leafDiff(parent, forked))
+}
+
+func TestFork_UnknownKey(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	t.Run("Misspelled", func(t *testing.T) {
+		_, err := parent.Fork(map[string]string{"backup.storage.nope": "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"backup.storage.nope" matches no v2 config key`)
+	})
+
+	t.Run("V1Key", func(t *testing.T) {
+		_, err := parent.Fork(map[string]string{"minio.backuprootpath": "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"minio.backuprootpath" is a v1 key`)
+		assert.Contains(t, err.Error(), "backup.storage.rootPath")
+	})
+
+	t.Run("RemovedV1Key", func(t *testing.T) {
+		_, err := parent.Fork(map[string]string{"http.enabled": "true"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"http.enabled" is a v1 key that was removed in v2`)
+	})
+
+	t.Run("EveryUnknownKeyIsReported", func(t *testing.T) {
+		_, err := parent.Fork(map[string]string{"foo.bar": "x", "milvus.address": "localhost"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foo.bar")
+		assert.Contains(t, err.Error(), "milvus.address")
+	})
+}
+
+func TestFork_InvalidValue(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	_, err = parent.Fork(map[string]string{"milvus.grpc.port": "not-a-port"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-a-port")
+}
+
+// An override that leaves the configuration in an invalid state fails the fork
+// rather than producing a config no load would have accepted.
+func TestFork_ValidationFails(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	_, err = parent.Fork(map[string]string{"milvus.storage.provider": "bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "bogus"`)
+}
+
+// A fork resolves from the receiver's rendered values with the environment
+// disabled: a variable set after the parent loaded must not leak in.
+func TestFork_EnvNotPickedUp(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+	require.Equal(t, "minioadmin", parent.Milvus.Storage.Auth.SecretAccessKey.Val)
+
+	t.Setenv("MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY", "changed")
+
+	forked, err := parent.Fork(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "minioadmin", forked.Milvus.Storage.Auth.SecretAccessKey.Val)
+	assert.Equal(t, param.SourceDefault, forked.Milvus.Storage.Auth.SecretAccessKey.Used.Kind)
+}
+
+// A value the parent took from the environment keeps that provenance in the
+// fork, env stamp included.
+func TestFork_ProvenancePreserved(t *testing.T) {
+	t.Setenv("MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY", "from-env")
+
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+	require.Equal(t, param.SourceEnv, parent.Milvus.Storage.Auth.SecretAccessKey.Used.Kind)
+
+	forked, err := parent.Fork(map[string]string{"restore.keepTempFiles": "true"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-env", forked.Milvus.Storage.Auth.SecretAccessKey.Val)
+	assert.Equal(t, param.Used{Kind: param.SourceEnv, Key: "milvus_storage_auth_secret_access_key"},
+		forked.Milvus.Storage.Auth.SecretAccessKey.Used)
+}
+
+func TestFork_ListOverride(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	forked, err := parent.Fork(map[string]string{"milvus.etcd.endpoints": "a:2379, b:2379"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"a:2379", "b:2379"}, forked.Milvus.Etcd.Endpoints.Val)
+	assert.Equal(t, param.Used{Kind: param.SourceOverride, Key: "milvus.etcd.endpoints"}, forked.Milvus.Etcd.Endpoints.Used)
+	assert.Equal(t, []string{"localhost:2379"}, parent.Milvus.Etcd.Endpoints.Val)
+}
+
+func TestFork_ParentUnchanged(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	_, err = parent.Fork(map[string]string{"backup.storage.rootPath": "req-path"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "backup", parent.Backup.Storage.RootPath.Val)
+	assert.Equal(t, param.SourceDefault, parent.Backup.Storage.RootPath.Used.Kind)
+}
+
+// A fork shares no mutable state with its parent: writing into either one
+// leaves the other alone.
+func TestFork_DeepCopyIndependence(t *testing.T) {
+	parent, err := Load("", nil)
+	require.NoError(t, err)
+
+	forked, err := parent.Fork(nil)
+	require.NoError(t, err)
+
+	forked.Backup.Storage.RootPath.Val = "changed"
+	forked.Milvus.Etcd.Endpoints.Val[0] = "changed:2379"
+
+	assert.Equal(t, "backup", parent.Backup.Storage.RootPath.Val)
+	assert.Equal(t, []string{"localhost:2379"}, parent.Milvus.Etcd.Endpoints.Val)
+}


### PR DESCRIPTION
Fixes #1209

Related: #1203

## What

Adds `func (c *Config) Fork(overrides map[string]string) (*Config, error)` to `internal/cfg/v2`: derive an independent copy of a resolved configuration with a `--set`-style override map applied. The first consumer is the GetBackup usecase (#1203), which needs to honor a per-request `path` parameter without mutating the shared config.

## Semantics

- **Frozen copy.** Every leaf keeps the receiver's resolved value unless the override map names it. The process environment is not consulted on the fork pass, and `backup.storage` does **not** re-inherit from an overridden `milvus.storage` — overrides apply to leaves, nothing cascades.
- **Provenance preserved.** Untouched leaves keep their original `Used` stamps (including `override`/`env` stamps from the parent load); overridden leaves get a fresh `SourceOverride` stamp.
- **`--set` semantics for the map.** Dotted lower-case config keys or credential environment names, string values parsed by the same `parseValue` path, lists comma-separated.
- **Fail-fast.** Unknown keys are errors (with a v1 migration hint), unparseable values error, and the derived configuration is re-`Validate()`d before returning. `Fork(nil)` yields a validated deep copy; the receiver is never mutated.

## How

Render the receiver to in-memory YAML → resolve a fresh tree from a new `param.NewSourceYAML` (in-memory, environment disabled) → walk both trees in parallel and copy back every leaf the map does not name, restoring value and provenance → `Validate()`. Re-resolution is only the application mechanism for the overridden leaves; the copy-back is what makes the fork differ from its parent at exactly the overridden keys.

## Tests

`fork_test.go` covers the frozen-copy equality, single-leaf override (by config key and by env name), the no-cascade guarantee, unknown/v1/removed keys, unparseable values, validation failure, post-load environment isolation, provenance preservation, list overrides, parent immutability, and deep-copy independence.