### PR TITLE
backup: probe etcd at task start and bound every etcd read

### DIFF
--- a/core/backup/coll_dyn_field_task.go
+++ b/core/backup/coll_dyn_field_task.go
@@ -3,8 +3,6 @@ package backup
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"go.uber.org/zap"
@@ -45,46 +43,51 @@ func (cdft *collDynFieldTask) Execute(ctx context.Context) error {
 	// Milvus stores collection field schemas under
 	//   {MetaRootPath}/root-coord/fields/{collectionID}/{fieldID}
 	// where MetaRootPath is "{etcdRootPath}/meta" in milvus-backup config terms.
-	prefix := fmt.Sprintf("%s/meta/root-coord/fields/", cdft.etcdRootPath)
-	cdft.logger.Info("start to get field schemas from etcd", zap.String("prefix", prefix))
-	resp, err := cdft.etcd.getPrefix(ctx, prefix)
-	if err != nil {
-		return fmt.Errorf("backup: get field schemas: %w", err)
-	}
-	cdft.logger.Info("get field schemas from etcd done", zap.Int("count", len(resp.Kvs)))
+	// The collection id is the first segment, so the scan is scoped to the
+	// backed-up collections rather than read whole. A cluster-wide read grows
+	// with the instance instead of with the backup, and nearly all of it is
+	// waste: every field of every collection comes back so that at most one
+	// dynamic field per backed-up collection can be picked out.
+	collIDs := cdft.metaBuilder.backupCollectionIDs()
 
 	dynFields := make(map[int64]*schemapb.FieldSchema)
-	for _, kv := range resp.Kvs {
-		collID, ok := parseCollIDFromFieldKey(string(kv.Key), prefix)
-		if !ok {
-			cdft.logger.Warn("skip field with unparsable key", zap.String("key", string(kv.Key)))
-			continue
+	for _, collID := range collIDs {
+		prefix := fmt.Sprintf("%s/meta/root-coord/fields/%d/", cdft.etcdRootPath, collID)
+		cdft.logger.Info("start to get field schemas from etcd", zap.String("prefix", prefix))
+		resp, err := cdft.etcd.getPrefix(ctx, prefix)
+		if err != nil {
+			return fmt.Errorf("backup: get field schemas: %w", err)
 		}
-		field := &schemapb.FieldSchema{}
-		if err := proto.Unmarshal(kv.Value, field); err != nil {
-			// The key may be a tombstone or a non-FieldSchema payload, skip
-			// rather than fail the whole backup.
-			cdft.logger.Warn("skip field that cannot be unmarshalled",
-				zap.String("key", string(kv.Key)), zap.Error(err))
-			continue
-		}
-		if !field.GetIsDynamic() {
-			continue
-		}
-		if existing, ok := dynFields[collID]; ok {
-			cdft.logger.Warn("multiple dynamic fields found for one collection, keeping the first",
+		cdft.logger.Info("get field schemas from etcd done",
+			zap.Int64("coll_id", collID), zap.Int("count", len(resp.Kvs)))
+
+		for _, kv := range resp.Kvs {
+			field := &schemapb.FieldSchema{}
+			if err := proto.Unmarshal(kv.Value, field); err != nil {
+				// The key may be a tombstone or a non-FieldSchema payload, skip
+				// rather than fail the whole backup.
+				cdft.logger.Warn("skip field that cannot be unmarshalled",
+					zap.String("key", string(kv.Key)), zap.Error(err))
+				continue
+			}
+			if !field.GetIsDynamic() {
+				continue
+			}
+			if existing, ok := dynFields[collID]; ok {
+				cdft.logger.Warn("multiple dynamic fields found for one collection, keeping the first",
+					zap.Int64("collection_id", collID),
+					zap.Int64("existing_field_id", existing.GetFieldID()),
+					zap.Int64("duplicate_field_id", field.GetFieldID()))
+				continue
+			}
+			cdft.logger.Info("found dynamic field",
+				zap.String("key", string(kv.Key)),
 				zap.Int64("collection_id", collID),
-				zap.Int64("existing_field_id", existing.GetFieldID()),
-				zap.Int64("duplicate_field_id", field.GetFieldID()))
-			continue
+				zap.Int64("field_id", field.GetFieldID()),
+				zap.String("name", field.GetName()),
+				zap.Bool("nullable", field.GetNullable()))
+			dynFields[collID] = field
 		}
-		cdft.logger.Info("found dynamic field",
-			zap.String("key", string(kv.Key)),
-			zap.Int64("collection_id", collID),
-			zap.Int64("field_id", field.GetFieldID()),
-			zap.String("name", field.GetName()),
-			zap.Bool("nullable", field.GetNullable()))
-		dynFields[collID] = field
 	}
 
 	if err := cdft.metaBuilder.addDynamicFields(dynFields); err != nil {
@@ -93,22 +96,4 @@ func (cdft *collDynFieldTask) Execute(ctx context.Context) error {
 
 	cdft.logger.Info("backup dynamic field info done", zap.Int("dynamic_field_count", len(dynFields)))
 	return nil
-}
-
-// parseCollIDFromFieldKey parses the collection id from an etcd field key like
-// "{prefix}{collectionID}/{fieldID}".
-func parseCollIDFromFieldKey(key, prefix string) (int64, bool) {
-	if !strings.HasPrefix(key, prefix) {
-		return 0, false
-	}
-	rest := strings.TrimPrefix(key, prefix)
-	idx := strings.Index(rest, "/")
-	if idx <= 0 {
-		return 0, false
-	}
-	collID, err := strconv.ParseInt(rest[:idx], 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	return collID, true
 }

--- a/core/backup/coll_dyn_field_task.go
+++ b/core/backup/coll_dyn_field_task.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -23,7 +22,7 @@ import (
 type collDynFieldTask struct {
 	taskID string
 
-	kv clientv3.KV
+	etcd *etcdMeta
 
 	etcdRootPath string
 
@@ -32,10 +31,10 @@ type collDynFieldTask struct {
 	logger *zap.Logger
 }
 
-func newCollDynFieldTask(taskID string, kv clientv3.KV, etcdRootPath string, metaBuilder *metaBuilder) *collDynFieldTask {
+func newCollDynFieldTask(taskID string, etcd *etcdMeta, etcdRootPath string, metaBuilder *metaBuilder) *collDynFieldTask {
 	return &collDynFieldTask{
 		taskID:       taskID,
-		kv:           kv,
+		etcd:         etcd,
 		etcdRootPath: etcdRootPath,
 		metaBuilder:  metaBuilder,
 		logger:       log.With(zap.String("task_id", taskID)),
@@ -48,9 +47,9 @@ func (cdft *collDynFieldTask) Execute(ctx context.Context) error {
 	// where MetaRootPath is "{etcdRootPath}/meta" in milvus-backup config terms.
 	prefix := fmt.Sprintf("%s/meta/root-coord/fields/", cdft.etcdRootPath)
 	cdft.logger.Info("start to get field schemas from etcd", zap.String("prefix", prefix))
-	resp, err := cdft.kv.Get(ctx, prefix, clientv3.WithPrefix())
+	resp, err := cdft.etcd.getPrefix(ctx, prefix)
 	if err != nil {
-		return fmt.Errorf("backup: get field schemas from etcd %w", err)
+		return fmt.Errorf("backup: get field schemas: %w", err)
 	}
 	cdft.logger.Info("get field schemas from etcd done", zap.Int("count", len(resp.Kvs)))
 

--- a/core/backup/coll_dyn_field_task_test.go
+++ b/core/backup/coll_dyn_field_task_test.go
@@ -1,10 +1,25 @@
 package backup
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCollDynFieldTaskExecute(t *testing.T) {
+	t.Run("UnreachableEtcdNamesEndpoint", func(t *testing.T) {
+		etcd := newEtcdMeta(&blockingEtcd{}, []string{"127.0.0.1:2379"})
+		etcd.timeout = 100 * time.Millisecond
+
+		task := newCollDynFieldTask("task1", etcd, "by-dev", newMetaBuilder("task1", "backup1"))
+		err := task.Execute(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "127.0.0.1:2379")
+	})
+}
 
 func TestParseCollIDFromFieldKey(t *testing.T) {
 	prefix := "by-dev/meta/root-coord/fields/"

--- a/core/backup/coll_dyn_field_task_test.go
+++ b/core/backup/coll_dyn_field_task_test.go
@@ -2,51 +2,81 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/zilliztech/milvus-backup/core/proto/backuppb"
+	"github.com/zilliztech/milvus-backup/internal/collref"
 )
 
+func mustMarshalFieldSchema(t *testing.T, field *schemapb.FieldSchema) []byte {
+	data, err := proto.Marshal(field)
+	require.NoError(t, err)
+	return data
+}
+
 func TestCollDynFieldTaskExecute(t *testing.T) {
+	const rootPath = "by-dev"
+
+	newBuilder := func() *metaBuilder {
+		builder := newMetaBuilder("task1", "backup1")
+		builder.addCollection(collref.New("db1", "coll1"), &backuppb.CollectionBackupInfo{
+			CollectionId:   1,
+			DbName:         "db1",
+			CollectionName: "coll1",
+			Schema:         &backuppb.CollectionSchema{EnableDynamicField: true},
+		})
+
+		return builder
+	}
+
+	// The field key is "root-coord/fields/{collectionID}/{fieldID}", so the scan
+	// is one read per backed-up collection. A collection outside the backup must
+	// not be read at all: its fields would be fetched and discarded, and on a
+	// large instance that is most of what comes back.
+	t.Run("ScopesToBackupCollections", func(t *testing.T) {
+		builder := newBuilder()
+		kv := &fakeKV{data: map[string][]byte{
+			fmt.Sprintf("%s/meta/root-coord/fields/1/100", rootPath): mustMarshalFieldSchema(t, &schemapb.FieldSchema{
+				FieldID: 100, Name: "id",
+			}),
+			fmt.Sprintf("%s/meta/root-coord/fields/1/101", rootPath): mustMarshalFieldSchema(t, &schemapb.FieldSchema{
+				FieldID: 101, Name: "$meta", IsDynamic: true, Nullable: true,
+			}),
+			// Not in this backup. Reading it would be waste, and its dynamic
+			// field must not reach the meta builder.
+			fmt.Sprintf("%s/meta/root-coord/fields/2/101", rootPath): mustMarshalFieldSchema(t, &schemapb.FieldSchema{
+				FieldID: 101, Name: "$meta", IsDynamic: true,
+			}),
+		}}
+
+		task := newCollDynFieldTask("task1", newEtcdMeta(kv, []string{"127.0.0.1:2379"}), rootPath, builder)
+		require.NoError(t, task.Execute(context.Background()))
+
+		require.Len(t, kv.gotKeys, 1)
+		assert.Equal(t, fmt.Sprintf("%s/meta/root-coord/fields/1/", rootPath), kv.gotKeys[0])
+
+		colls := builder.data.GetCollectionBackups()
+		require.Len(t, colls, 1)
+		fields := colls[0].GetSchema().GetFields()
+		require.Len(t, fields, 1)
+		assert.Equal(t, "$meta", fields[0].GetName())
+		assert.True(t, fields[0].GetNullable())
+	})
+
 	t.Run("UnreachableEtcdNamesEndpoint", func(t *testing.T) {
 		etcd := newEtcdMeta(&blockingEtcd{}, []string{"127.0.0.1:2379"})
 		etcd.timeout = 100 * time.Millisecond
 
-		task := newCollDynFieldTask("task1", etcd, "by-dev", newMetaBuilder("task1", "backup1"))
+		task := newCollDynFieldTask("task1", etcd, rootPath, newBuilder())
 		err := task.Execute(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "127.0.0.1:2379")
-	})
-}
-
-func TestParseCollIDFromFieldKey(t *testing.T) {
-	prefix := "by-dev/meta/root-coord/fields/"
-
-	t.Run("ValidKey", func(t *testing.T) {
-		collID, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/12345/678", prefix)
-		assert.True(t, ok)
-		assert.Equal(t, int64(12345), collID)
-	})
-
-	t.Run("PrefixMismatch", func(t *testing.T) {
-		_, ok := parseCollIDFromFieldKey("by-dev/meta/other/12345/678", prefix)
-		assert.False(t, ok)
-	})
-
-	t.Run("MissingFieldIDSegment", func(t *testing.T) {
-		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/12345", prefix)
-		assert.False(t, ok)
-	})
-
-	t.Run("EmptyCollectionID", func(t *testing.T) {
-		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields//678", prefix)
-		assert.False(t, ok)
-	})
-
-	t.Run("NonNumericCollectionID", func(t *testing.T) {
-		_, ok := parseCollIDFromFieldKey("by-dev/meta/root-coord/fields/abc/678", prefix)
-		assert.False(t, ok)
 	})
 }

--- a/core/backup/coll_index_extra_task.go
+++ b/core/backup/coll_index_extra_task.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -15,7 +14,7 @@ import (
 type collIndexExtraTask struct {
 	taskID string
 
-	kv clientv3.KV
+	etcd *etcdMeta
 
 	etcdRootPath string
 
@@ -24,10 +23,10 @@ type collIndexExtraTask struct {
 	logger *zap.Logger
 }
 
-func newCollIndexExtraTask(taskID string, kv clientv3.KV, etcdRootPath string, metaBuilder *metaBuilder) *collIndexExtraTask {
+func newCollIndexExtraTask(taskID string, etcd *etcdMeta, etcdRootPath string, metaBuilder *metaBuilder) *collIndexExtraTask {
 	return &collIndexExtraTask{
 		taskID:       taskID,
-		kv:           kv,
+		etcd:         etcd,
 		etcdRootPath: etcdRootPath,
 		metaBuilder:  metaBuilder,
 		logger:       log.With(zap.String("task_id", taskID)),
@@ -45,9 +44,9 @@ func (ciet *collIndexExtraTask) Execute(ctx context.Context) error {
 	for _, collID := range collIDs {
 		prefix := fmt.Sprintf("%s/meta/field-index/%d/", ciet.etcdRootPath, collID)
 		ciet.logger.Info("start to get index info from etcd", zap.String("prefix", prefix))
-		resp, err := ciet.kv.Get(ctx, prefix, clientv3.WithPrefix())
+		resp, err := ciet.etcd.getPrefix(ctx, prefix)
 		if err != nil {
-			return fmt.Errorf("backup: get indexes from etcd %w", err)
+			return fmt.Errorf("backup: get indexes: %w", err)
 		}
 		ciet.logger.Info("get indexes from etcd done", zap.Int64("coll_id", collID), zap.Int("count", len(resp.Kvs)))
 

--- a/core/backup/coll_index_extra_task_test.go
+++ b/core/backup/coll_index_extra_task_test.go
@@ -25,9 +25,15 @@ type fakeKV struct {
 	clientv3.KV
 
 	data map[string][]byte
+
+	// gotKeys records every prefix asked for, so a test can assert which
+	// collections were read rather than only what came back.
+	gotKeys []string
 }
 
 func (f *fakeKV) Get(_ context.Context, key string, _ ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	f.gotKeys = append(f.gotKeys, key)
+
 	resp := &clientv3.GetResponse{}
 	for k, v := range f.data {
 		if strings.HasPrefix(k, key) {

--- a/core/backup/coll_index_extra_task_test.go
+++ b/core/backup/coll_index_extra_task_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ import (
 	"github.com/zilliztech/milvus-backup/internal/collref"
 )
 
-// fakeKV implements clientv3.KV but only supports prefix Get, which is all the
+// fakeKV implements etcdReader but only supports prefix Get, which is all the
 // index extra task needs. Any other method would panic via the embedded nil
 // interface, surfacing accidental use.
 type fakeKV struct {
@@ -35,6 +36,10 @@ func (f *fakeKV) Get(_ context.Context, key string, _ ...clientv3.OpOption) (*cl
 	}
 
 	return resp, nil
+}
+
+func (f *fakeKV) Status(context.Context, string) (*clientv3.StatusResponse, error) {
+	return &clientv3.StatusResponse{}, nil
 }
 
 func mustMarshalFieldIndex(t *testing.T, idx *indexpb.FieldIndex) []byte {
@@ -78,12 +83,22 @@ func TestCollIndexExtraTaskExecute(t *testing.T) {
 			}),
 		}}
 
-		task := newCollIndexExtraTask("task1", kv, rootPath, builder)
+		task := newCollIndexExtraTask("task1", newEtcdMeta(kv, []string{"localhost:2379"}), rootPath, builder)
 		assert.NoError(t, task.Execute(context.Background()))
 
 		got := builder.collectionBackups[1].GetIndexInfos()[0]
 		assert.Equal(t, int64(5), got.GetFieldId())
 		assert.Equal(t, uint64(123), got.GetCreateTime())
+	})
+
+	t.Run("UnreachableEtcdNamesEndpoint", func(t *testing.T) {
+		etcd := newEtcdMeta(&blockingEtcd{}, []string{"127.0.0.1:2379"})
+		etcd.timeout = 100 * time.Millisecond
+
+		task := newCollIndexExtraTask("task1", etcd, rootPath, newBuilder())
+		err := task.Execute(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "127.0.0.1:2379")
 	})
 
 	t.Run("MissingIndexInBackupReturnsError", func(t *testing.T) {
@@ -95,7 +110,7 @@ func TestCollIndexExtraTaskExecute(t *testing.T) {
 			}),
 		}}
 
-		task := newCollIndexExtraTask("task1", kv, rootPath, builder)
+		task := newCollIndexExtraTask("task1", newEtcdMeta(kv, []string{"localhost:2379"}), rootPath, builder)
 		err := task.Execute(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not in backup index infos")

--- a/core/backup/etcd.go
+++ b/core/backup/etcd.go
@@ -1,0 +1,85 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// _etcdRequestTimeout bounds every etcd request the backup makes. Milvus bounds
+// its own etcd calls with etcd.requestTimeout, whose default is 10000ms, and
+// there is no reason for this tool to wait longer than the server it reads from.
+const _etcdRequestTimeout = 10 * time.Second
+
+// etcdReader is the part of *clientv3.Client the backup uses: prefix reads for
+// the Milvus metadata, and Status for the reachability probe.
+type etcdReader interface {
+	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error)
+}
+
+// etcdMeta reads Milvus metadata that the gRPC API does not expose. It carries
+// the endpoints it was built from because clientv3 never reports which address a
+// call was talking to, and an operator handed a bare "context deadline exceeded"
+// has nothing to act on.
+type etcdMeta struct {
+	cli       etcdReader
+	endpoints []string
+
+	// timeout applies to a whole call, probe included, and is a field only so
+	// that tests do not have to wait out the production default.
+	timeout time.Duration
+}
+
+func newEtcdMeta(cli etcdReader, endpoints []string) *etcdMeta {
+	return &etcdMeta{cli: cli, endpoints: endpoints, timeout: _etcdRequestTimeout}
+}
+
+// probe establishes that etcd answers before the backup starts copying data.
+// clientv3.New does not dial unless the config carries grpc.WithBlock(), so
+// construction succeeds against endpoints that do not exist and the failure
+// surfaces at the first read -- which happens only after every collection has
+// been copied. A blocking dial would not be enough either: it proves the TCP
+// connection, not that the peer speaks etcd, and an address that accepts the
+// connection and then never answers is exactly the reported failure. Status is
+// the cheapest RPC that settles both.
+//
+// One reachable member is enough. The client fails over between endpoints, so a
+// single down member of an otherwise healthy cluster must not fail a backup.
+func (e *etcdMeta) probe(ctx context.Context) error {
+	if len(e.endpoints) == 0 {
+		return errors.New("backup: no etcd endpoint configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	errs := make([]error, 0, len(e.endpoints))
+	for _, endpoint := range e.endpoints {
+		_, err := e.cli.Status(ctx, endpoint)
+		if err == nil {
+			return nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", endpoint, err))
+	}
+
+	return fmt.Errorf("backup: etcd is unreachable at %v: %w", e.endpoints, errors.Join(errs...))
+}
+
+// getPrefix reads every key under prefix. The deadline is the point of the
+// wrapper: the task context has none, so an endpoint that accepts the connection
+// but never answers blocks the read until the process is killed.
+func (e *etcdMeta) getPrefix(ctx context.Context, prefix string) (*clientv3.GetResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	resp, err := e.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, fmt.Errorf("etcd get %s from %v: %w", prefix, e.endpoints, err)
+	}
+
+	return resp, nil
+}

--- a/core/backup/etcd_test.go
+++ b/core/backup/etcd_test.go
@@ -1,0 +1,128 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// blockingEtcd stands in for an endpoint that accepts the connection and then
+// never answers -- the failure mode reported in #1216. Every call returns only
+// when the caller's context is done, so a test that finishes proves the caller
+// imposed a deadline of its own.
+type blockingEtcd struct{ clientv3.KV }
+
+func (b *blockingEtcd) Get(ctx context.Context, _ string, _ ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (b *blockingEtcd) Status(ctx context.Context, _ string) (*clientv3.StatusResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// downEtcd fails every call immediately, as an endpoint that is not listening at
+// all would.
+type downEtcd struct{ clientv3.KV }
+
+func (d *downEtcd) Get(context.Context, string, ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return nil, errors.New("connection refused")
+}
+
+func (d *downEtcd) Status(context.Context, string) (*clientv3.StatusResponse, error) {
+	return nil, errors.New("connection refused")
+}
+
+// oneUpEtcd answers only for upEndpoint, as a cluster with one down member does.
+type oneUpEtcd struct {
+	clientv3.KV
+
+	upEndpoint string
+}
+
+func (o *oneUpEtcd) Status(_ context.Context, endpoint string) (*clientv3.StatusResponse, error) {
+	if endpoint != o.upEndpoint {
+		return nil, errors.New("connection refused")
+	}
+	return &clientv3.StatusResponse{}, nil
+}
+
+func TestEtcdMeta_Probe(t *testing.T) {
+	t.Run("Reachable", func(t *testing.T) {
+		etcd := newEtcdMeta(&fakeKV{}, []string{"localhost:2379"})
+		assert.NoError(t, etcd.probe(context.Background()))
+	})
+
+	t.Run("OneReachableMemberIsEnough", func(t *testing.T) {
+		etcd := newEtcdMeta(&oneUpEtcd{upEndpoint: "b:2379"}, []string{"a:2379", "b:2379"})
+		assert.NoError(t, etcd.probe(context.Background()))
+	})
+
+	t.Run("UnreachableNamesEveryEndpoint", func(t *testing.T) {
+		etcd := newEtcdMeta(&downEtcd{}, []string{"a:2379", "b:2379"})
+
+		err := etcd.probe(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "a:2379")
+		assert.Contains(t, err.Error(), "b:2379")
+	})
+
+	t.Run("SilentEndpointDoesNotBlock", func(t *testing.T) {
+		etcd := newEtcdMeta(&blockingEtcd{}, []string{"127.0.0.1:2379"})
+		etcd.timeout = 100 * time.Millisecond
+
+		start := time.Now()
+		err := etcd.probe(context.Background())
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), time.Second)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Contains(t, err.Error(), "127.0.0.1:2379")
+	})
+
+	t.Run("NoEndpoint", func(t *testing.T) {
+		etcd := newEtcdMeta(&fakeKV{}, nil)
+		assert.ErrorContains(t, etcd.probe(context.Background()), "no etcd endpoint configured")
+	})
+}
+
+func TestEtcdMeta_GetPrefix(t *testing.T) {
+	t.Run("SilentEndpointDoesNotBlock", func(t *testing.T) {
+		etcd := newEtcdMeta(&blockingEtcd{}, []string{"127.0.0.1:2379"})
+		etcd.timeout = 100 * time.Millisecond
+
+		start := time.Now()
+		_, err := etcd.getPrefix(context.Background(), "by-dev/meta/field-index/1/")
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), time.Second)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Contains(t, err.Error(), "127.0.0.1:2379")
+		assert.Contains(t, err.Error(), "by-dev/meta/field-index/1/")
+	})
+}
+
+// TestEtcdMeta_ProbeWithRealClient pins the premise of the fix: clientv3.New
+// does not dial, so a client built against an address nothing listens on is
+// returned without error and only the probe reports the endpoint as unreachable.
+func TestEtcdMeta_ProbeWithRealClient(t *testing.T) {
+	// Port 1 is privileged and never an etcd, so the connection is refused.
+	const endpoint = "127.0.0.1:1"
+
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{endpoint}, DialTimeout: 5 * time.Second})
+	require.NoError(t, err, "clientv3.New must not dial, otherwise the probe would be redundant")
+	defer cli.Close()
+
+	etcd := newEtcdMeta(cli, []string{endpoint})
+	etcd.timeout = time.Second
+
+	start := time.Now()
+	err = etcd.probe(context.Background())
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 10*time.Second)
+	assert.Contains(t, err.Error(), endpoint)
+}

--- a/core/backup/task.go
+++ b/core/backup/task.go
@@ -83,6 +83,7 @@ type Task struct {
 	manage  milvus.Manage
 
 	etcdCli      *clientv3.Client
+	etcd         *etcdMeta
 	etcdRootPath string
 
 	metaBuilder *metaBuilder
@@ -162,7 +163,7 @@ func NewTask(args TaskArgs) (*Task, error) {
 	}, nil
 }
 
-func (t *Task) initClients() error {
+func (t *Task) initClients(ctx context.Context) error {
 	grpcCli, err := milvus.NewGrpc(&t.params.Milvus)
 	if err != nil {
 		return fmt.Errorf("backup: create grpc client: %w", err)
@@ -181,15 +182,25 @@ func (t *Task) initClients() error {
 	}
 	t.manage = milvus.NewManage(manageAddr)
 
+	// etcd is read only by the index extra and dynamic field steps, and both run
+	// after every collection has been copied. Probe it here instead, so a cluster
+	// whose etcd this tool cannot reach fails in the first seconds of the backup
+	// rather than at the end of it.
 	if t.option.BackupIndexExtra {
+		endpoints := t.params.Milvus.Etcd.Endpoints.Val
 		etcdCli, err := clientv3.New(clientv3.Config{
-			Endpoints:   t.params.Milvus.Etcd.Endpoints.Val,
+			Endpoints:   endpoints,
 			DialTimeout: 5 * time.Second,
 		})
 		if err != nil {
 			return fmt.Errorf("backup: create etcd client: %w", err)
 		}
 		t.etcdCli = etcdCli
+		t.etcd = newEtcdMeta(etcdCli, endpoints)
+
+		if err := t.etcd.probe(ctx); err != nil {
+			return err
+		}
 	}
 
 	t.gcCtrl = newGCCtrl(t.taskID, t.option.PauseGC, t.grpc, t.manage)
@@ -218,7 +229,7 @@ func (t *Task) Execute(ctx context.Context) (err error) {
 		}
 	}()
 
-	if err = t.initClients(); err != nil {
+	if err = t.initClients(ctx); err != nil {
 		return err
 	}
 
@@ -617,13 +628,13 @@ func (t *Task) backupIndexExtraInfo(ctx context.Context) error {
 		return nil
 	}
 
-	if t.etcdCli == nil {
+	if t.etcd == nil {
 		return errors.New("backup: need backup etcd info but etcd client is nil")
 	}
 
 	t.logger.Info("start backup index extra info")
 
-	indexExtraTask := newCollIndexExtraTask(t.taskID, t.etcdCli, t.etcdRootPath, t.metaBuilder)
+	indexExtraTask := newCollIndexExtraTask(t.taskID, t.etcd, t.etcdRootPath, t.metaBuilder)
 	if err := indexExtraTask.Execute(ctx); err != nil {
 		return fmt.Errorf("backup: execute index extra task: %w", err)
 	}
@@ -648,7 +659,7 @@ func (t *Task) backupIndexExtraInfo(ctx context.Context) error {
 // naming the collections it leaves incomplete -- that message is the only place
 // the missing option is visible before a restore fails on it much later.
 func (t *Task) backupCollDynField(ctx context.Context) error {
-	if t.etcdCli == nil {
+	if t.etcd == nil {
 		if affected := t.metaBuilder.dynamicSchemaCollections(); len(affected) > 0 {
 			t.logger.Warn("dynamic field not recorded, this backup cannot serve a secondary restore",
 				zap.Strings("collections_with_dynamic_schema", affected),
@@ -662,7 +673,7 @@ func (t *Task) backupCollDynField(ctx context.Context) error {
 
 	t.logger.Info("start backup collection dynamic field")
 
-	dynFieldTask := newCollDynFieldTask(t.taskID, t.etcdCli, t.etcdRootPath, t.metaBuilder)
+	dynFieldTask := newCollDynFieldTask(t.taskID, t.etcd, t.etcdRootPath, t.metaBuilder)
 	if err := dynFieldTask.Execute(ctx); err != nil {
 		return fmt.Errorf("backup: execute coll dyn field task: %w", err)
 	}


### PR DESCRIPTION
issue: #1216

A backup run with `--backup_index_extra` can hang forever on its first etcd read,
silently, after every collection has already been copied. Three things combine:
the client is created without ever dialling, the reads carry no deadline, and both
etcd steps run last, so an unreachable etcd is only discovered at the end of the
backup.

Reported on a deployment where all 69 collections and the RBAC metadata were
written, and the run then stopped dead on

```
start to get index info from etcd  prefix=by-dev/meta/field-index/462915446997590087/
```

with nothing after it in a 4.9 MB log.

### What changed

**`core/backup/etcd.go`** (new): `etcdMeta` wraps the client with the endpoints it
was built from, because clientv3 never reports which address a call was talking to
and a bare `context deadline exceeded` gives an operator nothing to act on.

- `probe` establishes that etcd answers before the backup starts copying. One
  reachable member is enough — the client fails over, so a single down member of an
  otherwise healthy cluster must not fail a backup. An unreachable cluster reports
  every endpoint with its own error.
- `getPrefix` bounds the read with a deadline: 10s, matching `etcd.requestTimeout`,
  the knob Milvus bounds its own etcd calls with. There is no reason for this tool
  to wait longer than the server it reads from.

**`core/backup/task.go`**: the probe runs in `initClients`, inside the existing
`if t.option.BackupIndexExtra` branch — the only case that builds an etcd client at
all — so a cluster whose etcd this tool cannot reach fails in the first seconds
rather than after the data is copied.

**`core/backup/coll_index_extra_task.go`**, **`core/backup/coll_dyn_field_task.go`**:
read through `etcdMeta` instead of calling `kv.Get` with the unbounded task context.
The dynamic field task's scan is also scoped to the backed-up collections: the key
is `root-coord/fields/{collectionID}/{fieldID}`, so the collection id is already the
first segment, and the previous cluster-wide read fetched every field of every
collection in order to keep at most one dynamic field per backed-up collection. The
index extra scan was scoped this way in #1055; this one was not, and its size
tracked the instance rather than the backup — which is what makes a bounded read
safe here.

### Why a probe rather than a blocking dial

`clientv3.New` does not dial unless the config carries `grpc.WithBlock()`, so
construction succeeds against endpoints that do not exist. Adding `WithBlock` would
not be enough: it proves the TCP connection, not that the peer speaks etcd, and an
address that accepts the connection and then never answers is exactly the reported
failure. `WithBlock` is also deprecated. An explicit `Status` settles both and
doubles as the start-of-task check.

### Tests

`core/backup/etcd_test.go` covers the probe: reachable, one member down, all
unreachable naming every endpoint, a silent endpoint that must not block, and no
endpoint configured. `TestEtcdMeta_ProbeWithRealClient` pins the premise of the fix
with a real `clientv3` client — `clientv3.New` against an address nothing listens on
returns no error, and only the probe reports it. The two task tests assert that an
unreachable etcd fails their `Execute` with the endpoint in the message, and that
each scan asks only for the collections in the backup.

### Not in this change

etcd TLS. `MilvusEtcdConfig` has only `Endpoints` and `RootPath`, so a deployment
whose etcd requires client certificates cannot be read by this tool at all; Milvus
itself supports `etcd.ssl.enabled` with `tlsCert` / `tlsKey` / `tlsCACert`. That is
the fourth defect in #1216 and is left open, which is why this says `issue` rather
than `fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
