### PR TITLE
backup: log snapshot lifetime and retry drop in client

### DIFF
--- a/core/backup/coll_snapshot_task.go
+++ b/core/backup/coll_snapshot_task.go
@@ -17,12 +17,6 @@ import (
 
 const (
 	_snapshotPollInterval = 3 * time.Second
-
-	// A drop right after the export job goes terminal can still be rejected: DataCoord
-	// releases the pin it took for the copy on its own reconcile tick, not inline with
-	// the state change the poll observed.
-	_snapshotDropRetry    = 10
-	_snapshotDropInterval = time.Second
 )
 
 type collSnapshotTask struct {
@@ -178,28 +172,14 @@ func (st *collSnapshotTask) dropSnapshot(ctx context.Context) {
 	// here, and the snapshot still has to go.
 	ctx = context.WithoutCancel(ctx)
 
-	for attempt := range _snapshotDropRetry {
-		err := st.grpc.DropSnapshot(ctx, st.collRef.DBName(), st.collRef.CollName(), st.snapshotName)
-		if err == nil {
-			st.logger.Info("snapshot dropped")
-			return
-		}
-
-		st.logger.Warn("drop snapshot failed, will retry",
-			zap.Int("attempt", attempt+1),
+	if err := st.grpc.DropSnapshot(ctx, st.collRef.DBName(), st.collRef.CollName(), st.snapshotName); err != nil {
+		// Nothing else can clean this up: the export job that pinned it is gone, and the
+		// backup meta does not record snapshot names.
+		st.logger.Error("could not drop snapshot, it holds its collection's files against gc until removed by hand",
+			zap.String("snapshot_name", st.snapshotName),
 			zap.Error(err))
-
-		timer := time.NewTimer(_snapshotDropInterval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return
-		case <-timer.C:
-		}
+		return
 	}
 
-	// Nothing else can clean this up: the export job that pinned it is gone, and the
-	// backup meta does not record snapshot names.
-	st.logger.Error("could not drop snapshot, it holds its collection's files against gc until removed by hand",
-		zap.String("snapshot_name", st.snapshotName))
+	st.logger.Info("snapshot dropped")
 }

--- a/core/backup/coll_snapshot_task.go
+++ b/core/backup/coll_snapshot_task.go
@@ -72,6 +72,9 @@ func (st *collSnapshotTask) Execute(ctx context.Context) error {
 	if err := st.grpc.CreateSnapshot(ctx, st.collRef.DBName(), st.collRef.CollName(), st.snapshotName, 0); err != nil {
 		return fmt.Errorf("backup: create snapshot: %w", err)
 	}
+	// A snapshot pins its collection's files in Milvus until dropped, so both ends of
+	// its lifetime are logged.
+	st.logger.Info("snapshot created")
 	defer st.dropSnapshot(ctx)
 
 	// The snapshot's own boundary, read before the export so a failed export still
@@ -178,6 +181,7 @@ func (st *collSnapshotTask) dropSnapshot(ctx context.Context) {
 	for attempt := range _snapshotDropRetry {
 		err := st.grpc.DropSnapshot(ctx, st.collRef.DBName(), st.collRef.CollName(), st.snapshotName)
 		if err == nil {
+			st.logger.Info("snapshot dropped")
 			return
 		}
 

--- a/core/backup/coll_snapshot_task_test.go
+++ b/core/backup/coll_snapshot_task_test.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -123,18 +122,4 @@ func TestCollSnapshotTask_Execute(t *testing.T) {
 		task, _ := newTestCollSnapshotTask(t, collRef, cli)
 		assert.Error(t, task.Execute(context.Background()))
 	})
-}
-
-// DataCoord releases the export's pin on its own reconcile tick, so the first drop
-// after a job completes can still be refused.
-func TestCollSnapshotTask_DropSnapshotRetries(t *testing.T) {
-	collRef := collref.New("db1", "coll1")
-
-	cli := milvus.NewMockGrpc(t)
-	cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").
-		Return(errors.New("snapshot is pinned")).Once()
-	cli.EXPECT().DropSnapshot(mock.Anything, "db1", "coll1", "mbk_mybackup").Return(nil).Once()
-
-	task, _ := newTestCollSnapshotTask(t, collRef, cli)
-	task.dropSnapshot(context.Background())
 }

--- a/internal/client/milvus/grpc.go
+++ b/internal/client/milvus/grpc.go
@@ -1261,9 +1261,17 @@ func (g *GrpcClient) CreateSnapshot(ctx context.Context, db, collName, snapshotN
 	return nil
 }
 
-// DropSnapshot deletes a snapshot. The server rejects the call while the snapshot has active
-// pins, and an export job holds one until it reaches a terminal state, so drop only once the
-// export is done with the snapshot.
+// A drop is refused while the snapshot still has pins, and the pin an export took is
+// released by DataCoord on its own reconcile tick rather than inline with the job reaching
+// a terminal state, so a drop issued right after an export can be refused for a while.
+const (
+	_snapshotDropAttempts = 10
+	_snapshotDropBackoff  = time.Second
+)
+
+// DropSnapshot deletes a snapshot, retrying while the server refuses it. An export job
+// holds a pin on the snapshot until it reaches a terminal state, so a drop issued right
+// after an export waits for DataCoord to release that pin.
 func (g *GrpcClient) DropSnapshot(ctx context.Context, db, collName, snapshotName string) error {
 	if !g.HasFeature(Snapshot) {
 		return errSnapshotUnsupported
@@ -1271,9 +1279,12 @@ func (g *GrpcClient) DropSnapshot(ctx context.Context, db, collName, snapshotNam
 
 	ctx = g.newCtxWithDB(ctx, db)
 	in := &milvuspb.DropSnapshotRequest{CollectionName: collName, Name: snapshotName}
-	resp, err := g.srv.DropSnapshot(ctx, in)
-	if err := checkResponse(resp, err); err != nil {
-		return fmt.Errorf("client: drop snapshot failed: %w", err)
+	err := retry.Do(ctx, func() error {
+		resp, err := g.srv.DropSnapshot(ctx, in)
+		return checkResponse(resp, err)
+	}, retry.Attempts(_snapshotDropAttempts), retry.Sleep(_snapshotDropBackoff))
+	if err != nil {
+		return fmt.Errorf("client: drop snapshot failed after retry: %w", err)
 	}
 
 	return nil

--- a/internal/client/milvus/grpc_test.go
+++ b/internal/client/milvus/grpc_test.go
@@ -569,14 +569,34 @@ func TestGrpcClient_DropSnapshot(t *testing.T) {
 		assert.Equal(t, "snap", got.GetName())
 	})
 
-	t.Run("StatusError", func(t *testing.T) {
+	// DataCoord releases the export's pin on its own reconcile tick, so the first drop
+	// after a job completes can still be refused.
+	t.Run("RetriesUntilPinReleased", func(t *testing.T) {
 		mockSrv := NewMockMilvusServiceClient(t)
 		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
 
 		mockSrv.EXPECT().DropSnapshot(mock.Anything, mock.Anything).
+			Return(&commonpb.Status{Code: 1, Reason: "snapshot is pinned"}, nil).Once()
+		mockSrv.EXPECT().DropSnapshot(mock.Anything, mock.Anything).
+			Return(&commonpb.Status{Code: 0}, nil).Once()
+
+		require.NoError(t, cli.DropSnapshot(context.Background(), "db", "coll", "snap"))
+	})
+
+	t.Run("GivesUpWhenContextEnds", func(t *testing.T) {
+		mockSrv := NewMockMilvusServiceClient(t)
+		cli := &GrpcClient{srv: mockSrv, flags: Snapshot}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// End the context on the first refusal so the test does not wait out the backoff.
+		mockSrv.EXPECT().DropSnapshot(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, _ *milvuspb.DropSnapshotRequest, _ ...grpc.CallOption) { cancel() }).
 			Return(&commonpb.Status{Code: 1, Reason: "snapshot is pinned"}, nil)
 
-		assert.Error(t, cli.DropSnapshot(context.Background(), "db", "coll", "snap"))
+		err := cli.DropSnapshot(ctx, "db", "coll", "snap")
+		assert.ErrorContains(t, err, "snapshot is pinned")
 	})
 }
 


### PR DESCRIPTION
Two changes to the snapshot backup task's drop path:

- **Log the snapshot's lifetime.** `snapshot created` once `CreateSnapshot` succeeds, `snapshot dropped` once the drop succeeds. A snapshot pins its collection's files in Milvus against GC for as long as it exists, so a snapshot that is never dropped is the failure worth seeing; the success path used to be silent, which made a leaked snapshot indistinguishable from a clean backup in the log.
- **Retry the drop in the milvus client.** `GrpcClient.DropSnapshot` now retries while the server refuses the call, and the task calls it once and logs the outcome. The reason for the retry — DataCoord releases the export's pin on its own reconcile tick, not inline with the job's terminal state — belongs with the RPC, and it is how every other retry in the client package already works. The per-attempt warning log goes away with the loop; the final failure is logged once, with the client's error.

Behaviour delta: the wait budget becomes ten attempts with exponential backoff (about 24s worst case) instead of ten attempts one second apart (about 10s). The first retry is still after one second.

/kind improvement