### PR TITLE
cfg: fork a resolved v2 config with map-based overrides

### DIFF
--- a/internal/cfg/loader/load_test.go
+++ b/internal/cfg/loader/load_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
 )
 
 // write puts content in a temp file and returns its path, so a test starts from
@@ -113,6 +115,30 @@ func TestLoad_UnknownVersion(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "v3")
 	assert.ErrorContains(t, err, "not a schema version this build knows")
+}
+
+// A v1 file loads through source-level translation, and the translated source
+// is the one Fork re-resolves — the v1 values ride along, still stamped with
+// the v1 keys they came from.
+func TestLoad_V1FileForks(t *testing.T) {
+	out, err := Load(write(t, `
+milvus:
+  address: milvus-proxy
+minio:
+  bucketName: v1-bucket
+`), nil)
+	require.NoError(t, err)
+
+	forked, err := out.Fork(map[string]string{"backup.storage.rootPath": "forked-root"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "forked-root", forked.Backup.Storage.RootPath.Val)
+	assert.Equal(t, param.SourceOverride, forked.Backup.Storage.RootPath.Used.Kind)
+
+	assert.Equal(t, "milvus-proxy", forked.Milvus.Grpc.Address.Val)
+	assert.Equal(t, param.SourceV1ConfigFile, forked.Milvus.Grpc.Address.Used.Kind)
+	assert.Equal(t, "milvus.address", forked.Milvus.Grpc.Address.Used.Key)
+	assert.Equal(t, "v1-bucket", forked.Milvus.Storage.BucketName.Val)
 }
 
 // The v1 path validates what it produced, so a provider v1 never checked fails

--- a/internal/cfg/migrate/translate_test.go
+++ b/internal/cfg/migrate/translate_test.go
@@ -221,10 +221,15 @@ minio:
   crossStorage: true
 `
 
-	translated, err := Translate(v1Source(t, content))
+	// One source feeds both entry points: a resolved configuration retains the
+	// source it was resolved from, and two reads of the file would differ in
+	// the path alone.
+	src := v1Source(t, content)
+
+	translated, err := Translate(src)
 	require.NoError(t, err)
 
-	migrated, report := migrateRun(t, v1Source(t, content))
+	migrated, report := migrateRun(t, src)
 	require.NoError(t, report.Err())
 
 	assert.Equal(t, migrated, translated)

--- a/internal/cfg/param/source.go
+++ b/internal/cfg/param/source.go
@@ -115,6 +115,43 @@ func NewTranslatedSource(path string, file map[string]Input, override map[string
 	return s
 }
 
+// WithOverrides returns a copy of the source with overrides merged into the
+// --set layer: a key already present takes the new value, and the spelling the
+// latest caller used is the one errors quote back. The receiver is never
+// mutated, so one loaded source forks into as many independent views as
+// needed.
+func (s *Source) WithOverrides(overrides map[string]string) *Source {
+	out := &Source{
+		path: s.path,
+		// The env and file layers are never written after construction, so the
+		// copy shares them; only the override layer being merged is rebuilt.
+		env:        s.env,
+		configFile: s.configFile,
+		override:   make(map[string]string, len(s.override)+len(overrides)),
+	}
+	for k, v := range s.override {
+		out.override[k] = v
+	}
+
+	spelling := make(map[string]string, len(s.overrideKeys)+len(overrides))
+	for _, k := range s.overrideKeys {
+		spelling[strings.ToLower(k)] = k
+	}
+	for k, v := range overrides {
+		lower := strings.ToLower(k)
+		out.override[lower] = v
+		spelling[lower] = k
+	}
+
+	out.overrideKeys = make([]string, 0, len(spelling))
+	for _, k := range spelling {
+		out.overrideKeys = append(out.overrideKeys, k)
+	}
+	slices.Sort(out.overrideKeys)
+
+	return out
+}
+
 func snapshotEnv() map[string]string {
 	env := make(map[string]string)
 	for _, kv := range os.Environ() {

--- a/internal/cfg/param/source_test.go
+++ b/internal/cfg/param/source_test.go
@@ -81,3 +81,67 @@ func TestNewTranslatedSource(t *testing.T) {
 		assert.False(t, ok, "a translated source carries no environment: the translation already carried its values over")
 	})
 }
+
+// WithOverrides is the merge Fork builds on, so it has to be exact: a repeated
+// key takes the new value under the new spelling, the receiver keeps its own
+// layer untouched, and the layers not being merged pass through.
+func TestWithOverrides(t *testing.T) {
+	t.Run("MergeLaterWins", func(t *testing.T) {
+		src, err := NewSource("", map[string]string{"milvus.grpc.port": "19531", "log.level": "info"})
+		require.NoError(t, err)
+
+		out := src.WithOverrides(map[string]string{"MILVUS.GRPC.PORT": "19532"})
+
+		v, ok := out.OverrideValue("milvus.grpc.port")
+		assert.True(t, ok)
+		assert.Equal(t, "19532", v)
+		// The latest spelling is the one errors quote back.
+		assert.Equal(t, []string{"MILVUS.GRPC.PORT", "log.level"}, out.OverrideKeys())
+	})
+
+	t.Run("ReceiverIsNeverMutated", func(t *testing.T) {
+		src, err := NewSource("", map[string]string{"milvus.grpc.port": "19531"})
+		require.NoError(t, err)
+
+		src.WithOverrides(map[string]string{"milvus.grpc.port": "19532", "log.level": "debug"})
+
+		v, ok := src.OverrideValue("milvus.grpc.port")
+		assert.True(t, ok)
+		assert.Equal(t, "19531", v)
+		_, ok = src.OverrideValue("log.level")
+		assert.False(t, ok)
+		assert.Equal(t, []string{"milvus.grpc.port"}, src.OverrideKeys())
+	})
+
+	t.Run("NilIsAPlainCopy", func(t *testing.T) {
+		src, err := NewSource("", map[string]string{"milvus.grpc.port": "19531"})
+		require.NoError(t, err)
+
+		out := src.WithOverrides(nil)
+
+		assert.Equal(t, src.OverrideKeys(), out.OverrideKeys())
+		v, ok := out.OverrideValue("milvus.grpc.port")
+		assert.True(t, ok)
+		assert.Equal(t, "19531", v)
+	})
+
+	t.Run("FileAndEnvLayersPassThrough", func(t *testing.T) {
+		t.Setenv("WITHOVERRIDES_ENV", "from-env")
+
+		p := filepath.Join(t.TempDir(), "backup.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("log:\n  level: debug\n"), 0o600))
+
+		src, err := NewSource(p, nil)
+		require.NoError(t, err)
+
+		out := src.WithOverrides(map[string]string{"log.console": "false"})
+
+		assert.Equal(t, p, out.ConfigFilePath())
+		raw, ok := out.ConfigFileValue("log.level")
+		assert.True(t, ok)
+		assert.Equal(t, "debug", raw)
+		env, ok := out.EnvValue("WITHOVERRIDES_ENV")
+		assert.True(t, ok)
+		assert.Equal(t, "from-env", env)
+	})
+}

--- a/internal/cfg/v2/cfg.go
+++ b/internal/cfg/v2/cfg.go
@@ -98,6 +98,12 @@ type Config struct {
 	Restore  RestoreConfig
 	Transfer TransferConfig
 	Cloud    CloudConfig
+
+	// src is the source the configuration was loaded from, kept so Fork can
+	// re-resolve it under extra overrides. It stays nil on a Config New built
+	// by hand. param.Walk skips pointer fields, so display, render and key
+	// declaration never see it.
+	src *param.Source
 }
 
 func New() *Config {

--- a/internal/cfg/v2/fork.go
+++ b/internal/cfg/v2/fork.go
@@ -1,0 +1,94 @@
+package v2
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// Fork derives an independent configuration from the receiver: the source the
+// receiver was loaded from, plus overrides as one more --set layer, resolved
+// and validated from scratch. The receiver is never mutated, so one loaded
+// configuration serves every request while each request can still run on its
+// own view.
+//
+// A fork is reload-equivalent: it behaves as if the process had been
+// restarted with the extra overrides. Re-resolution therefore re-reads the
+// environment snapshot the source was built from and re-runs backup.storage
+// inheritance, so overriding a milvus.storage leaf cascades into backup.storage
+// leaves that were never set explicitly — exactly what an extra --set at
+// startup would do. Provenance is reproduced by the re-resolution rather than
+// copied: a file leaf keeps its file stamp, an env leaf its env stamp, a
+// first-load override its override stamp.
+//
+// Overrides follow --set semantics: a dotted config key or a credential
+// environment name, a list comma-separated. An unknown key is an error rather
+// than a warning: a config file may predate the schema, but a key handed to
+// Fork was written against this build, so a misspelling is a bug in the
+// caller.
+//
+// Fork(nil) is a validated independent copy. Fork on a Config that was never
+// loaded from a source — one New built by hand — is an error, since there is
+// nothing to re-resolve.
+func (c *Config) Fork(overrides map[string]string) (*Config, error) {
+	if c.src == nil {
+		return nil, fmt.Errorf("cfg: cannot fork a configuration that was not loaded from a source")
+	}
+	if err := checkForkKeys(c, overrides); err != nil {
+		return nil, err
+	}
+
+	src := c.src.WithOverrides(overrides)
+	forked, err := Resolve(src)
+	if err != nil {
+		return nil, err
+	}
+	if err := forked.Validate(); err != nil {
+		return nil, err
+	}
+	forked.src = src
+
+	return forked, nil
+}
+
+// checkForkKeys rejects override keys the v2 schema does not declare, naming
+// the v2 replacement when the key is a v1 leftover. Where the load-time check
+// warns and ignores, Fork fails: an override that names nothing would silently
+// not apply, which is exactly the mistake the caller is trying to make.
+func checkForkKeys(c *Config, overrides map[string]string) error {
+	configKeys, envNames := param.DeclaredKeys(c)
+	configKeys[strings.ToLower(VersionKey)] = struct{}{}
+
+	// Sort so the first error is deterministic; a map iterates in random order.
+	keys := make([]string, 0, len(overrides))
+	for k := range overrides {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		lower := strings.ToLower(key)
+		if _, ok := configKeys[lower]; ok {
+			continue
+		}
+		// An override may name a credential by its environment variable, the
+		// same spelling --set accepts.
+		if _, ok := envNames[lower]; ok {
+			continue
+		}
+
+		to, isLegacy := Migration(key)
+		switch {
+		case isLegacy && to == "":
+			return fmt.Errorf("cfg: cannot fork: v1 key %q was removed in v2 and names nothing now", key)
+		case isLegacy:
+			return fmt.Errorf("cfg: cannot fork: v1 key %q is not accepted by a v2 config; use %s instead", key, to)
+		default:
+			return fmt.Errorf("cfg: cannot fork: unknown v2 key %q", key)
+		}
+	}
+
+	return nil
+}

--- a/internal/cfg/v2/fork_test.go
+++ b/internal/cfg/v2/fork_test.go
@@ -1,0 +1,164 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/milvus-backup/internal/cfg/param"
+)
+
+// Fork(nil) re-resolves the very source the receiver was loaded from, so the
+// copy comes out identical — values and provenance alike.
+func TestFork_NilOverrideIsAnIndependentCopy(t *testing.T) {
+	t.Setenv("MILVUS_STORAGE_AUTH_ACCESS_KEY_ID", "env-ak")
+
+	c, err := Load(writeYAML(t, "milvus:\n  user: fromfile\n"), map[string]string{"milvus.grpc.port": "19531"})
+	require.NoError(t, err)
+
+	forked, err := c.Fork(nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, c.Entries(), forked.Entries())
+	assert.NotSame(t, c, forked)
+}
+
+func TestFork_AppliesOverride(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	forked, err := c.Fork(map[string]string{"backup.storage.rootPath": "forked-root"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "forked-root", forked.Backup.Storage.RootPath.Val)
+	assert.Equal(t, param.SourceOverride, forked.Backup.Storage.RootPath.Used.Kind)
+	assert.Equal(t, "backup.storage.rootpath", forked.Backup.Storage.RootPath.Used.Key)
+
+	// The receiver is never mutated.
+	assert.Equal(t, "backup", c.Backup.Storage.RootPath.Val)
+	assert.Equal(t, param.SourceDefault, c.Backup.Storage.RootPath.Used.Kind)
+}
+
+// A fork is reload-equivalent: re-resolution re-runs backup.storage
+// inheritance, so overriding a milvus.storage leaf cascades into the
+// backup.storage leaves that were never set explicitly.
+func TestFork_CascadesIntoUnsetBackupLeaves(t *testing.T) {
+	c, err := Load(writeYAML(t, "milvus:\n  storage:\n    bucketName: milvus-bucket\n"), nil)
+	require.NoError(t, err)
+	require.Equal(t, "milvus-bucket", c.Backup.Storage.BucketName.Val)
+
+	forked, err := c.Fork(map[string]string{"milvus.storage.bucketName": "fork-bucket"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "fork-bucket", forked.Milvus.Storage.BucketName.Val)
+	assert.Equal(t, "fork-bucket", forked.Backup.Storage.BucketName.Val)
+
+	// A leaf that was set explicitly does not follow the cascade.
+	assert.Equal(t, "backup", forked.Backup.Storage.RootPath.Val)
+}
+
+// The environment a fork sees is the snapshot the source was built with:
+// re-resolution consults it again, and an override may still name a credential
+// by its environment variable, as --set does.
+func TestFork_EnvAndCredentialSpelling(t *testing.T) {
+	t.Setenv("MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY", "env-sk")
+
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	t.Run("EnvValueSurvivesIntoTheFork", func(t *testing.T) {
+		forked, err := c.Fork(nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "env-sk", forked.Milvus.Storage.Auth.SecretAccessKey.Val)
+		assert.Equal(t, param.SourceEnv, forked.Milvus.Storage.Auth.SecretAccessKey.Used.Kind)
+	})
+
+	t.Run("OverrideByEnvName", func(t *testing.T) {
+		forked, err := c.Fork(map[string]string{"MILVUS_STORAGE_AUTH_ACCESS_KEY_ID": "fork-ak"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "fork-ak", forked.Milvus.Storage.Auth.AccessKeyID.Val)
+		assert.Equal(t, param.SourceOverride, forked.Milvus.Storage.Auth.AccessKeyID.Used.Kind)
+	})
+}
+
+// Fork-of-fork stacks override layers on the same source, so overrides
+// accumulate; each fork along the way keeps its own view.
+func TestFork_ForkOfForkAccumulates(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	fork1, err := c.Fork(map[string]string{"backup.storage.rootPath": "fork-1"})
+	require.NoError(t, err)
+
+	fork2, err := fork1.Fork(map[string]string{"transfer.concurrency": "42"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "fork-1", fork2.Backup.Storage.RootPath.Val)
+	assert.Equal(t, 42, fork2.Transfer.Concurrency.Val)
+
+	assert.Equal(t, "fork-1", fork1.Backup.Storage.RootPath.Val)
+	assert.Equal(t, 128, fork1.Transfer.Concurrency.Val)
+}
+
+func TestFork_NeverLoadedConfig(t *testing.T) {
+	_, err := New().Fork(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not loaded from a source")
+}
+
+// An unknown key is an error, not the warning a load would log: a key handed
+// to Fork was written against this build, so a misspelling is a caller bug.
+func TestFork_UnknownKeyIsAnError(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	t.Run("Misspelled", func(t *testing.T) {
+		_, err := c.Fork(map[string]string{"milvus.grpc.adress": "localhost"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown v2 key "milvus.grpc.adress"`)
+	})
+
+	t.Run("V1Key", func(t *testing.T) {
+		_, err := c.Fork(map[string]string{"milvus.address": "localhost"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"milvus.address"`)
+		assert.Contains(t, err.Error(), "milvus.grpc.address")
+	})
+
+	t.Run("V1EnvName", func(t *testing.T) {
+		_, err := c.Fork(map[string]string{"MINIO_SECRET_KEY": "sk"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "MILVUS_STORAGE_AUTH_SECRET_ACCESS_KEY")
+	})
+
+	t.Run("RemovedV1Key", func(t *testing.T) {
+		_, err := c.Fork(map[string]string{"http.enabled": "true"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"http.enabled" was removed in v2`)
+	})
+}
+
+// A fork is validated like a first load: an override that resolves but breaks
+// a rule fails the fork instead of producing a config nothing checked.
+func TestFork_ValidationFailure(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	_, err = c.Fork(map[string]string{"transfer.mode": "bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "bogus"`)
+}
+
+// An override that cannot even be parsed for the parameter it names fails the
+// same way a bad --set fails a load.
+func TestFork_ParseFailure(t *testing.T) {
+	c, err := Load("", nil)
+	require.NoError(t, err)
+
+	_, err = c.Fork(map[string]string{"milvus.grpc.port": "not-a-number"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}

--- a/internal/cfg/v2/load.go
+++ b/internal/cfg/v2/load.go
@@ -40,6 +40,9 @@ func LoadFrom(src *param.Source) (*Config, error) {
 // Callers that report validation problems instead of failing on them — the
 // config migration, which still renders a config that needs fixing — use it
 // and run Validate themselves.
+//
+// The source is retained on the returned configuration, which is what Fork
+// re-resolves under extra overrides.
 func Resolve(src *param.Source) (*Config, error) {
 	cfg := New()
 
@@ -55,6 +58,7 @@ func Resolve(src *param.Source) (*Config, error) {
 	if err := cfg.Resolve(src); err != nil {
 		return nil, err
 	}
+	cfg.src = src
 
 	return cfg, nil
 }


### PR DESCRIPTION
## What

`v2.Config` gains `Fork(overrides)`: derive an independent, validated configuration from a loaded one, with the overrides applied as one more `--set` layer.

Fixes #1209

## How

A fork is reload-equivalent: the same load, plus an extra override layer.

- `v2.Config` retains the `param.Source` it was resolved from (unexported pointer field; `param.Walk` skips pointer fields, so display, render, defaults and key declaration are unaffected). The source is attached in `Resolve`, not `LoadFrom`, so the `config migrate` artifact — which resolves without validating — carries one as well, and the Translate/Migrate parity test keeps comparing whole configurations.
- `param.Source` gains `WithOverrides(map[string]string) *Source`: clone and merge, later wins, and the latest spelling is the one errors quote back. The receiver is never mutated. The env and file layers are never written after construction, so the copy shares them and only the override layer is rebuilt.
- `Fork(m)` = `checkForkKeys` (unknown keys are errors, with the v1 migration hint from `legacy.go`) → `Resolve(src.WithOverrides(m))` → `Validate()` → attach the merged source. Fork-of-fork accumulates naturally, `Fork(nil)` is a validated independent copy, and forking a configuration that was never loaded is an explicit error.

Semantics that follow from reload-equivalence, called out in the issue: overriding a `milvus.storage` leaf cascades into unset `backup.storage` leaves (exactly what an extra `--set` at startup would do), and provenance is reproduced by re-resolution rather than copied — env stays env, file stays file, v1 stays v1.

## Tests

- `param`: the merge itself — later wins, receiver immutable, nil is a plain copy, file and env layers pass through.
- `v2`: a nil copy reproduces values and provenance exactly; an override applies without mutating the receiver; the cascade reaches unset backup leaves; the env snapshot is re-read and a credential may be named by its environment variable; fork-of-fork accumulates; a never-loaded config errors; misspelled, v1 and removed keys error with the migration hint; validation and parse failures propagate.
- `loader`: a v1-loaded configuration forks through its translated source and keeps v1 provenance (`v1 config` stamp with the original v1 key).

The first consumer — the GetBackup usecase honoring its per-request `path` parameter (#1203) — follows as a separate PR once this lands.
